### PR TITLE
Bruk siste Altinn-klient for tilgangskontroll

### DIFF
--- a/altinn/gradle.properties
+++ b/altinn/gradle.properties
@@ -1,2 +1,0 @@
-# Dependency versions
-altinnClientVersion=0.2.1

--- a/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeserTest.kt
+++ b/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeserTest.kt
@@ -52,7 +52,7 @@ class AltinnLoeserTest : LoeserTest() {
 private fun mockAltinnOrganisasjonSet(): Set<AltinnOrganisasjon> =
     setOf(
         AltinnOrganisasjon(
-            name = "Pippin's Breakfast & Breakfast",
+            navn = "Pippin's Breakfast & Breakfast",
             type = "gluttonous"
         )
     )


### PR DESCRIPTION
Ved å slette den lokale versjonsspesifiseringen så brukes den globale, som bruker versjon 0.3.0 for Altinn-klienten.