### PR TITLE
Simuler tregt kall mot brreg

### DIFF
--- a/akkumulator/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trenger/TrengerService.kt
+++ b/akkumulator/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trenger/TrengerService.kt
@@ -113,14 +113,16 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
                     Key.EVENT_NAME to event.toJson(),
                     Key.BEHOV to listOf(BehovType.VIRKSOMHET).toJson(BehovType.serializer().list()),
                     Key.UUID to uuid.toJson(),
-                    DataFelt.ORGNRUNDERENHET to forespurtData.orgnr.toJson()
+                    DataFelt.ORGNRUNDERENHET to forespurtData.orgnr.toJson(),
+                    DataFelt.FORESPOERSEL_ID to redisStore.get(RedisKey.of(uuid, DataFelt.FORESPOERSEL_ID))!!.toJson()
                 )
                 logger.info("${this.javaClass.simpleName} dispatcher FULLT_NAVN for $uuid")
                 rapidsConnection.publish(
                     Key.EVENT_NAME to event.toJson(),
                     Key.BEHOV to listOf(BehovType.FULLT_NAVN).toJson(BehovType.serializer().list()),
                     Key.UUID to uuid.toJson(),
-                    Key.IDENTITETSNUMMER to forespurtData.fnr.toJson()
+                    Key.IDENTITETSNUMMER to forespurtData.fnr.toJson(),
+                    DataFelt.FORESPOERSEL_ID to redisStore.get(RedisKey.of(uuid, DataFelt.FORESPOERSEL_ID))!!.toJson()
                 )
                 /*
                 rapidsConnection.publish(
@@ -135,7 +137,8 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
                     Key.EVENT_NAME to event.toJson(),
                     Key.BEHOV to listOf(BehovType.INNTEKT).toJson(BehovType.serializer().list()),
                     Key.UUID to uuid.toJson(),
-                    DataFelt.TRENGER_INNTEKT to forespurtData.toJson(TrengerInntekt.serializer())
+                    DataFelt.TRENGER_INNTEKT to forespurtData.toJson(TrengerInntekt.serializer()),
+                    DataFelt.FORESPOERSEL_ID to redisStore.get(RedisKey.of(uuid, DataFelt.FORESPOERSEL_ID))!!.toJson()
                 )
             }
         } else {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/App.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/App.kt
@@ -18,6 +18,6 @@ fun main() {
 
 fun RapidsConnection.createBrreg(brregClient: BrregClient, isDevelopmentMode: Boolean): RapidsConnection {
     sikkerLogger.info("Starting VirksomhetLøser... developmentMode: $isDevelopmentMode")
-    VirksomhetLøser(this, brregClient, isDevelopmentMode)
+    IkkeBlokkerendeVirksomhetLøser(this, brregClient, isDevelopmentMode)
     return this
 }

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
@@ -1,0 +1,115 @@
+@file:Suppress("NonAsciiCharacters")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.brreg
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.helsearbeidsgiver.brreg.BrregClient
+import no.nav.helsearbeidsgiver.felles.BehovType
+import no.nav.helsearbeidsgiver.felles.DataFelt
+import no.nav.helsearbeidsgiver.felles.Feilmelding
+import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.VirksomhetLøsning
+import no.nav.helsearbeidsgiver.felles.createFail
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.StatelessLøser
+import no.nav.helsearbeidsgiver.utils.log.logger
+import kotlin.system.measureTimeMillis
+
+class IkkeBlokkerendeVirksomhetLøser(
+    rapidsConnection: RapidsConnection,
+    private val brregClient: BrregClient,
+    private val isPreProd: Boolean,
+    val delayMs: Long = 0
+) : StatelessLøser(rapidsConnection) {
+
+    private val logger = logger()
+    private val BEHOV = BehovType.VIRKSOMHET
+
+    private suspend fun hentVirksomhet(orgnr: String): String {
+        if (isPreProd) {
+            if (delayMs > 0) {
+                logger.warn("Kjører i testmodus, forsinker kallet med $delayMs millisekunder")
+            }
+            delay(delayMs)
+                when (orgnr) {
+                    "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
+                    "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
+                    "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
+                    "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
+                }
+                "Ukjent arbeidsgiver"
+        }
+        val virksomhetNav: String?
+            measureTimeMillis {
+                virksomhetNav = brregClient.hentVirksomhetNavn(orgnr)
+            }.also {
+                logger.info("BREG execution took $it")
+            }
+        return virksomhetNav ?: throw FantIkkeVirksomhetException(orgnr)
+    }
+
+    override fun accept(): River.PacketValidation {
+        return River.PacketValidation {
+            it.demandAll(Key.BEHOV.str, BEHOV)
+            it.requireKey(DataFelt.ORGNRUNDERENHET.str)
+            it.requireKey(Key.ID.str)
+        }
+    }
+
+    override fun onBehov(packet: JsonMessage) {
+        logger.info("Løser behov $BEHOV med id ${packet[Key.ID.str].asText()}")
+        val orgnr = packet[DataFelt.ORGNRUNDERENHET.str].asText()
+        hentNavnIkkeBlokker(orgnr, packet)
+        logger.info("Jeg er ferdig med onBehov...")
+    }
+
+    fun hentNavnIkkeBlokker(orgnr: String, packet: JsonMessage) {
+        logger.info("Kaller brreg")
+        val scope = CoroutineScope(Dispatchers.IO)
+        scope.launch {
+            try {
+                val navn = hentVirksomhet(orgnr)
+                logger.info("Fant $navn for $orgnr")
+                publiserLøsning(VirksomhetLøsning(navn), packet)
+                publishDatagram(navn, packet)
+            } catch (ex: FantIkkeVirksomhetException) {
+                logger.error("Fant ikke virksomhet for $orgnr")
+                publiserLøsning(VirksomhetLøsning(error = Feilmelding("Ugyldig virksomhet $orgnr")), packet)
+                publishFail(packet.createFail("Ugyldig virksomhet $orgnr", behovType = BehovType.VIRKSOMHET))
+            } catch (ex: Exception) {
+                logger.error("Det oppstod en feil ved henting for $orgnr")
+                sikkerLogger.error("Det oppstod en feil ved henting for orgnr $orgnr: ", ex)
+                publiserLøsning(VirksomhetLøsning(error = Feilmelding("Klarte ikke hente virksomhet")), packet)
+                publishFail(packet.createFail("Klarte ikke hente virksomhet", behovType = BehovType.VIRKSOMHET))
+            }
+           }
+    }
+    private fun publishDatagram(navn: String, jsonMessage: JsonMessage) {
+        val message = JsonMessage.newMessage(
+            mapOf(
+                Key.EVENT_NAME.str to jsonMessage[Key.EVENT_NAME.str].asText(),
+                Key.FORESPOERSEL_ID.str to jsonMessage[Key.FORESPOERSEL_ID.str].asText(),
+                Key.DATA.str to "",
+                Key.UUID.str to jsonMessage[Key.UUID.str].asText(),
+                DataFelt.VIRKSOMHET.str to navn
+            )
+        )
+        super.publishData(message)
+    }
+
+    private fun publiserLøsning(virksomhetLøsning: VirksomhetLøsning, packet: JsonMessage) {
+        packet.setLøsning(BEHOV, virksomhetLøsning)
+        super.publishBehov(packet)
+    }
+
+    private fun JsonMessage.setLøsning(nøkkel: BehovType, data: Any) {
+        this[Key.LØSNING.str] = mapOf(
+            nøkkel.name to data
+        )
+    }
+}

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
@@ -24,7 +24,7 @@ class IkkeBlokkerendeVirksomhetLøser(
     rapidsConnection: RapidsConnection,
     private val brregClient: BrregClient,
     private val isPreProd: Boolean,
-    val delayMs: Long = 0
+    val delayMs: Long = 2000
 ) : StatelessLøser(rapidsConnection) {
 
     private val logger = logger()

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
@@ -41,7 +41,7 @@ class IkkeBlokkerendeVirksomhetLøser(
                 "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
                 "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
                 "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
-                else -> {"Ukjent arbeidsgiver"}
+                else -> { "Ukjent arbeidsgiver" }
             }
         }
         val virksomhetNav: String?

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
@@ -36,13 +36,13 @@ class IkkeBlokkerendeVirksomhetLøser(
                 logger.warn("Kjører i testmodus, forsinker kallet med $delayMs millisekunder")
             }
             delay(delayMs)
-            when (orgnr) {
+            return when (orgnr) {
                 "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
                 "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
                 "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
                 "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
+                else -> {"Ukjent arbeidsgiver"}
             }
-            "Ukjent arbeidsgiver"
         }
         val virksomhetNav: String?
         measureTimeMillis {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøser.kt
@@ -36,20 +36,20 @@ class IkkeBlokkerendeVirksomhetLøser(
                 logger.warn("Kjører i testmodus, forsinker kallet med $delayMs millisekunder")
             }
             delay(delayMs)
-                when (orgnr) {
-                    "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
-                    "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
-                    "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
-                    "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
-                }
-                "Ukjent arbeidsgiver"
+            when (orgnr) {
+                "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
+                "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
+                "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
+                "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
+            }
+            "Ukjent arbeidsgiver"
         }
         val virksomhetNav: String?
-            measureTimeMillis {
-                virksomhetNav = brregClient.hentVirksomhetNavn(orgnr)
-            }.also {
-                logger.info("BREG execution took $it")
-            }
+        measureTimeMillis {
+            virksomhetNav = brregClient.hentVirksomhetNavn(orgnr)
+        }.also {
+            logger.info("BREG execution took $it")
+        }
         return virksomhetNav ?: throw FantIkkeVirksomhetException(orgnr)
     }
 
@@ -87,7 +87,7 @@ class IkkeBlokkerendeVirksomhetLøser(
                 publiserLøsning(VirksomhetLøsning(error = Feilmelding("Klarte ikke hente virksomhet")), packet)
                 publishFail(packet.createFail("Klarte ikke hente virksomhet", behovType = BehovType.VIRKSOMHET))
             }
-           }
+        }
     }
     private fun publishDatagram(navn: String, jsonMessage: JsonMessage) {
         val message = JsonMessage.newMessage(

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
@@ -39,7 +39,7 @@ class VirksomhetLøser(
                 "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
                 "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
                 "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
-                else -> {"Ukjent arbeidsgiver"}
+                else -> { "Ukjent arbeidsgiver" }
             }
         }
         return runBlocking {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
@@ -26,7 +26,7 @@ class VirksomhetLøser(
 
     private val logger = logger()
     private val BEHOV = BehovType.VIRKSOMHET
-    private val delayMs = 2500L
+    private val delayMs = 3000L
 
     private fun hentVirksomhet(orgnr: String): String {
         if (isPreProd) {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
@@ -30,16 +30,16 @@ class VirksomhetLøser(
 
     private fun hentVirksomhet(orgnr: String): String {
         if (isPreProd) {
-            return runBlocking {
+            runBlocking {
                 logger.warn("Simulerer tregt kall mot brreg!")
                 delay(delayMs)
-                when (orgnr) {
-                    "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
-                    "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
-                    "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
-                    "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
-                }
-                "Ukjent arbeidsgiver"
+            }
+            return when (orgnr) {
+                "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
+                "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
+                "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
+                "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
+                else -> {"Ukjent arbeidsgiver"}
             }
         }
         return runBlocking {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
@@ -26,7 +26,7 @@ class VirksomhetLøser(
 
     private val logger = logger()
     private val BEHOV = BehovType.VIRKSOMHET
-    private val delayMs = 3000L
+    private val delayMs = 2000L
 
     private fun hentVirksomhet(orgnr: String): String {
         if (isPreProd) {

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLøser.kt
@@ -2,6 +2,7 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.brreg
 
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -25,16 +26,21 @@ class VirksomhetLøser(
 
     private val logger = logger()
     private val BEHOV = BehovType.VIRKSOMHET
+    private val delayMs = 2500L
 
     private fun hentVirksomhet(orgnr: String): String {
         if (isPreProd) {
-            when (orgnr) {
-                "810007702" -> return "ANSTENDIG PIGGSVIN BYDEL"
-                "810007842" -> return "ANSTENDIG PIGGSVIN BARNEHAGE"
-                "810008032" -> return "ANSTENDIG PIGGSVIN BRANNVESEN"
-                "810007982" -> return "ANSTENDIG PIGGSVIN SYKEHJEM"
+            return runBlocking {
+                logger.warn("Simulerer tregt kall mot brreg!")
+                delay(delayMs)
+                when (orgnr) {
+                    "810007702" -> "ANSTENDIG PIGGSVIN BYDEL"
+                    "810007842" -> "ANSTENDIG PIGGSVIN BARNEHAGE"
+                    "810008032" -> "ANSTENDIG PIGGSVIN BRANNVESEN"
+                    "810007982" -> "ANSTENDIG PIGGSVIN SYKEHJEM"
+                }
+                "Ukjent arbeidsgiver"
             }
-            return "Ukjent arbeidsgiver"
         }
         return runBlocking {
             val virksomhetNav: String?

--- a/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøserTest.kt
+++ b/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøserTest.kt
@@ -74,19 +74,19 @@ class IkkeBlokkerendeVirksomhetLøserTest {
         coEvery {
             brregClient.hentVirksomhetNavn(any())
         } returns null
-            launch {
-                val løsning = sendMessage(
-                    mapOf(
-                        Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.name,
-                        Key.FORESPOERSEL_ID.str to UUID.randomUUID(),
-                        "@behov" to listOf(BEHOV),
-                        "@id" to UUID.randomUUID(),
-                        "uuid" to "uuid",
-                        DataFelt.ORGNRUNDERENHET.str to ORGNR
-                    )
+        launch {
+            val løsning = sendMessage(
+                mapOf(
+                    Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.name,
+                    Key.FORESPOERSEL_ID.str to UUID.randomUUID(),
+                    "@behov" to listOf(BEHOV),
+                    "@id" to UUID.randomUUID(),
+                    "uuid" to "uuid",
+                    DataFelt.ORGNRUNDERENHET.str to ORGNR
                 )
-                assertEquals("Ugyldig virksomhet $ORGNR", løsning.error?.melding)
-            }
+            )
+            assertEquals("Ugyldig virksomhet $ORGNR", løsning.error?.melding)
+        }
     }
 
     @Test

--- a/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøserTest.kt
+++ b/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/IkkeBlokkerendeVirksomhetLøserTest.kt
@@ -1,0 +1,123 @@
+@file:Suppress("NonAsciiCharacters")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.brreg
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.JsonNode
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
+import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
+import com.fasterxml.jackson.module.kotlin.readValue
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.withContext
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.helsearbeidsgiver.brreg.BrregClient
+import no.nav.helsearbeidsgiver.felles.BehovType
+import no.nav.helsearbeidsgiver.felles.DataFelt
+import no.nav.helsearbeidsgiver.felles.EventName
+import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.VirksomhetLøsning
+import no.nav.helsearbeidsgiver.utils.log.logger
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+import org.junit.jupiter.api.Test
+import java.util.UUID
+import kotlin.time.Duration.Companion.milliseconds
+
+class IkkeBlokkerendeVirksomhetLøserTest {
+
+    private val rapid = TestRapid()
+    private var løser: IkkeBlokkerendeVirksomhetLøser
+    private val BEHOV = BehovType.VIRKSOMHET.name
+    private val objectMapper: ObjectMapper = jacksonObjectMapper()
+        .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
+        .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
+        .registerModule(JavaTimeModule())
+    private val brregClient = mockk<BrregClient>()
+    private val ORGNR = "orgnr-1"
+    private val VIRKSOMHET_NAVN = "Norge AS"
+    private val DELAY = 1000L
+    init {
+        løser = IkkeBlokkerendeVirksomhetLøser(rapid, brregClient, false, DELAY)
+    }
+
+    private suspend fun sendMessage(packet: Map<String, Any>): VirksomhetLøsning {
+        rapid.reset()
+        rapid.sendTestMessage(
+            objectMapper.writeValueAsString(
+                packet
+            )
+        )
+        var counter = 0
+        while (rapid.inspektør.size == 0) {
+            counter++
+            // med runtest ignoreres vanlig delay()
+            withContext(Dispatchers.Default) {
+                delay(50.milliseconds)
+                if (counter % 100 == 0) {
+                    logger().info("Venter på svar...")
+                }
+            }
+        }
+        val losning: JsonNode = rapid.inspektør.message(0).path("@løsning")
+        return objectMapper.readValue<VirksomhetLøsning>(losning.get(BEHOV).toString())
+    }
+
+    @Test
+    fun `skal håndtere at klient feiler`() = runTest {
+        coEvery {
+            brregClient.hentVirksomhetNavn(any())
+        } returns null
+            launch {
+                val løsning = sendMessage(
+                    mapOf(
+                        Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.name,
+                        Key.FORESPOERSEL_ID.str to UUID.randomUUID(),
+                        "@behov" to listOf(BEHOV),
+                        "@id" to UUID.randomUUID(),
+                        "uuid" to "uuid",
+                        DataFelt.ORGNRUNDERENHET.str to ORGNR
+                    )
+                )
+                assertEquals("Ugyldig virksomhet $ORGNR", løsning.error?.melding)
+            }
+    }
+
+    @Test
+    fun `skal returnere løsning når gyldige data`() = runTest {
+        coEvery {
+            brregClient.hentVirksomhetNavn(any())
+        } returns VIRKSOMHET_NAVN
+        val løsning = sendMessage(
+            mapOf(
+                Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.name,
+                Key.FORESPOERSEL_ID.str to UUID.randomUUID(),
+                "@behov" to listOf(BEHOV),
+                "@id" to UUID.randomUUID(),
+                "uuid" to "uuid",
+                DataFelt.ORGNRUNDERENHET.str to ORGNR
+            )
+        )
+        assertEquals(VIRKSOMHET_NAVN, løsning.value)
+    }
+
+    @Test
+    fun `skal håndtere ukjente feil`() = runTest {
+        val løsning = sendMessage(
+            mapOf(
+                Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.name,
+                Key.FORESPOERSEL_ID.str to UUID.randomUUID(),
+                "@behov" to listOf(BEHOV),
+                "@id" to UUID.randomUUID(),
+                DataFelt.ORGNRUNDERENHET.str to ORGNR
+            )
+        )
+        assertNotNull(løsning.error)
+    }
+}

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/StatelessLøser.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/StatelessLøser.kt
@@ -1,0 +1,59 @@
+package no.nav.helsearbeidsgiver.felles.rapidsrivers
+
+import no.nav.helse.rapids_rivers.JsonMessage
+import no.nav.helse.rapids_rivers.MessageContext
+import no.nav.helse.rapids_rivers.RapidsConnection
+import no.nav.helse.rapids_rivers.River
+import no.nav.helsearbeidsgiver.felles.Fail
+import no.nav.helsearbeidsgiver.felles.Key
+
+abstract class StatelessLøser(val rapidsConnection: RapidsConnection) : River.PacketListener {
+
+    init {
+        configure(
+            River(rapidsConnection).apply {
+                validate(accept())
+            }
+        ).register(this)
+    }
+
+    abstract fun accept(): River.PacketValidation
+
+    private fun configure(river: River): River {
+        return river.validate {
+            it.demandKey(Key.EVENT_NAME.str)
+            it.demandKey(Key.BEHOV.str)
+            it.demandKey(Key.FORESPOERSEL_ID.str)
+            it.rejectKey(Key.LØSNING.str)
+            it.interestedIn(Key.UUID.str)
+        }
+    }
+
+    fun publishBehov(message: JsonMessage) {
+        rapidsConnection.publish(message.toJson())
+    }
+
+    // TODO: om denne skal benyttes og fungere, må den i så fall skrelle vekk Behov før den sender..
+    fun publishEvent(message: JsonMessage) {
+        throw NotImplementedError()
+        // rapidsConnection.publish(message.toJson())
+    }
+
+    fun publishData(message: JsonMessage) {
+        rapidsConnection.publish(message.toJson())
+    }
+
+    fun publishFail(fail: Fail) {
+        rapidsConnection.publish(fail.toJsonMessage().toJson())
+    }
+
+    fun publishFail(message: JsonMessage) {
+        rapidsConnection.publish(message.toJson())
+    }
+
+    override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        onBehov(packet)
+    }
+
+    abstract fun onBehov(packet: JsonMessage)
+}

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-# Build  versions
+# Build versions
 jvmTargetVersion=17
 
 # Plugin versions


### PR DESCRIPTION
Til bruk i ytelsestesting: 
I preprod forsinkes kallet i VirksomhetLøser med 2 sekunder

Ny IkkeblokkerendeVirksomhetLøser introdusert som Proof Of Concept - bruker samme forsinkelse på alle kall i preprod, men benytter coroutines for å kunne spise nye kall, heller enn å blokkere

