### PR TITLE
database-apper bør bruke rollout recreate

### DIFF
--- a/config/nais.yml
+++ b/config/nais.yml
@@ -54,6 +54,8 @@ spec:
       {{/if}}
   {{/if}}
   {{#if database}}
+  strategy:
+    type: Recreate
   gcp:
     sqlInstances:
       - type: POSTGRES_14


### PR DESCRIPTION
forhindrer at spørringer fra gammel versjon kjøres under db-migrering når ny versjon rulles ut