### PR TITLE
Forhindre crash loop i servicer for opprettelse av sak og oppgave

### DIFF
--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
@@ -16,13 +16,21 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
 import no.nav.helsearbeidsgiver.felles.utils.Log
+import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.parseJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.log.MdcUtils
+import no.nav.helsearbeidsgiver.utils.log.logger
+import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
 class OpprettOppgaveService(
     private val rapidsConnection: RapidsConnection,
     override val redisStore: RedisStore
 ) : CompositeEventListener(redisStore) {
+
+    private val logger = logger()
+    private val sikkerLogger = sikkerLogger()
 
     override val event: EventName = EventName.OPPGAVE_OPPRETT_REQUESTED
 
@@ -47,55 +55,110 @@ class OpprettOppgaveService(
         }
         withFailKanal { DelegatingFailKanal(event, this, rapidsConnection) }
     }
+
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.OPPGAVE_OPPRETT_REQUESTED)
+        ) {
+            val json = message.toJson().parseJson().toMap()
+
+            val transaksjonsId = json[Key.UUID]?.fromJson(UuidSerializer)
+            if (transaksjonsId == null) {
+                "Mangler transaksjonId. Klarer ikke opprette oppgave.".also {
+                    logger.error(it)
+                    sikkerLogger.error(it)
+                }
+                return
+            }
+
+            val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))?.let(UUID::fromString)
+                ?: json[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer)
+
+            if (forespoerselId == null) {
+                MdcUtils.withLogFields(
+                    Log.transaksjonId(transaksjonsId)
+                ) {
+                    "Mangler forespoerselId. Klarer ikke opprette oppgave.".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                }
+                return
+            }
+
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonsId),
+                Log.forespoerselId(forespoerselId)
+            ) {
+                if (transaction == Transaction.NEW) {
+                    rapidsConnection.publish(
+                        JsonMessage.newMessage(
+                            mapOf(
+                                Key.EVENT_NAME.str to event.name,
+                                Key.UUID.str to transaksjonsId,
+                                Key.BEHOV.str to BehovType.VIRKSOMHET.name,
+                                Key.FORESPOERSEL_ID.str to forespoerselId,
+                                Key.ORGNRUNDERENHET.str to message[Key.ORGNRUNDERENHET.str]
+                            )
+                        ).toJson()
+                    )
+                }
+            }
+        }
+    }
+
+    override fun finalize(message: JsonMessage) {
         val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
-        val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))!!
-        if (transaction == Transaction.NEW) {
+        val forespoerselId = message[Key.FORESPOERSEL_ID.str].asText().let(UUID::fromString)
+
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.OPPGAVE_OPPRETT_REQUESTED),
+            Log.transaksjonId(transaksjonsId),
+            Log.forespoerselId(forespoerselId)
+        ) {
+            val orgnr = redisStore.get(RedisKey.of(transaksjonsId, Key.ORGNRUNDERENHET))
+            if (orgnr == null) {
+                "Mangler orgnr i redis. Klarer ikke publisere event om opprettet oppgave.".also {
+                    logger.error(it)
+                    sikkerLogger.error(it)
+                }
+                return
+            }
+
+            val virksomhetNavn = redisStore.get(RedisKey.of(transaksjonsId, Key.VIRKSOMHET))
+                ?: defaultVirksomhetNavn()
+
             rapidsConnection.publish(
                 JsonMessage.newMessage(
                     mapOf(
                         Key.EVENT_NAME.str to event.name,
+                        Key.BEHOV.str to BehovType.OPPRETT_OPPGAVE,
                         Key.UUID.str to transaksjonsId,
-                        Key.BEHOV.str to BehovType.VIRKSOMHET.name,
                         Key.FORESPOERSEL_ID.str to forespoerselId,
-                        Key.ORGNRUNDERENHET.str to message[Key.ORGNRUNDERENHET.str]
+                        Key.VIRKSOMHET.str to virksomhetNavn,
+                        Key.ORGNRUNDERENHET.str to orgnr
                     )
                 ).toJson()
             )
         }
     }
 
-    override fun finalize(message: JsonMessage) {
-        val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
-        val virksomhetnavn = redisStore.get(RedisKey.of(transaksjonsId, Key.VIRKSOMHET))
-        val orgnr = redisStore.get(RedisKey.of(transaksjonsId, Key.ORGNRUNDERENHET))
-        val forespoerselId = message[Key.FORESPOERSEL_ID.str].asText()
-        rapidsConnection.publish(
-            JsonMessage.newMessage(
-                mapOf(
-                    Key.EVENT_NAME.str to event.name,
-                    Key.BEHOV.str to BehovType.OPPRETT_OPPGAVE,
-                    Key.UUID.str to transaksjonsId,
-                    Key.FORESPOERSEL_ID.str to forespoerselId,
-                    Key.VIRKSOMHET.str to virksomhetnavn!!,
-                    Key.ORGNRUNDERENHET.str to orgnr!!
-                )
-            ).toJson()
-        )
-    }
-
     override fun terminate(fail: Fail) {
-        val clientId = redisStore.get(RedisKey.of(fail.transaksjonId, event))
-            ?.let(UUID::fromString)
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.OPPGAVE_OPPRETT_REQUESTED),
+            Log.transaksjonId(fail.transaksjonId)
+        ) {
+            val clientId = redisStore.get(RedisKey.of(fail.transaksjonId, event))
+                ?.let(UUID::fromString)
 
-        if (clientId == null) {
-            MdcUtils.withLogFields(
-                Log.transaksjonId(fail.transaksjonId)
-            ) {
+            if (clientId == null) {
                 sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespoerselId}")
+            } else {
+                redisStore.set(RedisKey.of(clientId), fail.feilmelding)
             }
-        } else {
-            redisStore.set(RedisKey.of(clientId), fail.feilmelding)
         }
     }
 
@@ -103,9 +166,12 @@ class OpprettOppgaveService(
         val utloesendeBehov = Key.BEHOV.lesOrNull(BehovType.serializer(), feil.utloesendeMelding.toMap())
         if (utloesendeBehov == BehovType.VIRKSOMHET) {
             val virksomhetKey = RedisKey.of(feil.transaksjonId, Key.VIRKSOMHET)
-            redisStore.set(virksomhetKey, "Arbeidsgiver")
+            redisStore.set(virksomhetKey, defaultVirksomhetNavn())
             return Transaction.FINALIZE
         }
         return Transaction.TERMINATE
     }
+
+    private fun defaultVirksomhetNavn(): String =
+        "Arbeidsgiver"
 }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettOppgaveService.kt
@@ -120,7 +120,7 @@ class OpprettOppgaveService(
         ) {
             val orgnr = redisStore.get(RedisKey.of(transaksjonsId, Key.ORGNRUNDERENHET))
             if (orgnr == null) {
-                "Mangler orgnr i redis. Klarer ikke publisere event om opprettet oppgave.".also {
+                "Mangler orgnr i redis. Klarer ikke opprette oppgave.".also {
                     logger.error(it)
                     sikkerLogger.error(it)
                 }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OpprettSakService.kt
@@ -54,37 +54,65 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
         }
         withFailKanal { DelegatingFailKanal(event, this, rapidsConnection) }
     }
+
     override fun dispatchBehov(message: JsonMessage, transaction: Transaction) {
-        val json = message.toJson().parseJson().toMap()
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.SAK_OPPRETT_REQUESTED)
+        ) {
+            val json = message.toJson().parseJson().toMap()
 
-        val transaksjonsId = json[Key.UUID]?.fromJson(UuidSerializer)
-        if (transaksjonsId == null) {
-            "Mangler transaksjonId. Klarer ikke opprette sak.".also {
-                logger.error(it)
-                sikkerLogger.error(it)
+            val transaksjonsId = json[Key.UUID]?.fromJson(UuidSerializer)
+            if (transaksjonsId == null) {
+                "Mangler transaksjonId. Klarer ikke opprette sak.".also {
+                    logger.error(it)
+                    sikkerLogger.error(it)
+                }
+                return
             }
-            return
-        }
 
-        val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))?.let(UUID::fromString)
-            ?: json[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer)
+            val forespoerselId = redisStore.get(RedisKey.of(transaksjonsId, Key.FORESPOERSEL_ID))?.let(UUID::fromString)
+                ?: json[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer)
 
-        if (forespoerselId == null) {
-            "Mangler forespoerselId. Klarer ikke opprette sak.".also {
-                logger.error(it)
-                sikkerLogger.error(it)
+            if (forespoerselId == null) {
+                MdcUtils.withLogFields(
+                    Log.transaksjonId(transaksjonsId)
+                ) {
+                    "Mangler forespoerselId. Klarer ikke opprette sak.".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                }
+                return
             }
-            return
-        }
 
+            MdcUtils.withLogFields(
+                Log.transaksjonId(transaksjonsId),
+                Log.forespoerselId(forespoerselId)
+            ) {
+                dispatch(transaction, transaksjonsId, forespoerselId)
+            }
+        }
+    }
+
+    private fun dispatch(transaction: Transaction, transaksjonsId: UUID, forespoerselId: UUID) {
         if (transaction == Transaction.NEW) {
+            val fnr = redisStore.get(RedisKey.of(transaksjonsId, Key.IDENTITETSNUMMER))
+            if (fnr == null) {
+                "Mangler fnr i redis. Klarer ikke opprette sak.".also {
+                    logger.error(it)
+                    sikkerLogger.error(it)
+                }
+                return
+            }
+
             rapidsConnection.publish(
                 JsonMessage.newMessage(
                     mapOf(
                         Key.EVENT_NAME.str to event.name,
                         Key.UUID.str to transaksjonsId,
                         Key.BEHOV.str to BehovType.FULLT_NAVN.name,
-                        Key.IDENTITETSNUMMER.str to redisStore.get(RedisKey.of(transaksjonsId, Key.IDENTITETSNUMMER))!!,
+                        Key.IDENTITETSNUMMER.str to fnr,
                         Key.FORESPOERSEL_ID.str to forespoerselId
 
                     )
@@ -92,6 +120,15 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
             )
         } else if (transaction == Transaction.IN_PROGRESS) {
             if (isDataCollected(*steg3(transaksjonsId))) {
+                val sakId = redisStore.get(RedisKey.of(transaksjonsId, Key.SAK_ID))
+                if (sakId == null) {
+                    "Mangler sakId i redis. Klarer ikke opprette sak.".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                    return
+                }
+
                 rapidsConnection.publish(
                     JsonMessage.newMessage(
                         mapOf(
@@ -99,12 +136,24 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
                             Key.UUID.str to transaksjonsId,
                             Key.BEHOV.str to BehovType.PERSISTER_SAK_ID.name,
                             Key.FORESPOERSEL_ID.str to forespoerselId,
-                            Key.SAK_ID.str to redisStore.get(RedisKey.of(transaksjonsId, Key.SAK_ID))!!
+                            Key.SAK_ID.str to sakId
                         )
                     ).toJson()
                 )
             } else if (isDataCollected(*steg2(transaksjonsId))) {
-                val arbeidstakerRedis = redisStore.get(RedisKey.of(transaksjonsId, Key.ARBEIDSTAKER_INFORMASJON))?.fromJson(PersonDato.serializer())
+                val orgnr = redisStore.get(RedisKey.of(transaksjonsId, Key.ORGNRUNDERENHET))
+                if (orgnr == null) {
+                    "Mangler orgnr i redis. Klarer ikke opprette sak.".also {
+                        logger.error(it)
+                        sikkerLogger.error(it)
+                    }
+                    return
+                }
+
+                val arbeidstaker = redisStore.get(RedisKey.of(transaksjonsId, Key.ARBEIDSTAKER_INFORMASJON))
+                    ?.fromJson(PersonDato.serializer())
+                    ?: ukjentArbeidstaker()
+
                 rapidsConnection.publish(
                     JsonMessage.newMessage(
                         mapOf(
@@ -112,9 +161,8 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
                             Key.UUID.str to transaksjonsId,
                             Key.BEHOV.str to BehovType.OPPRETT_SAK,
                             Key.FORESPOERSEL_ID.str to forespoerselId,
-                            Key.ORGNRUNDERENHET.str to redisStore.get(RedisKey.of(transaksjonsId, Key.ORGNRUNDERENHET))!!,
-                            // @TODO this transformation is not nessesary. StatefullDataKanal should be fixed to use Tree
-                            Key.ARBEIDSTAKER_INFORMASJON.str to arbeidstakerRedis!!
+                            Key.ORGNRUNDERENHET.str to orgnr,
+                            Key.ARBEIDSTAKER_INFORMASJON.str to arbeidstaker
                         )
                     ).toJson()
                 )
@@ -124,42 +172,63 @@ class OpprettSakService(private val rapidsConnection: RapidsConnection, override
 
     override fun finalize(message: JsonMessage) {
         val transaksjonsId = message[Key.UUID.str].asText().let(UUID::fromString)
-        rapidsConnection.publish(
-            JsonMessage.newMessage(
-                mapOf(
-                    Key.EVENT_NAME.str to EventName.SAK_OPPRETTET.name,
-                    Key.FORESPOERSEL_ID.str to message[Key.FORESPOERSEL_ID.str],
-                    Key.SAK_ID.str to redisStore.get(RedisKey.of(transaksjonsId, Key.SAK_ID))!!
-                )
-            ).toJson()
-        )
+
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.SAK_OPPRETT_REQUESTED),
+            Log.transaksjonId(transaksjonsId)
+        ) {
+            val sakId = redisStore.get(RedisKey.of(transaksjonsId, Key.SAK_ID))
+            if (sakId == null) {
+                "Mangler sakId i redis. Klarer ikke publisere event om opprettet sak.".also {
+                    logger.error(it)
+                    sikkerLogger.error(it)
+                }
+                return
+            }
+
+            rapidsConnection.publish(
+                JsonMessage.newMessage(
+                    mapOf(
+                        Key.EVENT_NAME.str to EventName.SAK_OPPRETTET.name,
+                        Key.FORESPOERSEL_ID.str to message[Key.FORESPOERSEL_ID.str],
+                        Key.SAK_ID.str to sakId
+                    )
+                ).toJson()
+            )
+        }
     }
 
     override fun terminate(fail: Fail) {
-        val clientId = redisStore.get(RedisKey.of(fail.transaksjonId, event))
-            ?.let(UUID::fromString)
+        MdcUtils.withLogFields(
+            Log.klasse(this),
+            Log.event(EventName.SAK_OPPRETT_REQUESTED),
+            Log.transaksjonId(fail.transaksjonId)
+        ) {
+            val clientId = redisStore.get(RedisKey.of(fail.transaksjonId, event))
+                ?.let(UUID::fromString)
 
-        if (clientId == null) {
-            MdcUtils.withLogFields(
-                Log.transaksjonId(fail.transaksjonId)
-            ) {
+            if (clientId == null) {
                 sikkerLogger.error("Forsøkte å terminere, men clientId mangler i Redis. forespoerselId=${fail.forespoerselId}")
+            } else {
+                redisStore.set(RedisKey.of(clientId), fail.feilmelding)
             }
-        } else {
-            redisStore.set(RedisKey.of(clientId), fail.feilmelding)
         }
     }
 
     override fun onError(feil: Fail): Transaction {
         val utloesendeBehov = Key.BEHOV.lesOrNull(BehovType.serializer(), feil.utloesendeMelding.toMap())
         if (utloesendeBehov == BehovType.FULLT_NAVN) {
-            val fulltNavnKey = RedisKey.of(feil.transaksjonId, Key.ARBEIDSTAKER_INFORMASJON)
-            redisStore.set(fulltNavnKey, PersonDato("Ukjent person", null, "").toJsonStr(PersonDato.serializer()))
+            val arbeidstakerKey = RedisKey.of(feil.transaksjonId, Key.ARBEIDSTAKER_INFORMASJON)
+            redisStore.set(arbeidstakerKey, ukjentArbeidstaker().toJsonStr(PersonDato.serializer()))
             return Transaction.IN_PROGRESS
         }
         return Transaction.TERMINATE
     }
 
-    fun steg2(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, Key.ARBEIDSTAKER_INFORMASJON))
-    fun steg3(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, Key.SAK_ID))
+    private fun ukjentArbeidstaker(): PersonDato =
+        PersonDato("Ukjent person", null, "")
+
+    private fun steg2(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, Key.ARBEIDSTAKER_INFORMASJON))
+    private fun steg3(transactionId: UUID) = arrayOf(RedisKey.of(transactionId, Key.SAK_ID))
 }


### PR DESCRIPTION
Fikser crash loop i prod som oppstår etter lesing av utgåtte verdier fra Redis, kombinert med (alltid) uheldige `!!`.