### PR TITLE
Fiks potensiell evig loop i service

### DIFF
--- a/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -14,6 +14,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.PersonDato
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.FailKanal
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.LagreDataRedisRiver
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.StatefullEventListener
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.composite.CompositeEventListener
@@ -56,10 +57,14 @@ class AktiveOrgnrService(
         Key.ARBEIDSFORHOLD,
         Key.ORG_RETTIGHETER
     )
+    private val step2Keys = setOf(
+        Key.VIRKSOMHETER
+    )
 
     init {
         StatefullEventListener(event, startKeys, rapid, redisStore, ::onPacket)
         LagreDataRedisRiver(event, dataKeys, rapid, redisStore, ::onPacket)
+        FailKanal(event, rapid, ::onPacket)
     }
 
     override fun new(melding: Map<Key, JsonElement>) {
@@ -106,7 +111,7 @@ class AktiveOrgnrService(
     override fun inProgress(melding: Map<Key, JsonElement>) {
         val transaksjonId = Key.UUID.les(UuidSerializer, melding)
 
-        if (step1Keys.all(melding::containsKey)) {
+        if (step1Keys.all(melding::containsKey) && step2Keys.none(melding::containsKey)) {
             val arbeidsforholdListe = Key.ARBEIDSFORHOLD.les(Arbeidsforhold.serializer().list(), melding)
             val orgrettigheter = Key.ORG_RETTIGHETER.les(String.serializer().set(), melding)
 
@@ -188,6 +193,7 @@ class AktiveOrgnrService(
                     )
                 )
             ).toJson(AktiveOrgnrResponse.serializer())
+
             RedisKey.of(clientId).write(feilResponse)
         }
     }

--- a/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeserTest.kt
+++ b/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeserTest.kt
@@ -45,7 +45,6 @@ class VirksomhetLoeserTest {
 
     @Test
     fun `skal håndtere at klient feiler`() {
-        coEvery { mockBrregClient.hentVirksomhetNavn(any()) } returns null
         coEvery { mockBrregClient.hentVirksomheter(any()) } returns emptyList()
 
         testRapid.sendJson(
@@ -62,7 +61,6 @@ class VirksomhetLoeserTest {
 
     @Test
     fun `skal returnere løsning når gyldige data`() {
-        coEvery { mockBrregClient.hentVirksomhetNavn(any()) } returns VIRKSOMHET_NAVN
         coEvery { mockBrregClient.hentVirksomheter(any()) } returns listOf(Virksomhet(organisasjonsnummer = ORGNR, navn = VIRKSOMHET_NAVN))
 
         testRapid.sendJson(

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
@@ -1,8 +1,14 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest
 
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
+import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
+import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
+import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.every
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.aareg.Ansettelsesperiode
@@ -14,11 +20,15 @@ import no.nav.helsearbeidsgiver.brreg.Virksomhet
 import no.nav.helsearbeidsgiver.felles.Arbeidsforhold
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
+import no.nav.helsearbeidsgiver.felles.Feilmelding
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.tilArbeidsforhold
+import no.nav.helsearbeidsgiver.inntektsmelding.aktiveorgnrservice.AktiveOrgnrResponse
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
 import no.nav.helsearbeidsgiver.pdl.domene.PersonNavn
@@ -29,22 +39,28 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.kl
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
+import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
+import java.util.UUID
 import no.nav.helsearbeidsgiver.aareg.Arbeidsforhold as AAregArbeidsforhold
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class AktiveOrgnrServiceIT : EndToEndTest() {
 
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
     @Test
     fun `Test hente aktive organisasjoner`() {
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforholdListe
         coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
-        coEvery { brregClient.hentVirksomhetNavn("810007842") } returns "ANSTENDIG PIGGSVIN BARNEHAGE"
         coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Virksomhet(organisasjonsnummer = "810007842", navn = "ANSTENDIG PIGGSVIN BARNEHAGE"))
-        coEvery { pdlKlient.personBolk(any()) } returns listOf(
-            FullPerson(navn = PersonNavn(fornavn = "Bjarne", mellomnavn = null, etternavn = "Betjent"), foedselsdato = 1.januar, ident = Mock.FNR)
-        )
+        coEvery { pdlKlient.personBolk(any()) } returns listOf(Mock.person)
+
         publish(
             Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
             Key.CLIENT_ID to Mock.clientId.toJson(),
@@ -100,16 +116,20 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
     fun `Aareg kall feiler`() {
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns emptyList()
         coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
-        coEvery { brregClient.hentVirksomhetNavn("810007842") } returns "ANSTENDIG PIGGSVIN BARNEHAGE"
         coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Virksomhet(organisasjonsnummer = "810007842", navn = "ANSTENDIG PIGGSVIN BARNEHAGE"))
+        coEvery { pdlKlient.personBolk(any()) } returns listOf(Mock.person)
+
         publish(
             Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
             Key.CLIENT_ID to Mock.clientId.toJson(),
             Key.FNR to Mock.FNR.toJson(),
             Key.ARBEIDSGIVER_FNR to Mock.FNR_AG.toJson()
         )
+
         Thread.sleep(10000)
+
         redisStore.get(RedisKey.of(Mock.clientId)) shouldBe Mock.FEILTET_AKTIVE_ORGNR_RESPONSE
+
         val aktiveOrgnrMeldinger = messages.filter(EventName.AKTIVE_ORGNR_REQUESTED)
 
         aktiveOrgnrMeldinger
@@ -136,6 +156,60 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             .filter(Key.ARBEIDSFORHOLD)
             .firstAsMap()[Key.ARBEIDSFORHOLD]
             ?.fromJson(Arbeidsforhold.serializer().list()) shouldBe emptyList()
+    }
+
+    @Test
+    fun `Ved feil under henting av personer så svarer service med feil`() {
+        coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforholdListe
+        coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
+        coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Virksomhet(organisasjonsnummer = "810007842", navn = "ANSTENDIG PIGGSVIN BARNEHAGE"))
+
+        coEvery { pdlKlient.personBolk(any()) } throws IllegalArgumentException("Ingen folk å finne her!")
+
+        val transaksjonId = UUID.randomUUID()
+
+        val expectedFail = Fail(
+            feilmelding = "Klarte ikke hente navn",
+            event = EventName.AKTIVE_ORGNR_REQUESTED,
+            transaksjonId = transaksjonId,
+            forespoerselId = null,
+            utloesendeMelding = mapOf(
+                Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
+                Key.BEHOV to BehovType.FULLT_NAVN.toJson(),
+                Key.IDENTITETSNUMMER to Mock.FNR.toJson(),
+                Key.UUID to transaksjonId.toJson()
+            ).toJson()
+        )
+
+        mockStatic(::randomUuid) {
+            every { randomUuid() } returns transaksjonId
+
+            publish(
+                Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
+                Key.CLIENT_ID to Mock.clientId.toJson(),
+                Key.FNR to Mock.FNR.toJson(),
+                Key.ARBEIDSGIVER_FNR to Mock.FNR_AG.toJson()
+            )
+
+            Thread.sleep(10000)
+        }
+
+        val response = redisStore.get(RedisKey.of(Mock.clientId))
+            ?.fromJson(AktiveOrgnrResponse.serializer())
+            .shouldNotBeNull()
+
+        response.underenheter.shouldBeEmpty()
+        response.feilReport.shouldNotBeNull().feil shouldContainExactly listOf(Feilmelding(expectedFail.feilmelding))
+
+        val actualFail = messages.filter(EventName.AKTIVE_ORGNR_REQUESTED)
+            .filterFeil()
+            .firstAsMap()
+            .get(Key.FAIL)
+            ?.fromJson(Fail.serializer())
+            .shouldNotBeNull()
+
+        actualFail.shouldBeEqualToIgnoringFields(expectedFail, Fail::utloesendeMelding)
+        actualFail.utloesendeMelding.toMap() shouldContainExactly expectedFail.utloesendeMelding.toMap()
     }
 
     private object Mock {
@@ -210,5 +284,11 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             )
 
         val underenheter = listOf("810007842")
+
+        val person = FullPerson(
+            navn = PersonNavn(fornavn = "Bjarne", mellomnavn = null, etternavn = "Betjent"),
+            foedselsdato = 1.januar,
+            ident = FNR
+        )
     }
 }


### PR DESCRIPTION
Det kunne oppstå en evig loop dersom henting av fullt navn på sykmeldt feilet, men det forhindres av ny if-sjekk i `inProgress`. 

I tillegg så har jeg lagt til lesing av publiserte feil, slik at servicen avbryter umiddelbart om noe går galt. Jeg har blitt enig med Kent om at det er best at man avbryter for alle typer publiserte feil, så det er ikke lagt til noen recover-logikk, som noen andre servicer har.