### PR TITLE
Bruk nyttigere type i db for inntektsmelding

### DIFF
--- a/db/src/main/resources/db/migration/V9__inntektsmelding_type_jsonb.sql
+++ b/db/src/main/resources/db/migration/V9__inntektsmelding_type_jsonb.sql
@@ -1,0 +1,2 @@
+ALTER TABLE inntektsmelding
+    ALTER COLUMN dokument TYPE JSONB USING dokument::jsonb;

--- a/db/src/main/resources/db/migration/V9__inntektsmelding_type_jsonb.sql
+++ b/db/src/main/resources/db/migration/V9__inntektsmelding_type_jsonb.sql
@@ -1,2 +1,2 @@
 ALTER TABLE inntektsmelding
-    ALTER COLUMN dokument TYPE JSONB USING dokument::jsonb;
+    ALTER COLUMN dokument TYPE JSONB USING dokument::JSONB;


### PR DESCRIPTION
~Det trengs ingen andre endringer enn dette ettersom koden som bruker databasen allerede tror at `dokument`-feltet er av typen `jsonb`: https://github.com/navikt/helsearbeidsgiver-inntektsmelding/blob/88fd30d7adaf6908e2434b2eae8343d9a02626a6/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingEntitet.kt#L32~

Litt kjapp på avtrekken med denne. Selv om det ser ut som i koden som bruker databasen allerede tror `dokument`-feltet er av typen `jsonb`, så stemmer ikke det helt. Man kan sikkert hacke seg rundt det, men den siste aktiviteten på exposed-repoet tilsier at det kommer noen endringer som bedrer støtten for `jsonb`, så da er det nok bedre å vente på det ⏳ 