### PR TITLE
Kort ned ventetid på meldinger for alle integrasjonstester

### DIFF
--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
@@ -30,7 +30,9 @@ class ForespoerselMottattIT : EndToEndTest() {
             Pri.Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson()
         )
 
-        waitForMessages(8000)
+        waitForNonEmpty(8000) {
+            messages.filter(EventName.FORESPØRSEL_LAGRET)
+        }
 
         messages.filter(EventName.FORESPØRSEL_MOTTATT)
             .filter(BehovType.LAGRE_FORESPOERSEL, loesningPaakrevd = false)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -57,7 +57,9 @@ class InnsendingIT : EndToEndTest() {
             DataFelt.INNTEKTSMELDING to Mock.innsendingRequest.let(Jackson::toJson)
         )
 
-        Thread.sleep(10000)
+        waitForNonEmpty(10000) {
+            messages.filter(EventName.INNTEKTSMELDING_DISTRIBUERT)
+        }
 
         messages.filter(EventName.INSENDING_STARTED)
             .filter(DataFelt.INNTEKTSMELDING_DOKUMENT)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -39,7 +39,9 @@ class InnsendingServiceIT : EndToEndTest() {
             Key.FORESPOERSEL_ID to forespoerselId.toJson()
         )
 
-        Thread.sleep(10000)
+        waitForNonEmpty(10000) {
+            messages.filter(EventName.INNTEKTSMELDING_MOTTATT)
+        }
 
         messages.all().filter(clientId).size shouldBe 10
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -32,7 +32,10 @@ class KvitteringIT : EndToEndTest() {
             Key.FORESPOERSEL_ID to Mock.FORESPOERSEL_ID_GYLDIG.toJson()
         )
 
-        Thread.sleep(1000)
+        waitForNonEmpty(1000) {
+            messages.filter(EventName.KVITTERING_REQUESTED)
+                .filter(DataFelt.INNTEKTSMELDING_DOKUMENT)
+        }
 
         messages.filter(EventName.KVITTERING_REQUESTED)
             .filter(DataFelt.INNTEKTSMELDING_DOKUMENT)
@@ -59,7 +62,10 @@ class KvitteringIT : EndToEndTest() {
             Key.FORESPOERSEL_ID to Mock.FORESPOERSEL_ID_UGYLDIG.toJson()
         )
 
-        Thread.sleep(5000)
+        waitForNonEmpty(5000) {
+            messages.filter(EventName.KVITTERING_REQUESTED)
+                .filter(DataFelt.INNTEKTSMELDING_DOKUMENT)
+        }
 
         messages.filter(EventName.KVITTERING_REQUESTED)
             .filter(DataFelt.INNTEKTSMELDING_DOKUMENT)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/NotifikasjonTrengerInntektMeldingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/NotifikasjonTrengerInntektMeldingIT.kt
@@ -37,7 +37,9 @@ class NotifikasjonTrengerInntektMeldingIT : EndToEndTest() {
             Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson()
         )
 
-        Thread.sleep(10000)
+        waitForNonEmpty(10000) {
+            messages.filter(EventName.SAK_OPPRETTET)
+        }
 
         messages.filter(EventName.FORESPØRSEL_LAGRET)
             .filter(BehovType.FULLT_NAVN, loesningPaakrevd = false)
@@ -99,7 +101,9 @@ class NotifikasjonTrengerInntektMeldingIT : EndToEndTest() {
             Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson()
         )
 
-        Thread.sleep(8000)
+        waitForNonEmpty(8000) {
+            messages.filter(EventName.OPPGAVE_LAGRET)
+        }
 
         var transaksjonsId: String
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
@@ -45,7 +45,10 @@ class TilgangskontrollIT : EndToEndTest() {
     fun `skal få tilgang`() {
         tilgangProducer.publish(Mock.INNLOGGET_FNR, Mock.FORESPOERSEL_ID_MED_TILGANG)
 
-        Thread.sleep(6000)
+        waitForNonEmpty(6000) {
+            messages.filter(EventName.HENT_PREUTFYLT)
+                .filter(BehovType.TILGANGSKONTROLL, loesningPaakrevd = true)
+        }
 
         val result = messages.filter(EventName.HENT_PREUTFYLT)
             .filter(BehovType.TILGANGSKONTROLL, loesningPaakrevd = true)
@@ -65,7 +68,10 @@ class TilgangskontrollIT : EndToEndTest() {
     fun `skal bli nektet tilgang`() {
         tilgangProducer.publish(Mock.INNLOGGET_FNR, Mock.FORESPOERSEL_ID_UTEN_TILGANG)
 
-        Thread.sleep(4000)
+        waitForNonEmpty(4000) {
+            messages.filter(EventName.HENT_PREUTFYLT)
+                .filter(BehovType.TILGANGSKONTROLL, loesningPaakrevd = true)
+        }
 
         val result = messages.filter(EventName.HENT_PREUTFYLT)
             .filter(BehovType.TILGANGSKONTROLL, loesningPaakrevd = true)
@@ -85,7 +91,10 @@ class TilgangskontrollIT : EndToEndTest() {
     fun `skal få melding om at forespørsel ikke finnes`() {
         tilgangProducer.publish(Mock.INNLOGGET_FNR, Mock.FORESPOERSEL_ID_FINNES_IKKE)
 
-        Thread.sleep(4000)
+        waitForNonEmpty(4000) {
+            messages.filter(EventName.HENT_PREUTFYLT)
+                .filter(BehovType.HENT_IM_ORGNR, loesningPaakrevd = true)
+        }
 
         val result = messages.filter(EventName.HENT_PREUTFYLT)
             .filter(BehovType.HENT_IM_ORGNR, loesningPaakrevd = true)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
@@ -33,7 +33,10 @@ class TrengerIT : EndToEndTest() {
             DataFelt.FORESPOERSEL_ID to Mock.forespoerselId.toJson(UuidSerializer)
         )
 
-        waitForMessages(10000)
+        waitForNonEmpty(10000) {
+            messages.filter(EventName.TRENGER_REQUESTED)
+                .filter(BehovType.HENT_TRENGER_IM, loesningPaakrevd = false)
+        }
 
         messages.filter(EventName.TRENGER_REQUESTED)
             .filter(BehovType.HENT_TRENGER_IM, loesningPaakrevd = false)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -135,6 +135,19 @@ abstract class EndToEndTest : ContainerTest(), RapidsConnection.MessageListener 
             Thread.sleep(1500)
         }
     }
+
+    fun waitForNonEmpty(millis: Long, messagesWaitingFor: () -> Messages) {
+        val startTime = System.nanoTime()
+
+        while (messagesWaitingFor().all().isEmpty()) {
+            val elapsedTime = (System.nanoTime() - startTime) / 1_000_000
+            if (elapsedTime > millis) {
+                throw MessagesWaitLimitException(millis)
+            }
+
+            Thread.sleep(500)
+        }
+    }
 }
 
 private class MessagesWaitLimitException(millis: Long) : RuntimeException(


### PR DESCRIPTION
Kopi av https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/188. 

Trolig avhengig av endringer ala https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/208.

https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/208 + denne PR-en fungerer ikke helt som ønsket. Integrasjonstestene feiler ofte pga. timeout under venting. Usikker om det er det økte kosten av mutex-låsen i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/208 som er problemet. Uansett så skaper denne endringen mer problemer enn den løser for øyeblikket.