### PR TITLE
Bruk kraftigere workflow runner for integrasjonstest

### DIFF
--- a/.github/workflows/integrasjonstest.yml
+++ b/.github/workflows/integrasjonstest.yml
@@ -3,8 +3,8 @@ name: Integrasjonstester
 on: pull_request
 
 jobs:
-  Test:
-    runs-on: ubuntu-latest
+  test:
+    runs-on: ubuntu-latest-8-cores
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-java@v3


### PR DESCRIPTION
Gjorde et lite eksperiment med å kjøre integrasjonstestene med kraftigere runners i Github Actions med følgende resultater:
* 2-core (standard) runner tok 10 min og 40 sek, se [eksempel](https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/5290867528/jobs/9575622492)
* 4-core runner (https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/165) tok 9 min og 53 sek, se [eksempel](https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/5323342236/jobs/9641030282)
* 8-core runner (denne PR) tok 7 min og 18 sek, se [eksempel](https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/5309745094/jobs/9640203435)
* 16-core runner (https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/163) tok 7 min og 10 sek, se [eksempel](https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/5323016671/jobs/9640236241)

Jeg vil si at dette taler for at vi bruker 8-core for integrasjonstestene.