### PR TITLE
Bruk mer restriktiv tilgang i workflow for bygging

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -81,6 +81,8 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
     needs: generate_vars
     if: needs.generate_vars.outputs.is_matrix_empty == 'false'
     strategy:


### PR DESCRIPTION
Bygger og deployer helt fint: https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/5472910091

Vi trenger `packages:write` for å pushe docker imaget.