### PR TITLE
Avvis meldinger med fail

### DIFF
--- a/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -43,7 +43,8 @@ class MarkerForespoerselBesvartRiver(
             )
             msg.rejectKeys(
                 Key.BEHOV,
-                Key.DATA
+                Key.DATA,
+                Key.FAIL
             )
         }
             .register(this)


### PR DESCRIPTION
Dette burde ha vært med fra start, men potensielle konsekvenser har bare vært at forespørsler har blitt marker besvart to ganger rett etter hverandre, så det har ikke blitt oppdaget.