### PR TITLE
Fullfør med korrekt ID i service

### DIFF
--- a/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/SpinnService.kt
+++ b/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/SpinnService.kt
@@ -63,7 +63,7 @@ class SpinnService(
 
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
-        val forespoerselId = RedisKey.of(transaksjonId.toString(), DataFelt.FORESPOERSEL_ID)
+        val forespoerselId = RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_ID)
             .read()?.let(UUID::fromString)
         if (forespoerselId == null) {
             "Klarte ikke finne forespoerselId for transaksjon $transaksjonId i Redis.".also {
@@ -72,7 +72,7 @@ class SpinnService(
             }
             return
         }
-        val spinnImId = RedisKey.of(transaksjonId.toString(), DataFelt.SPINN_INNTEKTSMELDING_ID)
+        val spinnImId = RedisKey.of(transaksjonId, DataFelt.SPINN_INNTEKTSMELDING_ID)
             .read()?.let(UUID::fromString)
         if (spinnImId == null) {
             "Klarte ikke finne spinnImId for transaksjon $transaksjonId i Redis.".also {
@@ -108,7 +108,7 @@ class SpinnService(
         val json = message.toJsonMap()
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
         val eksternInntektsmelding = DataFelt.EKSTERN_INNTEKTSMELDING.lesOrNull(EksternInntektsmelding.serializer(), json)
-        val forespoerselId = RedisKey.of(transaksjonId.toString(), DataFelt.FORESPOERSEL_ID)
+        val forespoerselId = RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_ID)
             .read()?.let(UUID::fromString)
         if (
             forespoerselId != null &&

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisKey.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisKey.kt
@@ -7,63 +7,50 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.utils.simpleName
 import java.util.UUID
 
-sealed class RedisKey(open val uuid: String) {
+sealed class RedisKey {
+    abstract val uuid: UUID
     abstract override fun toString(): String
 
     companion object {
-        fun of(uuid: String, dataFelt: DataFelt): RedisKey {
-            return DataKey(uuid, dataFelt)
-        }
+        fun of(uuid: UUID): RedisKey =
+            ClientKey(uuid)
 
-        fun of(uuid: String): RedisKey {
-            return ClientKey(uuid)
-        }
+        fun of(uuid: UUID, eventname: EventName): RedisKey =
+            TransactionKey(uuid, eventname)
 
-        fun of(uuid: String, eventname: EventName): RedisKey {
-            return TransactionKey(uuid, eventname)
-        }
+        fun of(uuid: UUID, key: Key): RedisKey =
+            KeyKey(uuid, key)
+
+        fun of(uuid: UUID, dataFelt: DataFelt): RedisKey =
+            DataKey(uuid, dataFelt)
 
         // @TODO ikke bra nok
-        fun of(uuid: String, feilMelding: Feilmelding): RedisKey {
-            return FeilKey(uuid, feilMelding)
-        }
-
-        fun of(uuid: UUID, key: Key): RedisKey {
-            return KeyKey(uuid.toString(), key)
-        }
-
-        fun of(uuid: UUID, dataFelt: DataFelt): RedisKey {
-            return DataKey(uuid.toString(), dataFelt)
-        }
+        fun of(uuid: UUID, feilMelding: Feilmelding): RedisKey =
+            FeilKey(uuid, feilMelding)
     }
 }
 
-private data class KeyKey(override val uuid: String, val key: Key) : RedisKey(uuid) {
-    override fun toString(): String {
-        return uuid + key.str
-    }
+private data class KeyKey(override val uuid: UUID, val key: Key) : RedisKey() {
+    override fun toString(): String =
+        uuid.toString() + key.str
 }
 
-private data class DataKey(override val uuid: String, val datafelt: DataFelt) : RedisKey(uuid) {
-    override fun toString(): String {
-        return uuid + datafelt.str
-    }
+private data class DataKey(override val uuid: UUID, val datafelt: DataFelt) : RedisKey() {
+    override fun toString(): String =
+        uuid.toString() + datafelt.str
 }
 
-private data class TransactionKey(override val uuid: String, val eventName: EventName) : RedisKey(uuid) {
-    override fun toString(): String {
-        return uuid + eventName.name
-    }
+private data class TransactionKey(override val uuid: UUID, val eventName: EventName) : RedisKey() {
+    override fun toString(): String =
+        uuid.toString() + eventName.name
 }
 
-private data class ClientKey(override val uuid: String) : RedisKey(uuid) {
-    override fun toString(): String {
-        return uuid
-    }
+private data class ClientKey(override val uuid: UUID) : RedisKey() {
+    override fun toString(): String =
+        uuid.toString()
 }
 
-private data class FeilKey(override val uuid: String, val feilMeldingClass: Feilmelding) : RedisKey(uuid) {
-    override fun toString(): String {
-        return uuid + feilMeldingClass.simpleName()
-    }
+private data class FeilKey(override val uuid: UUID, val feilMeldingClass: Feilmelding) : RedisKey() {
+    override fun toString(): String =
+        uuid.toString() + feilMeldingClass.simpleName()
 }

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -18,11 +18,13 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import java.util.UUID
@@ -95,7 +97,11 @@ class InnsendingService(
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespørselId}")
+            }
         } else {
             redisStore.set(RedisKey.of(clientId), fail.feilmelding)
         }

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -18,11 +18,14 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.json.toPretty
 import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.pipe.orDefault
+import java.util.UUID
 
 class InnsendingService(
     private val rapid: RapidsConnection,
@@ -69,13 +72,15 @@ class InnsendingService(
     }
 
     override fun onError(feil: Fail): Transaction {
+        val transaksjonId = feil.uuid!!.let(UUID::fromString)
+
         if (feil.behov == BehovType.VIRKSOMHET) {
-            val virksomhetKey = "${feil.uuid}${DataFelt.VIRKSOMHET}"
+            val virksomhetKey = RedisKey.of(transaksjonId, DataFelt.VIRKSOMHET)
             redisStore.set(virksomhetKey, "Ukjent virksomhet")
             return Transaction.IN_PROGRESS
         } else if (feil.behov == BehovType.FULLT_NAVN) {
-            val arbeidstakerFulltnavnKey = "${feil.uuid}${DataFelt.ARBEIDSTAKER_INFORMASJON.str}"
-            val arbeidsgiverFulltnavnKey = "${feil.uuid}${DataFelt.ARBEIDSGIVER_INFORMASJON.str}"
+            val arbeidstakerFulltnavnKey = RedisKey.of(transaksjonId, DataFelt.ARBEIDSTAKER_INFORMASJON)
+            val arbeidsgiverFulltnavnKey = RedisKey.of(transaksjonId, DataFelt.ARBEIDSGIVER_INFORMASJON)
             redisStore.set(arbeidstakerFulltnavnKey, personIkkeFunnet().toJsonStr(PersonDato.serializer()))
             redisStore.set(arbeidsgiverFulltnavnKey, personIkkeFunnet().toJsonStr(PersonDato.serializer()))
             return Transaction.IN_PROGRESS
@@ -84,11 +89,20 @@ class InnsendingService(
     }
 
     override fun terminate(fail: Fail) {
-        redisStore.set(fail.uuid!!, fail.feilmelding)
+        val transaksjonId = fail.uuid!!.let(UUID::fromString)
+
+        val clientId = redisStore.get(RedisKey.of(transaksjonId, event))
+            ?.let(UUID::fromString)
+
+        if (clientId == null) {
+            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+        } else {
+            redisStore.set(RedisKey.of(clientId), fail.feilmelding)
+        }
     }
 
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
-        val uuid: String = message[Key.UUID.str].asText()
+        val transaksjonId = message[Key.UUID.str].asText().let(UUID::fromString)
         when (transaction) {
             Transaction.NEW -> {
                 logger.info("InnsendingService: emitting behov Virksomhet")
@@ -96,7 +110,7 @@ class InnsendingService(
                     Key.EVENT_NAME to event.toJson(),
                     Key.BEHOV to BehovType.VIRKSOMHET.toJson(),
                     DataFelt.ORGNRUNDERENHET to message[DataFelt.ORGNRUNDERENHET.str].asText().toJson(),
-                    Key.UUID to uuid.toJson()
+                    Key.UUID to transaksjonId.toJson()
                 )
 
                 logger.info("InnsendingService: emitting behov ARBEIDSFORHOLD")
@@ -104,7 +118,7 @@ class InnsendingService(
                     Key.EVENT_NAME to event.toJson(),
                     Key.BEHOV to BehovType.ARBEIDSFORHOLD.toJson(),
                     Key.IDENTITETSNUMMER to message[Key.IDENTITETSNUMMER.str].asText().toJson(),
-                    Key.UUID to uuid.toJson()
+                    Key.UUID to transaksjonId.toJson()
                 )
 
                 logger.info("InnsendingService: emitting behov FULLT_NAVN")
@@ -113,41 +127,41 @@ class InnsendingService(
                     Key.BEHOV to BehovType.FULLT_NAVN.toJson(),
                     Key.IDENTITETSNUMMER to message[Key.IDENTITETSNUMMER.str].asText().toJson(),
                     Key.ARBEIDSGIVER_ID to message[Key.ARBEIDSGIVER_ID.str].asText().toJson(),
-                    Key.UUID to uuid.toJson()
+                    Key.UUID to transaksjonId.toJson()
                 )
             }
 
             Transaction.IN_PROGRESS -> {
-                if (isDataCollected(*step1data(message[Key.UUID.str].asText()))) {
-                    val arbeidstakerRedis = redisStore.get(RedisKey.of(uuid, DataFelt.ARBEIDSTAKER_INFORMASJON), PersonDato::class.java)
-                    val arbeidsgiverRedis = redisStore.get(RedisKey.of(uuid, DataFelt.ARBEIDSGIVER_INFORMASJON), PersonDato::class.java)
+                if (isDataCollected(*step1data(transaksjonId))) {
+                    val arbeidstakerRedis = redisStore.get(RedisKey.of(transaksjonId, DataFelt.ARBEIDSTAKER_INFORMASJON))?.fromJson(PersonDato.serializer())
+                    val arbeidsgiverRedis = redisStore.get(RedisKey.of(transaksjonId, DataFelt.ARBEIDSGIVER_INFORMASJON))?.fromJson(PersonDato.serializer())
                     logger.info("InnsendingService: emitting behov PERSISTER_IM")
                     rapid.publish(
                         Key.EVENT_NAME to event.toJson(),
                         Key.BEHOV to BehovType.PERSISTER_IM.toJson(),
-                        DataFelt.VIRKSOMHET to (redisStore.get(RedisKey.of(uuid, DataFelt.VIRKSOMHET)) ?: "Ukjent virksomhet").toJson(),
+                        DataFelt.VIRKSOMHET to redisStore.get(RedisKey.of(transaksjonId, DataFelt.VIRKSOMHET)).orDefault("Ukjent virksomhet").toJson(),
                         DataFelt.ARBEIDSTAKER_INFORMASJON to (
                             arbeidstakerRedis ?: personIkkeFunnet(message[Key.IDENTITETSNUMMER.str].asText())
                             ).toJson(PersonDato.serializer()),
                         DataFelt.ARBEIDSGIVER_INFORMASJON to (
                             arbeidsgiverRedis ?: personIkkeFunnet(message[Key.ARBEIDSGIVER_ID.str].asText())
                             ).toJson(PersonDato.serializer()),
-                        DataFelt.INNTEKTSMELDING to redisStore.get(RedisKey.of(uuid, DataFelt.INNTEKTSMELDING))!!.parseJson(),
-                        Key.FORESPOERSEL_ID to redisStore.get(RedisKey.of(uuid, DataFelt.FORESPOERSEL_ID))!!.toJson(),
-                        Key.UUID to uuid.toJson()
+                        DataFelt.INNTEKTSMELDING to redisStore.get(RedisKey.of(transaksjonId, DataFelt.INNTEKTSMELDING))!!.parseJson(),
+                        Key.FORESPOERSEL_ID to redisStore.get(RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_ID))!!.toJson(),
+                        Key.UUID to transaksjonId.toJson()
                     )
                 }
             }
 
             else -> {
-                logger.error("Illegal transaction type ecountered in dispatchBehov $transaction for uuid= $uuid")
+                logger.error("Illegal transaction type ecountered in dispatchBehov $transaction for uuid=$transaksjonId")
             }
         }
     }
 
     override fun finalize(message: JsonMessage) {
-        val uuid: String = message[Key.UUID.str].asText()
-        val clientId = redisStore.get(RedisKey.of(uuid, event))
+        val uuid = message[Key.UUID.str].asText().let(UUID::fromString)
+        val clientId = redisStore.get(RedisKey.of(uuid, event))?.let(UUID::fromString)
         logger.info("publiserer under clientID $clientId")
         redisStore.set(RedisKey.of(clientId!!), redisStore.get(RedisKey.of(uuid, DataFelt.INNTEKTSMELDING_DOKUMENT))!!)
         val erDuplikat = message[DataFelt.ER_DUPLIKAT_IM.str].asBoolean()
@@ -167,7 +181,7 @@ class InnsendingService(
         }
     }
 
-    private fun step1data(uuid: String): Array<RedisKey> = arrayOf(
+    private fun step1data(uuid: UUID): Array<RedisKey> = arrayOf(
         RedisKey.of(uuid, DataFelt.VIRKSOMHET),
         RedisKey.of(uuid, DataFelt.ARBEIDSFORHOLD),
         RedisKey.of(uuid, DataFelt.ARBEIDSTAKER_INFORMASJON),

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
@@ -17,8 +17,10 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.CompositeEventList
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.log.logger
 import java.util.UUID
 
@@ -86,7 +88,11 @@ class KvitteringService(
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespørselId}")
+            }
         } else {
             logger.info("Terminate kvittering med forespoerselId=${fail.forespørselId} og transaksjonsId ${fail.uuid}")
             redisStore.set(RedisKey.of(clientId), fail.feilmelding)

--- a/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -181,8 +181,12 @@ class InntektService(
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
-            logger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
+                logger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
+            }
         } else {
             val feil = RedisKey.of(transaksjonId, Feilmelding("")).read()
 

--- a/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -68,7 +68,7 @@ class InntektService(
 
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
-        val forespoerselId = RedisKey.of(transaksjonId.toString(), DataFelt.FORESPOERSEL_ID)
+        val forespoerselId = RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_ID)
             .read()
             ?.let(UUID::fromString)
         if (forespoerselId == null) {
@@ -102,11 +102,11 @@ class InntektService(
                 }
 
                 Transaction.IN_PROGRESS -> {
-                    val forspoerselKey = RedisKey.of(transaksjonId.toString(), DataFelt.FORESPOERSEL_SVAR)
+                    val forspoerselKey = RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_SVAR)
 
                     if (isDataCollected(forspoerselKey)) {
                         val forespoersel = forspoerselKey.read()?.fromJson(TrengerInntekt.serializer())
-                        val skjaeringstidspunkt = RedisKey.of(transaksjonId.toString(), DataFelt.SKJAERINGSTIDSPUNKT).read()
+                        val skjaeringstidspunkt = RedisKey.of(transaksjonId, DataFelt.SKJAERINGSTIDSPUNKT).read()
                         if (forespoersel == null || skjaeringstidspunkt == null) {
                             logger.error("Klarte ikke å finne forespørsel eller skjæringstidspunkt i Redis!")
                             sikkerLogger.error("Klarte ikke å finne data i Redis - forespørsel: $forespoersel og skjæringstidspunkt $skjaeringstidspunkt")
@@ -132,6 +132,7 @@ class InntektService(
                         sikkerLogger.error("Transaksjon er underveis, men mangler data. Dette bør aldri skje, ettersom vi kun venter på én datapakke.")
                     }
                 }
+
                 else -> {
                     sikkerLogger.error("Støtte på forutsett transaksjonstype: $transaction")
                 }
@@ -144,59 +145,66 @@ class InntektService(
 
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
-        val clientId = RedisKey.of(transaksjonId.toString(), event)
+        val clientId = RedisKey.of(transaksjonId, event)
             .read()
             ?.let(UUID::fromString)
 
         if (clientId == null) {
             sikkerLogger.error("Kunne ikke finne clientId for transaksjonId $transaksjonId i Redis!")
             logger.error("Kunne ikke finne clientId for transaksjonId $transaksjonId i Redis!")
-        }
-        val inntekt = RedisKey.of(transaksjonId.toString(), DataFelt.INNTEKT).read()
-        val feil = RedisKey.of(transaksjonId.toString(), Feilmelding("")).read()
+        } else {
+            val inntekt = RedisKey.of(transaksjonId, DataFelt.INNTEKT).read()
+            val feil = RedisKey.of(transaksjonId, Feilmelding("")).read()
 
-        val inntektJson = InntektData(
-            inntekt = inntekt?.fromJson(Inntekt.serializer()),
-            feil = feil?.fromJson(FeilReport.serializer())
-        )
-            .toJson(InntektData.serializer())
+            val inntektJson = InntektData(
+                inntekt = inntekt?.fromJson(Inntekt.serializer()),
+                feil = feil?.fromJson(FeilReport.serializer())
+            )
+                .toJson(InntektData.serializer())
 
-        RedisKey.of(clientId.toString()).write(inntektJson)
-        val logFields = loggFelterNotNull(transaksjonId, clientId)
+            RedisKey.of(clientId).write(inntektJson)
 
-        MdcUtils.withLogFields(
-            *logFields
-        ) {
-            sikkerLogger.info("$event fullført.")
+            MdcUtils.withLogFields(
+                Log.clientId(clientId),
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.info("$event fullført.")
+            }
         }
     }
 
     override fun terminate(fail: Fail) {
-        val clientId = RedisKey.of(fail.uuid!!, event)
+        val transaksjonId = fail.uuid.let(UUID::fromString)
+
+        val clientId = RedisKey.of(transaksjonId, event)
             .read()
             ?.let(UUID::fromString)
+
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon ${fail.uuid} i Redis")
-            logger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon ${fail.uuid} i Redis")
-        }
-        val feil = RedisKey.of(fail.uuid!!, Feilmelding("")).read()
+            sikkerLogger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
+            logger.error("Forsøkte å terminere, men fant ikke clientID for transaksjon $transaksjonId i Redis")
+        } else {
+            val feil = RedisKey.of(transaksjonId, Feilmelding("")).read()
 
-        val feilResponse = InntektData(
-            feil = feil?.fromJson(FeilReport.serializer())
-        )
-            .toJson(InntektData.serializer())
+            val feilResponse = InntektData(
+                feil = feil?.fromJson(FeilReport.serializer())
+            )
+                .toJson(InntektData.serializer())
 
-        RedisKey.of(clientId.toString()).write(feilResponse)
-        val logFields = loggFelterNotNull(fail.uuid.let(UUID::fromString), clientId)
-        MdcUtils.withLogFields(
-            *logFields
-        ) {
-            sikkerLogger.error("$event terminert.")
+            RedisKey.of(clientId).write(feilResponse)
+
+            MdcUtils.withLogFields(
+                Log.clientId(clientId),
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("$event terminert.")
+            }
         }
     }
 
     override fun onError(feil: Fail): Transaction {
-        val transaksjonId = feil.uuid ?: throw IllegalStateException("Feil mangler transaksjon-ID.")
+        val transaksjonId = feil.uuid?.let(UUID::fromString)
+            ?: throw IllegalStateException("Feil mangler transaksjon-ID.")
 
         val (feilmelding, transaction) = when (feil.behov) {
             BehovType.HENT_TRENGER_IM -> {
@@ -204,6 +212,7 @@ class InntektService(
 
                 feilmelding to Transaction.TERMINATE
             }
+
             BehovType.INNTEKT -> {
                 val feilmelding = Feilmelding(
                     "Vi har problemer med å hente inntektsopplysninger. Du kan legge inn beregnet månedsinntekt manuelt, eller prøv igjen senere.",
@@ -214,6 +223,7 @@ class InntektService(
 
                 feilmelding to null
             }
+
             else -> null to null
         }
 
@@ -242,24 +252,4 @@ class InntektService(
 
     private fun RedisKey.read(): String? =
         redisStore.get(this)
-
-    // Veldig stygt, ta med clientId i loggfelter når den eksisterer
-    // TODO: skriv heller om MDCUtils.log
-    private fun loggFelterNotNull(
-        transaksjonId: UUID,
-        clientId: UUID?
-    ): Array<Pair<String, String>> {
-        val logs = arrayOf(
-            Log.klasse(this),
-            Log.event(event),
-            Log.transaksjonId(transaksjonId)
-        )
-        val logFields = clientId?.let {
-            logs +
-                arrayOf(
-                    Log.clientId(clientId)
-                )
-        } ?: logs
-        return logFields
-    }
 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.DataFelt
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.test.json.fromJsonMapOnlyKeys
 import no.nav.helsearbeidsgiver.felles.test.mock.GYLDIG_INNSENDING_REQUEST
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
@@ -56,7 +57,7 @@ class InnsendingServiceIT : EndToEndTest() {
 
         messages.filterFeil().all().size shouldBe 0
 
-        val innsendingStr = redisStore.get(Mock.clientId.toString()).shouldNotBeNull()
+        val innsendingStr = redisStore.get(RedisKey.of(Mock.clientId)).shouldNotBeNull()
         innsendingStr.length shouldBeGreaterThan 2
     }
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -57,7 +58,7 @@ class KvitteringIT : EndToEndTest() {
                 it[DataFelt.EKSTERN_INNTEKTSMELDING] shouldBe Mock.tomObjektStreng
             }
 
-        redisStore.get(clientId.toString()).shouldNotBeNull()
+        redisStore.get(RedisKey.of(clientId)).shouldNotBeNull()
     }
 
     @Test
@@ -87,7 +88,7 @@ class KvitteringIT : EndToEndTest() {
                 eIm shouldNotBe Mock.tomObjektStreng
             }
 
-        redisStore.get(clientId.toString()).shouldNotBeNull()
+        redisStore.get(RedisKey.of(clientId)).shouldNotBeNull()
     }
 
     @Test

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
@@ -90,7 +90,7 @@ class TrengerIT : EndToEndTest() {
                 it[Key.UUID]?.fromJson(UuidSerializer) shouldBe transactionId
             }
 
-        val trengerResultatJson = redisStore.get(RedisKey.of(Mock.clientId.toString()))
+        val trengerResultatJson = redisStore.get(RedisKey.of(Mock.clientId))
         println("In test $trengerResultatJson")
         val objekt = trengerResultatJson?.fromJson(TrengerData.serializer())
         println(objekt)

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ManuellOpprettSakService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ManuellOpprettSakService.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import java.util.UUID
 
 class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, override val redisStore: IRedisStore) : CompositeEventListener(redisStore) {
     override val event: EventName = EventName.MANUELL_OPPRETT_SAK_REQUESTED
@@ -52,8 +53,8 @@ class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, o
     }
 
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
-        val transaksjonsId = message[Key.UUID.str].asText()
-        val forespoerselId = redisStore.get(transaksjonsId + Key.FORESPOERSEL_ID.str)!!
+        val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
+        val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))!!
         if (transaction == Transaction.NEW) {
             rapidsConnection.publish(
                 JsonMessage.newMessage(
@@ -66,7 +67,7 @@ class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, o
                 ).toJson()
             )
         } else if (transaction == Transaction.IN_PROGRESS) {
-            val forespoersel = redisStore.get(transaksjonsId + DataFelt.FORESPOERSEL_SVAR.str)?.fromJson(TrengerInntekt.serializer())
+            val forespoersel = redisStore.get(RedisKey.of(transaksjonsId, DataFelt.FORESPOERSEL_SVAR))?.fromJson(TrengerInntekt.serializer())
 
             if (forespoersel == null) {
                 sikkerLogger.error("Fant ikke forespørsel '$forespoerselId' i redis-cache. transaksjonId='$transaksjonsId'")
@@ -101,7 +102,7 @@ class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, o
                     }
                 }
                 isDataCollected(*steg3(transaksjonsId)) -> {
-                    val arbeidstakerRedis = redisStore.get(RedisKey.of(transaksjonsId, DataFelt.ARBEIDSTAKER_INFORMASJON), PersonDato::class.java)
+                    val arbeidstakerRedis = redisStore.get(RedisKey.of(transaksjonsId, DataFelt.ARBEIDSTAKER_INFORMASJON))?.fromJson(PersonDato.serializer())
                     rapidsConnection.publish(
                         JsonMessage.newMessage(
                             mapOf(
@@ -135,7 +136,7 @@ class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, o
     }
 
     override fun finalize(message: JsonMessage) {
-        val transaksjonsId = message[Key.UUID.str].asText()
+        val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
         rapidsConnection.publish(
             JsonMessage.newMessage(
                 mapOf(
@@ -156,7 +157,7 @@ class ManuellOpprettSakService(private val rapidsConnection: RapidsConnection, o
         return Transaction.TERMINATE
     }
 
-    private fun steg2(transactionId: String) = arrayOf(RedisKey.of(transactionId, DataFelt.FORESPOERSEL_SVAR))
-    private fun steg3(transactionId: String) = arrayOf(RedisKey.of(transactionId, DataFelt.ARBEIDSTAKER_INFORMASJON))
-    private fun steg4(transactionId: String) = arrayOf(RedisKey.of(transactionId, DataFelt.SAK_ID))
+    private fun steg2(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, DataFelt.FORESPOERSEL_SVAR))
+    private fun steg3(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, DataFelt.ARBEIDSTAKER_INFORMASJON))
+    private fun steg4(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, DataFelt.SAK_ID))
 }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
@@ -14,6 +14,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.CompositeEventList
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import java.util.UUID
 
 class OpprettOppgaveService(
     private val rapidsConnection: RapidsConnection,
@@ -44,8 +45,8 @@ class OpprettOppgaveService(
         withFailKanal { DelegatingFailKanal(event, this, rapidsConnection) }
     }
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
-        val transaksjonsId = message[Key.UUID.str].asText()
-        val forespørselId = redisStore.get(transaksjonsId + Key.FORESPOERSEL_ID.str)!!
+        val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
+        val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))!!
         if (transaction == Transaction.NEW) {
             rapidsConnection.publish(
                 JsonMessage.newMessage(
@@ -53,7 +54,7 @@ class OpprettOppgaveService(
                         Key.EVENT_NAME.str to event.name,
                         Key.UUID.str to transaksjonsId,
                         Key.BEHOV.str to BehovType.VIRKSOMHET.name,
-                        Key.FORESPOERSEL_ID.str to forespørselId,
+                        Key.FORESPOERSEL_ID.str to forespoerselId,
                         DataFelt.ORGNRUNDERENHET.str to message[DataFelt.ORGNRUNDERENHET.str]
                     )
                 ).toJson()
@@ -62,7 +63,7 @@ class OpprettOppgaveService(
     }
 
     override fun finalize(message: JsonMessage) {
-        val transaksjonsId = message[Key.UUID.str].asText()
+        val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
         val virksomhetnavn = redisStore.get(RedisKey.of(transaksjonsId, DataFelt.VIRKSOMHET))
         val orgnr = redisStore.get(RedisKey.of(transaksjonsId, DataFelt.ORGNRUNDERENHET))
         val forespoerselId = message[Key.FORESPOERSEL_ID.str].asText()
@@ -81,12 +82,21 @@ class OpprettOppgaveService(
     }
 
     override fun terminate(fail: Fail) {
-        redisStore.set(fail.uuid!!, fail.feilmelding)
+        val transaksjonId = fail.uuid!!.let(UUID::fromString)
+
+        val clientId = redisStore.get(RedisKey.of(transaksjonId, event))
+            ?.let(UUID::fromString)
+
+        if (clientId == null) {
+            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+        } else {
+            redisStore.set(RedisKey.of(clientId), fail.feilmelding)
+        }
     }
 
     override fun onError(feil: Fail): Transaction {
         if (feil.behov == BehovType.VIRKSOMHET) {
-            val virksomhetKey = "${feil.uuid}${DataFelt.VIRKSOMHET.str}"
+            val virksomhetKey = RedisKey.of(feil.uuid!!.let(UUID::fromString), DataFelt.VIRKSOMHET)
             redisStore.set(virksomhetKey, "Arbeidsgiver")
             return Transaction.FINALIZE
         }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
@@ -14,6 +14,8 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.CompositeEventList
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.utils.Log
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 class OpprettOppgaveService(
@@ -88,7 +90,11 @@ class OpprettOppgaveService(
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespørselId}")
+            }
         } else {
             redisStore.set(RedisKey.of(clientId), fail.feilmelding)
         }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakService.kt
@@ -15,8 +15,10 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.CompositeEventList
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 class OpprettSakService(private val rapidsConnection: RapidsConnection, override val redisStore: IRedisStore) : CompositeEventListener(redisStore) {
@@ -111,7 +113,11 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis.")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespørselId}")
+            }
         } else {
             redisStore.set(RedisKey.of(clientId), fail.feilmelding)
         }

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakServiceTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakServiceTest.kt
@@ -35,7 +35,7 @@ class OpprettSakServiceTest {
         testRapid.sendTestMessage(
             message.toJson()
         )
-        val uuid = testRedis.get("uuid").orEmpty()
+        val uuid = testRedis.get("uuid").orEmpty().let(UUID::fromString)
         println("Fant uuid: $uuid")
         assertNotNull(testRedis.get(RedisKey.of(uuid, EventName.SAK_OPPRETT_REQUESTED)))
         val feilmelding = JsonMessage.newMessage(
@@ -59,6 +59,6 @@ class OpprettSakServiceTest {
         testRapid.sendTestMessage(
             feilmelding.toJson()
         )
-        assertNotNull(testRedis.get(RedisKey.of(uuid + "arbeidstakerInformasjon")))
+        assertNotNull(testRedis.get(RedisKey.of(uuid, DataFelt.ARBEIDSTAKER_INFORMASJON)))
     }
 }

--- a/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangService.kt
+++ b/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangService.kt
@@ -66,75 +66,79 @@ class TilgangService(
 
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
-        val forespoerselId = RedisKey.of(transaksjonId.toString(), DataFelt.FORESPOERSEL_ID)
+        val forespoerselId = RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_ID)
             .read()?.let(UUID::fromString)
         if (forespoerselId == null) {
             "Klarte ikke finne forespoerselId for transaksjon $transaksjonId i Redis.".also {
                 logger.error(it)
                 sikkerLogger.error(it)
             }
-            return
+        } else {
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId),
+                Log.forespoerselId(forespoerselId)
+            ) {
+                dispatch(transaction, transaksjonId, forespoerselId)
+            }
         }
-        val fields = loggFelterNotNull(transaksjonId, forespoerselId)
+    }
 
-        MdcUtils.withLogFields(
-            *fields
-        ) {
-            sikkerLogger.info("Prosesserer transaksjon $transaction.")
+    private fun dispatch(transaction: Transaction, transaksjonId: UUID, forespoerselId: UUID) {
+        sikkerLogger.info("Prosesserer transaksjon $transaction.")
 
-            when (transaction) {
-                Transaction.NEW -> {
+        when (transaction) {
+            Transaction.NEW -> {
+                rapid.publish(
+                    Key.EVENT_NAME to event.toJson(),
+                    Key.BEHOV to BehovType.HENT_IM_ORGNR.toJson(),
+                    DataFelt.FORESPOERSEL_ID to forespoerselId.toJson(),
+                    Key.UUID to transaksjonId.toJson()
+                )
+                    .also {
+                        MdcUtils.withLogFields(
+                            Log.behov(BehovType.HENT_IM_ORGNR)
+                        ) {
+                            sikkerLogger.info("Publiserte melding:\n${it.toPretty()}.")
+                        }
+                    }
+            }
+
+            Transaction.IN_PROGRESS -> {
+                val orgnrKey = RedisKey.of(transaksjonId, DataFelt.ORGNRUNDERENHET)
+
+                if (isDataCollected(orgnrKey)) {
+                    val orgnr = orgnrKey.read()
+
+                    val fnr = RedisKey.of(transaksjonId, DataFelt.FNR)
+                        .read()
+                    if (orgnr == null || fnr == null) {
+                        "Klarte ikke lese orgnr og / eller fnr fra Redis.".also {
+                            logger.error(it)
+                            sikkerLogger.error(it)
+                        }
+                        return
+                    }
                     rapid.publish(
                         Key.EVENT_NAME to event.toJson(),
-                        Key.BEHOV to BehovType.HENT_IM_ORGNR.toJson(),
-                        DataFelt.FORESPOERSEL_ID to forespoerselId.toJson(),
+                        Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
+                        DataFelt.ORGNRUNDERENHET to orgnr.toJson(),
+                        DataFelt.FNR to fnr.toJson(),
                         Key.UUID to transaksjonId.toJson()
                     )
                         .also {
                             MdcUtils.withLogFields(
-                                Log.behov(BehovType.HENT_IM_ORGNR)
+                                Log.behov(BehovType.TILGANGSKONTROLL)
                             ) {
                                 sikkerLogger.info("Publiserte melding:\n${it.toPretty()}.")
                             }
                         }
+                } else {
+                    sikkerLogger.error("Transaksjon er underveis, men mangler data. Dette bør aldri skje, ettersom vi kun venter på én datapakke.")
                 }
+            }
 
-                Transaction.IN_PROGRESS -> {
-                    val orgnrKey = RedisKey.of(transaksjonId.toString(), DataFelt.ORGNRUNDERENHET)
-
-                    if (isDataCollected(orgnrKey)) {
-                        val orgnr = orgnrKey.read()
-
-                        val fnr = RedisKey.of(transaksjonId.toString(), DataFelt.FNR)
-                            .read()
-                        if (orgnr == null || fnr == null) {
-                            "Klarte ikke lese orgnr og / eller fnr fra Redis.".also {
-                                logger.error(it)
-                                sikkerLogger.error(it)
-                            }
-                            return
-                        }
-                        rapid.publish(
-                            Key.EVENT_NAME to event.toJson(),
-                            Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
-                            DataFelt.ORGNRUNDERENHET to orgnr.toJson(),
-                            DataFelt.FNR to fnr.toJson(),
-                            Key.UUID to transaksjonId.toJson()
-                        )
-                            .also {
-                                MdcUtils.withLogFields(
-                                    Log.behov(BehovType.TILGANGSKONTROLL)
-                                ) {
-                                    sikkerLogger.info("Publiserte melding:\n${it.toPretty()}.")
-                                }
-                            }
-                    } else {
-                        sikkerLogger.error("Transaksjon er underveis, men mangler data. Dette bør aldri skje, ettersom vi kun venter på én datapakke.")
-                    }
-                }
-                else -> {
-                    sikkerLogger.error("Støtte på forutsett transaksjonstype: $transaction")
-                }
+            else -> {
+                sikkerLogger.error("Støtte på forutsett transaksjonstype: $transaction")
             }
         }
     }
@@ -144,59 +148,64 @@ class TilgangService(
 
         val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
-        val clientId = RedisKey.of(transaksjonId.toString(), event)
+        val clientId = RedisKey.of(transaksjonId, event)
             .read()?.let(UUID::fromString)
+
         if (clientId == null) {
             sikkerLogger.error("Kunne ikke lese clientId for $transaksjonId fra Redis")
-        }
+        } else {
+            val tilgang = RedisKey.of(transaksjonId, DataFelt.TILGANG).read()
+            val feil = RedisKey.of(transaksjonId, Feilmelding("")).read()
 
-        val tilgang = RedisKey.of(transaksjonId.toString(), DataFelt.TILGANG).read()
-        val feil = RedisKey.of(transaksjonId.toString(), Feilmelding("")).read()
+            val tilgangJson = TilgangData(
+                tilgang = tilgang?.fromJson(Tilgang.serializer()),
+                feil = feil?.fromJson(FeilReport.serializer())
+            )
+                .toJson(TilgangData.serializer())
 
-        val tilgangJson = TilgangData(
-            tilgang = tilgang?.fromJson(Tilgang.serializer()),
-            feil = feil?.fromJson(FeilReport.serializer())
-        )
-            .toJson(TilgangData.serializer())
+            RedisKey.of(clientId).write(tilgangJson)
 
-        RedisKey.of(clientId.toString()).write(tilgangJson)
-
-        val logFields = loggFelterNotNull(transaksjonId, clientId)
-
-        MdcUtils.withLogFields(
-            *logFields
-        ) {
-            sikkerLogger.info("$event fullført.")
+            MdcUtils.withLogFields(
+                Log.clientId(clientId),
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.info("$event fullført.")
+            }
         }
     }
 
     override fun terminate(fail: Fail) {
-        val clientId = RedisKey.of(fail.uuid!!, event)
+        val transaksjonId = fail.uuid!!.let(UUID::fromString)
+
+        val clientId = RedisKey.of(transaksjonId, event)
             .read()
             ?.let(UUID::fromString)
 
-        val feil = RedisKey.of(fail.uuid!!, Feilmelding(""))
+        val feil = RedisKey.of(transaksjonId, Feilmelding(""))
             .read()
 
         val feilResponse = TilgangData(
             feil = feil?.fromJson(FeilReport.serializer())
         )
             .toJson(TilgangData.serializer())
-        if (clientId == null) {
-            sikkerLogger.error("$event forsøkt terminert, kunne ikke finne ${fail.uuid} i redis!")
-        }
-        RedisKey.of(clientId.toString()).write(feilResponse)
 
-        val logFields = loggFelterNotNull(fail.uuid!!.let(UUID::fromString), clientId)
-        MdcUtils.withLogFields(
-            *logFields
-        ) {
-            sikkerLogger.error("$event terminert.")
+        if (clientId == null) {
+            sikkerLogger.error("$event forsøkt terminert, kunne ikke finne $transaksjonId i redis!")
+        } else {
+            RedisKey.of(clientId).write(feilResponse)
+
+            MdcUtils.withLogFields(
+                Log.clientId(clientId),
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("$event terminert.")
+            }
         }
     }
 
     override fun onError(feil: Fail): Transaction {
-        val transaksjonId = feil.uuid ?: throw IllegalStateException("Feil mangler transaksjon-ID.")
+        val transaksjonId = feil.uuid?.let(UUID::fromString)
+            ?: throw IllegalStateException("Feil mangler transaksjon-ID.")
 
         val manglendeDatafelt = when (feil.behov) {
             BehovType.HENT_IM_ORGNR -> DataFelt.ORGNRUNDERENHET
@@ -231,24 +240,4 @@ class TilgangService(
 
     private fun RedisKey.read(): String? =
         redisStore.get(this)
-
-    // Veldig stygt, ta med clientId i loggfelter når den eksisterer
-    // TODO: skriv heller om MDCUtils.log. Fjern dette...
-    private fun loggFelterNotNull(
-        transaksjonId: UUID,
-        clientId: UUID?
-    ): Array<Pair<String, String>> {
-        val logs = arrayOf(
-            Log.klasse(this),
-            Log.event(event),
-            Log.transaksjonId(transaksjonId)
-        )
-        val logFields = clientId?.let {
-            logs +
-                arrayOf(
-                    Log.clientId(clientId)
-                )
-        } ?: logs
-        return logFields
-    }
 }

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
@@ -14,6 +14,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.PersonDato
 import no.nav.helsearbeidsgiver.felles.TrengerData
 import no.nav.helsearbeidsgiver.felles.TrengerInntekt
+import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.DelegatingFailKanal
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.StatefullDataKanal
@@ -23,11 +24,14 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.Transaction
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.toJsonMap
 import no.nav.helsearbeidsgiver.felles.utils.simpleName
 import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import java.util.UUID
 
 const val UNDEFINED_FELT: String = "{}"
 class TrengerService(private val rapidsConnection: RapidsConnection, override val redisStore: IRedisStore) : CompositeEventListener(redisStore) {
@@ -65,7 +69,7 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
     }
 
     override fun onError(feil: Fail): Transaction {
-        val uuid = feil.uuid!!
+        val uuid = feil.uuid!!.let(UUID::fromString)
         var feilmelding: Feilmelding? = null
         if (feil.behov == BehovType.HENT_TRENGER_IM) {
             feilmelding = Feilmelding("Teknisk feil, prøv igjen senere.", -1, datafelt = DataFelt.FORESPOERSEL_SVAR)
@@ -98,7 +102,7 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
     }
 
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
-        val uuid = message[Key.UUID.str].asText()
+        val uuid = message[Key.UUID.str].asText().let(UUID::fromString)
         sikkerLogger.info("Dispatcher for $uuid with trans state $transaction")
         if (transaction == Transaction.NEW) {
             sikkerLogger.info("Dispatcher HENT_TRENGER_IM for $uuid")
@@ -158,7 +162,7 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
 
                     "Fant ikke skjaeringstidspunkt å hente inntekt for.".also {
                         sikkerLogger.error("$it forespoersel=$forespoersel")
-                        val feil = Fail(event, BehovType.INNTEKT, it, null, uuid, forespoerselId)
+                        val feil = Fail(event, BehovType.INNTEKT, it, null, uuid.toString(), forespoerselId)
                         onError(feil)
                     }
                 }
@@ -169,41 +173,53 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
     }
 
     override fun finalize(message: JsonMessage) {
-        val transactionId = message[Key.UUID.str].asText()
-        val foresporselSvar = redisStore.get(RedisKey.of(transactionId, DataFelt.FORESPOERSEL_SVAR))?.fromJson(TrengerInntekt.serializer())
-        val inntekt = redisStore.get(RedisKey.of(transactionId, DataFelt.INNTEKT))?.fromJson(Inntekt.serializer())
-        val clientId = redisStore.get(RedisKey.of(transactionId, EventName.valueOf(message[Key.EVENT_NAME.str].asText())))
-        val feilReport: FeilReport? = redisStore.get(RedisKey.of(uuid = transactionId, Feilmelding("")))?.fromJson(FeilReport.serializer())
-        val trengerData = TrengerData(
-            fnr = foresporselSvar?.fnr,
-            orgnr = foresporselSvar?.orgnr,
-            personDato = redisStore.get(RedisKey.of(transactionId, DataFelt.ARBEIDSTAKER_INFORMASJON), PersonDato::class.java),
-            arbeidsgiver = redisStore.get(RedisKey.of(transactionId, DataFelt.ARBEIDSGIVER_INFORMASJON), PersonDato::class.java),
-            virksomhetNavn = redisStore.get(RedisKey.of(transactionId, DataFelt.VIRKSOMHET)),
-            inntekt = redisStore.get(RedisKey.of(transactionId, DataFelt.INNTEKT))?.fromJsonWithUndefined(Inntekt.serializer()),
-            skjaeringstidspunkt = foresporselSvar?.skjaeringstidspunkt,
-            fravarsPerioder = foresporselSvar?.sykmeldingsperioder,
-            egenmeldingsPerioder = foresporselSvar?.egenmeldingsperioder,
-            forespurtData = foresporselSvar?.forespurtData,
-            bruttoinntekt = inntekt?.gjennomsnitt(),
-            tidligereinntekter = inntekt?.maanedOversikt,
-            feilReport = feilReport
-        )
-        val json = trengerData.toJsonStr(TrengerData.serializer())
-        redisStore.set(RedisKey.of(clientId!!), json)
+        val melding = message.toJsonMap()
+
+        val transaksjonId = Key.UUID.les(UuidSerializer, melding)
+        val clientId = redisStore.get(RedisKey.of(transaksjonId, EventName.TRENGER_REQUESTED))
+            ?.let(UUID::fromString)
+
+        if (clientId == null) {
+            sikkerLogger.error("Forsøkte å fullføre, men clientId mangler i Redis.")
+        } else {
+            val foresporselSvar = redisStore.get(RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_SVAR))?.fromJson(TrengerInntekt.serializer())
+            val inntekt = redisStore.get(RedisKey.of(transaksjonId, DataFelt.INNTEKT))?.fromJson(Inntekt.serializer())
+            val feilReport: FeilReport? = redisStore.get(RedisKey.of(transaksjonId, Feilmelding("")))?.fromJson(FeilReport.serializer())
+
+            val trengerData = TrengerData(
+                fnr = foresporselSvar?.fnr,
+                orgnr = foresporselSvar?.orgnr,
+                personDato = redisStore.get(RedisKey.of(transaksjonId, DataFelt.ARBEIDSTAKER_INFORMASJON))?.fromJson(PersonDato.serializer()),
+                arbeidsgiver = redisStore.get(RedisKey.of(transaksjonId, DataFelt.ARBEIDSGIVER_INFORMASJON))?.fromJson(PersonDato.serializer()),
+                virksomhetNavn = redisStore.get(RedisKey.of(transaksjonId, DataFelt.VIRKSOMHET)),
+                inntekt = redisStore.get(RedisKey.of(transaksjonId, DataFelt.INNTEKT))?.fromJsonWithUndefined(Inntekt.serializer()),
+                skjaeringstidspunkt = foresporselSvar?.skjaeringstidspunkt,
+                fravarsPerioder = foresporselSvar?.sykmeldingsperioder,
+                egenmeldingsPerioder = foresporselSvar?.egenmeldingsperioder,
+                forespurtData = foresporselSvar?.forespurtData,
+                bruttoinntekt = inntekt?.gjennomsnitt(),
+                tidligereinntekter = inntekt?.maanedOversikt,
+                feilReport = feilReport
+            )
+
+            val json = trengerData.toJsonStr(TrengerData.serializer())
+            redisStore.set(RedisKey.of(clientId), json)
+        }
     }
 
     override fun terminate(fail: Fail) {
-        sikkerLogger.info("terminate transaction id ${fail.uuid} with eventname ${fail.eventName}")
-        val clientId: String? = redisStore.get(RedisKey.of(fail.uuid!!, fail.eventName!!))
+        val transaksjonId = fail.uuid!!.let(UUID::fromString)
+
+        sikkerLogger.info("terminate transaction id $transaksjonId with eventname ${fail.eventName}")
+        val clientId = redisStore.get(RedisKey.of(transaksjonId, fail.eventName!!))?.let(UUID::fromString)
         // @TODO kan vare smartere her. Kan definere feilmeldingen i Feil message istedenfor å hardkode det i TrengerService. Vi også ikke trenger å sende alle andre ikke kritiske feilmeldinger hvis vi har noe kritisk
-        val feilReport: FeilReport = redisStore.get(RedisKey.of(uuid = fail.uuid!!, Feilmelding("")))!!.fromJson(FeilReport.serializer())
+        val feilReport: FeilReport = redisStore.get(RedisKey.of(transaksjonId, Feilmelding("")))!!.fromJson(FeilReport.serializer())
         if (clientId != null) {
             redisStore.set(RedisKey.of(clientId), TrengerData(feilReport = feilReport).toJsonStr(TrengerData.serializer()))
         }
     }
 
-    private fun step1data(uuid: String): Array<RedisKey> = arrayOf(
+    private fun step1data(uuid: UUID): Array<RedisKey> = arrayOf(
         RedisKey.of(uuid, DataFelt.FORESPOERSEL_SVAR)
     )
 

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
@@ -25,11 +25,13 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.IRedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.toJsonMap
+import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.felles.utils.simpleName
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
@@ -180,7 +182,11 @@ class TrengerService(private val rapidsConnection: RapidsConnection, override va
             ?.let(UUID::fromString)
 
         if (clientId == null) {
-            sikkerLogger.error("Forsøkte å fullføre, men clientId mangler i Redis.")
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonId)
+            ) {
+                sikkerLogger.error("Forsøkte å fullføre, men clientId mangler i Redis.")
+            }
         } else {
             val foresporselSvar = redisStore.get(RedisKey.of(transaksjonId, DataFelt.FORESPOERSEL_SVAR))?.fromJson(TrengerInntekt.serializer())
             val inntekt = redisStore.get(RedisKey.of(transaksjonId, DataFelt.INNTEKT))?.fromJson(Inntekt.serializer())


### PR DESCRIPTION
Endringene her startet som en innsats for å gjøre all bruk av RedisStore avhengig av RedisKey, men underveis oppdaget jeg at vi hadde en del skriving til redis som brukte feil nøkkel. Fikset disse i samme slengen, siden de var knyttet opp til lesing og skriving til redis. De endringene er færre linjer enn endringer på RedisKey, men de er viktigere, så de trumfet i commit- og PR-navn. I realiteten er PR-en en "herlig" blanding av RedisKey-endringer og endringer i nøkler brukt mot redis.