### PR TITLE
Bruk forbedret måte å lese alle enum-verdier

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -45,7 +45,7 @@ enum class Key(override val str: String) : IKey {
 
     companion object {
         internal fun fromJson(json: String): Key =
-            Key.values().firstOrNull {
+            Key.entries.firstOrNull {
                 json == it.str
             }
                 ?: throw IllegalArgumentException("Fant ingen Key med verdi som matchet '$json'.")
@@ -76,7 +76,7 @@ enum class DataFelt(override val str: String) : IKey {
 
     companion object {
         internal fun fromJson(json: String): DataFelt =
-            DataFelt.values().firstOrNull {
+            DataFelt.entries.firstOrNull {
                 json == it.str
             }
                 ?: throw IllegalArgumentException("Fant ingen DataFelt med verdi som matchet '$json'.")

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -29,7 +29,7 @@ class InnsendingService(
 
     init {
         withFailKanal { DelegatingFailKanal(event, it, rapidsConnection) }
-        withDataKanal { StatefullDataKanal(DataFelter.values().map { it.str }.toTypedArray(), event, it, rapidsConnection, redisStore) }
+        withDataKanal { StatefullDataKanal(DataFelter.entries.map { it.str }.toTypedArray(), event, it, rapidsConnection, redisStore) }
         withEventListener {
             StatefullEventListener(
                 redisStore,

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/GenericDataPackageListenerTest.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/GenericDataPackageListenerTest.kt
@@ -42,7 +42,7 @@ class GenericDataPackageListenerTest {
     @BeforeEach
     fun beforeAll() {
         dataListener = StatefullDataKanal(
-            TestFelter.values().map { it.toString() }.toTypedArray(),
+            TestFelter.entries.map { it.toString() }.toTypedArray(),
             EventName.INSENDING_STARTED,
             mockListener,
             testRapid,

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/UtilsTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/UtilsTest.kt
@@ -10,8 +10,7 @@ class UtilsTest {
 
     @Test
     fun `ingen eller redusert refusjon begrunnelsetekst`() {
-        val begrunnelser = BegrunnelseIngenEllerRedusertUtbetalingKode.values()
-        begrunnelser.forEach {
+        BegrunnelseIngenEllerRedusertUtbetalingKode.entries.forEach {
             // sjekk at vi har lagt inn en fin tekst for alle koder:
             assertNotEquals(it.value, it.tekst(), "Mangler verdi i tekst()-funksjon!")
         }


### PR DESCRIPTION
Nytt i Kotlin 1.9.0: https://kotlinlang.org/docs/whatsnew19.html#stable-replacement-of-the-enum-class-values-function