### PR TITLE
Erstatt utdatert bruk av IKey (stammer fra Datafelt)

### DIFF
--- a/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/ArbeidsforholdLoeserTest.kt
+++ b/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/ArbeidsforholdLoeserTest.kt
@@ -12,8 +12,6 @@ import io.mockk.coEvery
 import io.mockk.coVerifySequence
 import io.mockk.mockk
 import kotlinx.serialization.UseSerializers
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.aareg.AaregClient
 import no.nav.helsearbeidsgiver.felles.Arbeidsforhold
@@ -29,7 +27,6 @@ import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.ArbeidsforholdLoeser
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.tilArbeidsforhold
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -91,12 +88,7 @@ class ArbeidsforholdLoeserTest : FunSpec({
             event = event,
             transaksjonId = transaksjonId,
             forespoerselId = forespoerselId,
-            utloesendeMelding = innkommendeMelding.toJson(
-                MapSerializer(
-                    Key.serializer(),
-                    JsonElement.serializer()
-                )
-            )
+            utloesendeMelding = innkommendeMelding.toJson()
         )
 
         coEvery { mockAaregClient.hentArbeidsforhold(any(), any()) } throws RuntimeException()
@@ -112,7 +104,7 @@ class ArbeidsforholdLoeserTest : FunSpec({
         val fail = testRapid.firstMessage().readFail()
 
         fail.shouldBeEqualToIgnoringFields(expected, Fail::utloesendeMelding)
-        fail.utloesendeMelding.fromJsonMapFiltered(Key.serializer()) shouldContainAll innkommendeMelding
+        fail.utloesendeMelding.toMap() shouldContainAll innkommendeMelding
     }
 })
 

--- a/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -208,12 +208,7 @@ class AktiveOrgnrService(
             event = event,
             transaksjonId = transaksjonId,
             forespoerselId = null,
-            utloesendeMelding = toJson(
-                MapSerializer(
-                    Key.serializer(),
-                    JsonElement.serializer()
-                )
-            )
+            utloesendeMelding = toJson()
         )
 
     private fun trekkUtArbeidsforhold(arbeidsforholdListe: List<Arbeidsforhold>?, orgrettigheter: Set<String>?): Result<List<String>> {

--- a/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeser.kt
+++ b/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeser.kt
@@ -5,7 +5,6 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.altinn.AltinnClient
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
@@ -29,7 +28,7 @@ class AltinnLoeser(
     private val altinnClient: AltinnClient
 ) : ObjectRiver<Melding>() {
 
-    override fun les(json: Map<IKey, JsonElement>): Melding =
+    override fun les(json: Map<Key, JsonElement>): Melding =
         Melding(
             eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
             transactionId = Key.UUID.les(UuidSerializer, json),
@@ -37,7 +36,7 @@ class AltinnLoeser(
             identitetsnummer = Key.IDENTITETSNUMMER.les(String.serializer(), json)
         )
 
-    override fun Melding.haandter(): Map<IKey, JsonElement> {
+    override fun Melding.haandter(): Map<Key, JsonElement> {
         val rettigheterForenklet =
             Metrics.altinnRequest.recordTime {
                 altinnClient

--- a/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangLoeser.kt
+++ b/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangLoeser.kt
@@ -8,7 +8,6 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.altinn.AltinnClient
 import no.nav.helsearbeidsgiver.felles.BehovType
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.Tilgang
 import no.nav.helsearbeidsgiver.felles.json.les
@@ -70,7 +69,7 @@ class TilgangLoeser(
         }
     }
 
-    private fun hentTilgang(behov: Behov, json: Map<IKey, JsonElement>, transaksjonId: UUID) {
+    private fun hentTilgang(behov: Behov, json: Map<Key, JsonElement>, transaksjonId: UUID) {
         val fnr = Key.FNR.les(String.serializer(), json)
         val orgnr = Key.ORGNRUNDERENHET.les(String.serializer(), json)
 

--- a/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeserTest.kt
+++ b/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnLoeserTest.kt
@@ -9,13 +9,11 @@ import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.mockk
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.altinn.AltinnClient
 import no.nav.helsearbeidsgiver.altinn.AltinnOrganisasjon
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
@@ -43,7 +41,7 @@ class AltinnLoeserTest : FunSpec({
         val mockId = "long-john-silver"
         val mockUuid = randomUuid()
 
-        val expectedPublished = mapOf<IKey, JsonElement>(
+        val expectedPublished = mapOf(
             Key.DATA to "".toJson(),
             Key.UUID to mockUuid.toJson(),
             Key.ORG_RETTIGHETER to mockAltinnOrganisasjonSet().mapNotNull { it.orgnr }.toSet().toJson(String.serializer().set())

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeser.kt
@@ -4,8 +4,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.brreg
 
 import io.prometheus.client.Summary
 import kotlinx.coroutines.runBlocking
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.builtins.serializer
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.brreg.BrregClient
@@ -13,6 +11,7 @@ import no.nav.helsearbeidsgiver.brreg.Virksomhet
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
+import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
@@ -108,7 +107,7 @@ class VirksomhetLoeser(
                 transaksjonId = transaksjonId,
                 forespoerselId = behov.forespoerselId?.let(UUID::fromString),
                 Key.VIRKSOMHET to navnListe.values.first().toJson(),
-                Key.VIRKSOMHETER to navnListe.toJson(MapSerializer(String.serializer(), String.serializer()))
+                Key.VIRKSOMHETER to navnListe.toJson()
             )
         } catch (ex: FantIkkeVirksomhetException) {
             logger.error("Fant ikke virksomhet for $orgnr")

--- a/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -14,7 +14,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.ModelUtils.toFailOrNull
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.toPretty
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
@@ -46,7 +45,7 @@ class FeilLytter(rapidsConnection: RapidsConnection, private val repository: Bak
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
         sikkerLogger.info("Mottok feil: ${packet.toPretty()}")
-        val fail = toFailOrNull(packet.toJson().parseJson().fromJsonMapFiltered(Key.serializer()))
+        val fail = toFailOrNull(packet.toJson().parseJson().toMap())
         if (skalHaandteres(fail)) {
             sikkerLogger.info("Lagrer mottatt pakke!")
             val jobb = Bakgrunnsjobb(

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
@@ -1,13 +1,14 @@
 package no.nav.helsearbeidsgiver.felles.json
 
 import kotlinx.serialization.KSerializer
+import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.nullable
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -18,14 +19,24 @@ fun EventName.toJson(): JsonElement =
 fun BehovType.toJson(): JsonElement =
     toJson(BehovType.serializer())
 
-fun JsonElement.toMap(): Map<IKey, JsonElement> =
-    listOf(
-        Key.serializer(),
-        Pri.Key.serializer()
+fun Map<String, String>.toJson(): JsonElement =
+    toJson(
+        MapSerializer(
+            String.serializer(),
+            String.serializer()
+        )
     )
-        .fold(emptyMap()) { jsonMap, keySerializer ->
-            jsonMap + fromJsonMapFiltered(keySerializer)
-        }
+
+fun Map<Key, JsonElement>.toJson(): JsonElement =
+    toJson(
+        MapSerializer(
+            Key.serializer(),
+            JsonElement.serializer()
+        )
+    )
+
+fun JsonElement.toMap(): Map<Key, JsonElement> =
+    fromJsonMapFiltered(Key.serializer())
 
 fun <K : IKey, T : Any> K.lesOrNull(serializer: KSerializer<T>, melding: Map<K, JsonElement>): T? =
     melding[this]?.fromJson(serializer.nullable)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
@@ -19,6 +19,7 @@ fun EventName.toJson(): JsonElement =
 fun BehovType.toJson(): JsonElement =
     toJson(BehovType.serializer())
 
+@JvmName("toJsonMapKeyStringValueString")
 fun Map<String, String>.toJson(): JsonElement =
     toJson(
         MapSerializer(
@@ -27,6 +28,7 @@ fun Map<String, String>.toJson(): JsonElement =
         )
     )
 
+@JvmName("toJsonMapKeyKeyValueJsonElement")
 fun Map<Key, JsonElement>.toJson(): JsonElement =
     toJson(
         MapSerializer(

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/loeser/ObjectRiver.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/loeser/ObjectRiver.kt
@@ -2,7 +2,7 @@ package no.nav.helsearbeidsgiver.felles.loeser
 
 import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helsearbeidsgiver.felles.IKey
+import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
@@ -29,14 +29,14 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
  *
  * class HobbitFoodRiver : ObjectRiver<LotrCharacter>() {
  *
- *     override fun les(json: Map<IKey, JsonElement>): LotrCharacter =
+ *     override fun les(json: Map<Key, JsonElement>): LotrCharacter =
  *         LotrCharacter(
  *             race = Key.RACE.krev(Race.HOBBIT, Race.serializer(), json),
  *             name = Key.NAME.les(String.serializer(), json),
  *             height = Key.HEIGHT.lesOrNull(Int.serializer(), json)
  *         )
  *
- *     override fun LotrCharacter.haandter(): Map<IKey, JsonElement> {
+ *     override fun LotrCharacter.haandter(): Map<Key, JsonElement> {
  *         val favouriteFood = when (name) {
  *             "Frodo" -> "\uD83C\uDF53"
  *             "Sam" -> "\uD83E\uDD54"
@@ -74,7 +74,7 @@ abstract class ObjectRiver<Melding : Any> {
      *
      * @return Verdi lest fra [json]. Brukes som input i [haandter].
      */
-    protected abstract fun les(json: Map<IKey, JsonElement>): Melding
+    protected abstract fun les(json: Map<Key, JsonElement>): Melding
 
     /**
      * Riverens hovedfunksjon. Agerer på innkommende melding.
@@ -86,7 +86,7 @@ abstract class ObjectRiver<Melding : Any> {
      * Utgående melding som skal publiseres når innkommende melding er ferdig prosessert.
      * Returneres '`null`' så vil ingen utgående melding publiseres.
      */
-    protected abstract fun Melding.haandter(): Map<IKey, JsonElement>?
+    protected abstract fun Melding.haandter(): Map<Key, JsonElement>?
 
     /**
      * Kalles ved exception under [haandter].
@@ -95,7 +95,7 @@ abstract class ObjectRiver<Melding : Any> {
      * Utgående melding som skal publiseres når feil er ferdig prosessert.
      * Default implementasjon returnerer '`null`', som betyr at ingen utgående melding publiseres.
      */
-    protected open fun Throwable.haandterFeil(json: Map<IKey, JsonElement>): Map<IKey, JsonElement>? {
+    protected open fun Throwable.haandterFeil(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         "Ukjent feil.".also {
             logger.error(it)
             sikkerLogger.error(it, this)
@@ -104,7 +104,7 @@ abstract class ObjectRiver<Melding : Any> {
     }
 
     /** Brukes av [OpenRiver]. */
-    internal fun lesOgHaandter(json: Map<IKey, JsonElement>): Map<IKey, JsonElement>? {
+    internal fun lesOgHaandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         val innkommende = runCatching { les(json) }.getOrNull()
 
         val utgaaende = runCatching {

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -6,6 +6,7 @@ import no.nav.helse.rapids_rivers.JsonMessage
 import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.MessageProblems
 import no.nav.helsearbeidsgiver.felles.IKey
+import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -51,10 +52,10 @@ fun JsonMessage.interestedIn(vararg keys: IKey) {
     interestedIn(*keysAsStr)
 }
 
-fun MessageContext.publish(vararg messageFields: Pair<IKey, JsonElement>): JsonElement =
+fun MessageContext.publish(vararg messageFields: Pair<Key, JsonElement>): JsonElement =
     publish(messageFields.toMap())
 
-fun MessageContext.publish(messageFields: Map<IKey, JsonElement>): JsonElement =
+fun MessageContext.publish(messageFields: Map<Key, JsonElement>): JsonElement =
     messageFields
         .mapKeys { (key, _) -> key.toString() }
         .toJson()

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
@@ -8,13 +8,13 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
+import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.ModelUtils.toFailOrNull
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.fromJson
-import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toPretty
@@ -40,7 +40,7 @@ abstract class CompositeEventListener : River.PacketListener {
     abstract fun onError(melding: Map<Key, JsonElement>, fail: Fail)
 
     override fun onPacket(packet: JsonMessage, context: MessageContext) {
-        val melding = packet.toJson().parseJson().fromJsonMapFiltered(Key.serializer())
+        val melding = packet.toJson().parseJson().toMap()
 
         if (Key.FORESPOERSEL_ID.lesOrNull(String.serializer(), melding).isNullOrEmpty()) {
             logger.warn("Mangler forespørselId!")

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
@@ -18,18 +18,34 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 class KotlinxUtilsKtTest : FunSpec({
 
     context("toMap") {
-        withData(
-            mapOf<String, Map<IKey, String>>(
-                "inneholder bare Key" to mapOf(Key.EVENT_NAME to "testevent"),
-                "inneholder bare Pri.Key" to mapOf(Pri.Key.NOTIS to "husk å drikke vann"),
-                "inneholder Key og Pri.Key" to mapOf(
-                    Key.EVENT_NAME to "testevent",
-                    Pri.Key.NOTIS to "husk å drikke vann"
-                )
+        test("inneholder alle Keys") {
+            val expectedMap = mapOf(
+                Key.EVENT_NAME to "test_event",
+                Key.BEHOV to "test_behov",
+                Key.UUID to "test_transaksjonId"
             )
-        ) { expectedMap ->
+
             val json = JsonObject(
                 expectedMap.mapKeys { it.key.str }
+                    .mapValues { it.value.toJson() }
+            )
+
+            val jsonMap = json.toMap()
+
+            jsonMap shouldBe expectedMap.mapValues { it.value.toJson() }
+        }
+
+        test("inneholder bare Keys") {
+            val expectedMap = mapOf(
+                Key.EVENT_NAME to "test_event",
+                Key.BEHOV to "test_behov"
+            )
+
+            val json = JsonObject(
+                expectedMap.mapKeys { it.key.str }
+                    .plus(
+                        "ikke en key" to "skal ikke være med"
+                    )
                     .mapValues { it.value.toJson() }
             )
 

--- a/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSimbaLoeser.kt
+++ b/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSimbaLoeser.kt
@@ -5,9 +5,9 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
+import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.rejectKeys
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.requireKeys
@@ -44,13 +44,15 @@ class ForespoerselBesvartFraSimbaLoeser(
         }.register(this)
     }
 
-    override fun Map<IKey, JsonElement>.lesMelding(): Melding =
-        Melding(
+    override fun JsonElement.lesMelding(): Melding {
+        val json = toMap()
+        return Melding(
             event = EventName.INNTEKTSMELDING_MOTTATT.name,
-            forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, this),
-            transaksjonId = Key.UUID.les(UuidSerializer, this),
+            forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, json),
+            transaksjonId = Key.UUID.les(UuidSerializer, json),
             spinnInntektsmeldingId = null
         )
+    }
 
     override fun haandterFeil(json: JsonElement) {
         sikkerLogger.error(

--- a/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSpleisLoeser.kt
+++ b/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSpleisLoeser.kt
@@ -4,7 +4,6 @@ import io.prometheus.client.Counter
 import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.requireKeys
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
+import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 
 class ForespoerselBesvartFraSpleisLoeser(
@@ -41,13 +41,15 @@ class ForespoerselBesvartFraSpleisLoeser(
         }.register(this)
     }
 
-    override fun Map<IKey, JsonElement>.lesMelding(): Melding =
-        Melding(
+    override fun JsonElement.lesMelding(): Melding {
+        val json = fromJsonMapFiltered(Pri.Key.serializer())
+        return Melding(
             event = Pri.NotisType.FORESPOERSEL_BESVART.name,
-            forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, this),
+            forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             transaksjonId = randomUuid(),
-            spinnInntektsmeldingId = Pri.Key.SPINN_INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, this)
+            spinnInntektsmeldingId = Pri.Key.SPINN_INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, json)
         )
+    }
 
     override fun haandterFeil(json: JsonElement) {
         priProducer.send(json)

--- a/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartLoeser.kt
+++ b/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartLoeser.kt
@@ -7,10 +7,8 @@ import no.nav.helse.rapids_rivers.MessageContext
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
-import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -31,7 +29,7 @@ sealed class ForespoerselBesvartLoeser : River.PacketListener {
 
     abstract val forespoerselBesvartCounter: Counter
 
-    abstract fun Map<IKey, JsonElement>.lesMelding(): Melding
+    abstract fun JsonElement.lesMelding(): Melding
 
     abstract fun haandterFeil(json: JsonElement)
 
@@ -62,7 +60,7 @@ sealed class ForespoerselBesvartLoeser : River.PacketListener {
     }
 
     private fun opprettEvent(json: JsonElement, context: MessageContext) {
-        val melding = json.toMap().lesMelding()
+        val melding = json.lesMelding()
 
         logger.info("Mottok melding om '${melding.event}'.")
 

--- a/forespoersel-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSpleisLoeserTest.kt
+++ b/forespoersel-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartFraSpleisLoeserTest.kt
@@ -12,13 +12,13 @@ import io.mockk.verifySequence
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
-import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
@@ -67,7 +67,7 @@ class ForespoerselBesvartFraSpleisLoeserTest : FunSpec({
         verifySequence {
             mockPriProducer.send(
                 withArg<JsonElement> { json ->
-                    json.toMap().filterKeys { it is Pri.Key } shouldBe expectedRepublisert
+                    json.fromJsonMapFiltered(Pri.Key.serializer()) shouldBe expectedRepublisert
                 }
             )
         }

--- a/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattLoeserTest.kt
+++ b/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattLoeserTest.kt
@@ -16,13 +16,13 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
@@ -76,7 +76,7 @@ class ForespoerselMottattLoeserTest : FunSpec({
         verifySequence {
             mockPriProducer.send(
                 withArg<JsonElement> { json ->
-                    json.toMap().filterKeys { it is Pri.Key } shouldBe expectedRepublisert
+                    json.fromJsonMapFiltered(Pri.Key.serializer()) shouldBe expectedRepublisert
                 }
             )
         }

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarLoeser.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarLoeser.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselSvar
 import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -155,7 +156,7 @@ private data class Melding(
 ) {
     companion object {
         fun fra(json: JsonElement): Melding =
-            json.toMap().let {
+            json.fromJsonMapFiltered(Pri.Key.serializer()).let {
                 val forespoerselSvar = Pri.Key.LØSNING.les(ForespoerselSvar.serializer(), it)
                 val boomerang = forespoerselSvar.boomerang.toMap()
 

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselLoeser.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselLoeser.kt
@@ -1,7 +1,5 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.helsebro
 
-import kotlinx.serialization.builtins.MapSerializer
-import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
@@ -86,11 +84,3 @@ class TrengerForespoerselLoeser(
             }
     }
 }
-
-private fun Map<Key, JsonElement>.toJson(): JsonElement =
-    toJson(
-        MapSerializer(
-            Key.serializer(),
-            JsonElement.serializer()
-        )
-    )

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselLoeserTest.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselLoeserTest.kt
@@ -4,7 +4,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verifySequence
-import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -46,12 +45,7 @@ class TrengerForespoerselLoeserTest : FunSpec({
                 Pri.Key.BOOMERANG to mapOf(
                     Key.EVENT_NAME to expectedEvent.toJson(),
                     Key.UUID to expectedTransaksjonId.toJson()
-                ).toJson(
-                    MapSerializer(
-                        Key.serializer(),
-                        JsonElement.serializer()
-                    )
-                )
+                ).toJson()
             )
         }
     }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/EksternInntektsmeldingLagretIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/EksternInntektsmeldingLagretIT.kt
@@ -8,7 +8,6 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -39,8 +38,8 @@ class EksternInntektsmeldingLagretIT : EndToEndTest() {
 
             publish(
                 Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_REQUESTED.toJson(),
-                Pri.Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson(),
-                Pri.Key.SPINN_INNTEKTSMELDING_ID to Mock.spinnInntektsmeldingId.toJson()
+                Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson(),
+                Key.SPINN_INNTEKTSMELDING_ID to Mock.spinnInntektsmeldingId.toJson()
             )
             Thread.sleep(10000)
         }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -11,7 +11,6 @@ import no.nav.helsearbeidsgiver.dokarkiv.domene.OpprettOgFerdigstillResponse
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.PersonDato
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
@@ -154,12 +153,12 @@ class InnsendingServiceIT : EndToEndTest() {
         }
     }
 
-    private fun Map<IKey, JsonElement>.verifiserTransaksjonId(transaksjonId: UUID): Map<IKey, JsonElement> =
+    private fun Map<Key, JsonElement>.verifiserTransaksjonId(transaksjonId: UUID): Map<Key, JsonElement> =
         also {
             Key.UUID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
         }
 
-    private fun Map<IKey, JsonElement>.verifiserForespoerselId(): Map<IKey, JsonElement> =
+    private fun Map<Key, JsonElement>.verifiserForespoerselId(): Map<Key, JsonElement> =
         also {
             Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, it) shouldBe Mock.forespoerselId
         }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/Messages.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/Messages.kt
@@ -6,7 +6,6 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonPrimitive
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
-import no.nav.helsearbeidsgiver.felles.IKey
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -18,7 +17,7 @@ import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 value class Messages(
     private val value: MutableList<JsonElement> = mutableListOf()
 ) {
-    fun firstAsMap(): Map<IKey, JsonElement> =
+    fun firstAsMap(): Map<Key, JsonElement> =
         value.firstOrNull()
             .shouldNotBeNull()
             .toMap()

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OppgaveFerdigLoeser.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/OppgaveFerdigLoeser.kt
@@ -12,11 +12,11 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.requireKeys
 import no.nav.helsearbeidsgiver.felles.utils.Log
-import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -54,12 +54,15 @@ class OppgaveFerdigLoeser(
         }
         val json = packet.toJson().parseJson()
 
+        logger.info("Mottok melding med event '${EventName.FORESPOERSEL_BESVART}'.")
+        sikkerLogger.info("Mottok melding:\n${json.toPretty()}")
+
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.FORESPOERSEL_BESVART)
         ) {
             runCatching {
-                json.haandterMelding(context)
+                haandterMelding(json.toMap(), context)
             }
                 .onFailure { e ->
                     "Ukjent feil.".also {
@@ -70,12 +73,7 @@ class OppgaveFerdigLoeser(
         }
     }
 
-    private fun JsonElement.haandterMelding(context: MessageContext) {
-        logger.info("Mottok melding med event '${EventName.FORESPOERSEL_BESVART}'.")
-        sikkerLogger.info("Mottok melding:\n${toPretty()}")
-
-        val melding = fromJsonMapFiltered(Key.serializer()) + fromJsonMapFiltered(Key.serializer())
-
+    private fun haandterMelding(melding: Map<Key, JsonElement>, context: MessageContext) {
         val oppgaveId = Key.OPPGAVE_ID.les(String.serializer(), melding)
         val forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding)
         val transaksjonId = Key.UUID.les(UuidSerializer, melding)

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
@@ -1,7 +1,6 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.trengerservice
 
 import kotlinx.serialization.KSerializer
-import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
@@ -129,12 +128,7 @@ class TrengerService(
                         event = event,
                         transaksjonId = transaksjonId,
                         forespoerselId = forespoerselId,
-                        utloesendeMelding = melding.toJson(
-                            MapSerializer(
-                                Key.serializer(),
-                                JsonElement.serializer()
-                            )
-                        )
+                        utloesendeMelding = melding.toJson()
                     )
                     onError(melding, fail)
                 }


### PR DESCRIPTION
Bruken av IKey ble utstrakt når Simba sin interne rapid har nøkler som stammer fra Key eller Datafelt, som begge var IKey. Nå er det bare Key og Pri.Key som er IKey, og bruken bør snevres inn til mindre viktige funksjoner.

(Ved å beholde IKey så slipper vi noe duplisering av relativt få metoder som også er aktuelle for Pri.Key. Det kan vi alltids vurdere om vi vil beholde.)