### PR TITLE
midlertidig logg warn om forespørselId ikke kommer i packet

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/loeser/PacketSolver.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/loeser/PacketSolver.kt
@@ -32,7 +32,7 @@ internal class PacketSolver(
                 validate { packet ->
                     packet.demandAll(Key.BEHOV.str, loeser.behovType)
                     packet.rejectKey(Key.LØSNING.str)
-                    packet.interestedIn(Key.INITIATE_ID.str)
+                    packet.interestedIn(Key.INITIATE_ID.str, Key.FORESPOERSEL_ID.str)
 
                     loeser.behovReadingKeys.forEach { packet.requireKey(it.str) }
                 }

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/DataKanal.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/DataKanal.kt
@@ -6,10 +6,14 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 abstract class DataKanal(val rapidsConnection: RapidsConnection) : River.PacketListener {
     abstract val eventName: EventName
 
+    private val logger = logger()
+    private val sikkerLogger = sikkerLogger()
     init {
         configure(
             River(rapidsConnection).apply {
@@ -32,6 +36,10 @@ abstract class DataKanal(val rapidsConnection: RapidsConnection) : River.PacketL
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         onData(packet)
     }
 

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/EventListener.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/EventListener.kt
@@ -8,12 +8,15 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Fail
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Event
+import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 abstract class EventListener(val rapidsConnection: RapidsConnection) : River.PacketListener {
 
     abstract val event: EventName
     lateinit var forespørselId: String
-
+    private val logger = logger()
+    private val sikkerLogger = sikkerLogger()
     init {
         configureAsListener(
             River(rapidsConnection).apply {
@@ -47,6 +50,10 @@ abstract class EventListener(val rapidsConnection: RapidsConnection) : River.Pac
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         forespørselId = packet[Key.FORESPOERSEL_ID.str].asText()
         val event = Event.create(packet)
         onEvent(packet)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/Loeser.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/Loeser.kt
@@ -75,6 +75,10 @@ abstract class Loeser(val rapidsConnection: RapidsConnection) : River.PacketList
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
         logger.info("Mottok melding med behov '${packet[Key.BEHOV.str].asText()}'.")
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         sikkerLogger.info("Mottok melding:\n${packet.toPretty()}")
         if (!packet[Key.BEHOV.str].isArray) {
             val behov = Behov.create(packet)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/StatefullDataKanal.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/StatefullDataKanal.kt
@@ -34,6 +34,10 @@ class StatefullDataKanal(
     }
 
     override fun onData(packet: JsonMessage) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger().warn("Mangler forespørselId!")
+            sikkerLogger().warn("Mangler forespørselId!")
+        }
         if (packet[Key.UUID.str].asText().isNullOrEmpty()) {
             sikkerLogger().error("TransaksjonsID er ikke initialisert for\n${packet.toPretty()}")
             rapidsConnection.publish(

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
@@ -28,6 +28,10 @@ abstract class CompositeEventListener(open val redisStore: IRedisStore) : River.
     private lateinit var dataKanal: StatefullDataKanal
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val transaction: Transaction = determineTransactionState(packet)
 
         when (transaction) {

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Data.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Data.kt
@@ -22,6 +22,7 @@ class Data(val event: EventName, val jsonMessage: JsonMessage) : TxMessage {
             it.demandKey(Key.DATA.str)
             it.rejectKey(Key.FAIL.str)
             it.interestedIn(Key.UUID.str)
+            it.interestedIn(Key.FORESPOERSEL_ID.str)
         }
 
         fun create(event: EventName, uuid: UUID, map: Map<DataFelt, Any> = emptyMap()): Data {

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Fail.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Fail.kt
@@ -29,6 +29,7 @@ class Fail(
             it.demandKey(Key.FAIL.str)
             it.interestedIn(Key.UUID.str)
             it.interestedIn(Key.FAILED_BEHOV.str)
+            it.interestedIn(Key.FORESPOERSEL_ID.str)
         }
 
         fun create(event: EventName, behov: BehovType? = null, feilmelding: String, uuid: String? = null, data: Map<IKey, Any> = emptyMap()): Fail {

--- a/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartLoeser.kt
+++ b/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartLoeser.kt
@@ -37,6 +37,10 @@ sealed class ForespoerselBesvartLoeser : River.PacketListener {
     abstract fun haandterFeil(json: JsonElement)
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         sikkerLogger.info("Mottok melding:\n${json.toPretty()}")

--- a/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -50,6 +50,10 @@ class MarkerForespoerselBesvartRiver(
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         MdcUtils.withLogFields(

--- a/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattLoeser.kt
+++ b/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattLoeser.kt
@@ -58,6 +58,10 @@ class ForespoerselMottattLoeser(
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         val transaksjonId = randomUuid()

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarLoeser.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarLoeser.kt
@@ -45,11 +45,16 @@ class ForespoerselSvarLoeser(rapid: RapidsConnection) : River.PacketListener {
                 msg.demand(
                     Pri.Key.LØSNING to { it.fromJson(ForespoerselSvar.serializer()) }
                 )
+                msg.interestedIn(Key.FORESPOERSEL_ID.str)
             }
         }.register(this)
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         logger.info("Mottok løsning på pri-topic om ${ForespoerselSvar.behovType}.")

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OppgaveFerdigLoeser.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OppgaveFerdigLoeser.kt
@@ -49,6 +49,10 @@ class OppgaveFerdigLoeser(
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         MdcUtils.withLogFields(

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/SakFerdigLoeser.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/SakFerdigLoeser.kt
@@ -50,6 +50,10 @@ class SakFerdigLoeser(
     }
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
+        if (packet[Key.FORESPOERSEL_ID.str].asText().isEmpty()) {
+            logger.warn("Mangler forespørselId!")
+            sikkerLogger.warn("Mangler forespørselId!")
+        }
         val json = packet.toJson().parseJson()
 
         MdcUtils.withLogFields(


### PR DESCRIPTION
+ lagt til interestedIn på forespørselId i Data, Fail, packetSolver og ForespoerselBesvartLoeser

Det er litt mye duplisert kode, men tanken var egentlig bare å rulle ut dette og la det kjøre en stund i produksjon, for å se om vi egentlig har noen tilfeller der forespørselID IKKE sendes. 
Hvis vi er trygge på at vi alltid mottar forespørselId, kan vi vurdere å bare lese denne verdien rett fra packet, heller enn å lese fra en noe tvilsom redis. 
