### PR TITLE
oppgraderer ktor (CVE-2022-48476)

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -12,10 +12,10 @@ junitJupiterVersion=5.9.2
 kotestVersion=5.5.5
 kotlinCoroutinesVersion=1.6.4
 kotlinSerializationVersion=1.5.0
-ktorVersion=2.2.4
+ktorVersion=2.3.0
 lettuceVersion=6.2.3.RELEASE
 mockkVersion=1.13.5
-rapidsAndRiversVersion=2023041310341681374880.67ced5ad4dda
+rapidsAndRiversVersion=2023042611061682500003.f24c0756e00a
 
 # -- Client dependency versions
 aaregClientVersion=0.4.0


### PR DESCRIPTION
sikkerhetsfix - treffer egentlig kun der ktor-server serverer statisk innhold, men better safe than sorry