### PR TITLE
Fiks unquoted string parsing for strenger med bare siffer (v2)

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/composite/CompositeEventListener.kt
@@ -5,7 +5,9 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import kotlinx.serialization.json.JsonPrimitive
 import kotlinx.serialization.json.booleanOrNull
+import kotlinx.serialization.json.double
 import kotlinx.serialization.json.doubleOrNull
+import kotlinx.serialization.json.float
 import kotlinx.serialization.json.floatOrNull
 import kotlinx.serialization.json.int
 import kotlinx.serialization.json.intOrNull
@@ -145,15 +147,17 @@ abstract class CompositeEventListener : River.PacketListener {
                         if (
                             json is JsonNull ||
                             json.isString ||
-                            json.booleanOrNull != null ||
-                            json.doubleOrNull != null ||
-                            json.floatOrNull != null
+                            json.booleanOrNull != null
                         ) {
                             json
                         } else if (json.intOrNull != null) {
                             "\"${json.int}\"".parseJson()
                         } else if (json.longOrNull != null) {
                             "\"${json.long}\"".parseJson()
+                        } else if (json.doubleOrNull != null) {
+                            "\"${json.double}\"".parseJson()
+                        } else if (json.floatOrNull != null) {
+                            "\"${json.float}\"".parseJson()
                         } else {
                             "\"$value\"".parseJson()
                         }


### PR DESCRIPTION
Innså ikke konsekvensene av endringen i if-rekkefølgen i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/419. Feilen gjør at `123` tolkes som `1.23`. Flytter `double`- og `float`-sjekken under `int`- og `long`-sjekken for at tall skal parses riktig. 