### PR TITLE
Legg til erstatningskey i melding

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
@@ -29,7 +29,8 @@ class InnsendingProducer(
             Key.ORGNRUNDERENHET to request.orgnrUnderenhet.toJson(),
             Key.IDENTITETSNUMMER to request.identitetsnummer.toJson(),
             Key.ARBEIDSGIVER_ID to arbeidsgiverFnr.toJson(),
-            Key.INNTEKTSMELDING to request.toJson(Innsending.serializer())
+            Key.INNTEKTSMELDING to request.toJson(Innsending.serializer()),
+            Key.SKJEMA_INNTEKTSMELDING to request.toJson(Innsending.serializer())
         )
             .also {
                 logger.info("Publiserte til kafka forespørselId: $forespoerselId og clientId=$clientId")

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterImLoeser.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterImLoeser.kt
@@ -56,7 +56,8 @@ class PersisterImLoeser(rapidsConnection: RapidsConnection, private val reposito
             val json = behov.jsonMessage.toJson().parseJson().toMap()
 
             val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
-            val innsending = Key.INNTEKTSMELDING.les(Innsending.serializer(), json)
+            val innsending = Key.SKJEMA_INNTEKTSMELDING.lesOrNull(Innsending.serializer(), json)
+                ?: Key.INNTEKTSMELDING.les(Innsending.serializer(), json)
             val virksomhetNavn = Key.VIRKSOMHET.les(String.serializer(), json)
             val arbeidstaker = Key.ARBEIDSTAKER_INFORMASJON.les(PersonDato.serializer(), json)
             val innsender = Key.ARBEIDSGIVER_INFORMASJON.les(PersonDato.serializer(), json)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -24,6 +24,7 @@ enum class Key(override val str: String) : IKey {
     DATA("data"),
     FAIL("fail"),
     SKJEMA_INNTEKTSMELDING("skjema_inntektsmelding"),
+    INNTEKTSMELDING("inntektsmelding"),
     SELVBESTEMT_INNTEKTSMELDING("selvbestemt_inntektsmelding"),
 
     // Tidligere DataFelt
@@ -39,7 +40,6 @@ enum class Key(override val str: String) : IKey {
     ORGNRUNDERENHET("orgnrUnderenhet"),
     ORGNRUNDERENHETER("orgnrUnderenheter"),
     ORG_RETTIGHETER("org_rettigheter"),
-    INNTEKTSMELDING("inntektsmelding"),
     FORESPOERSEL_SVAR("forespoersel-svar"),
     TRENGER_INNTEKT("trenger-inntekt"),
     INNTEKT("inntekt"),

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -131,6 +131,7 @@ class InnsendingService(
                 Key.UUID to transaksjonId.toJson(),
                 Key.FORESPOERSEL_ID to forespoerselId.toJson(),
                 Key.INNTEKTSMELDING to inntektsmeldingJson,
+                Key.SKJEMA_INNTEKTSMELDING to inntektsmeldingJson,
                 Key.VIRKSOMHET to virksomhetNavn.toJson(),
                 Key.ARBEIDSTAKER_INFORMASJON to arbeidstaker.toJson(PersonDato.serializer()),
                 Key.ARBEIDSGIVER_INFORMASJON to arbeidsgiver.toJson(PersonDato.serializer()),


### PR DESCRIPTION
Klassen `Innsending` sendes under `Key.INNTEKTSMELDING`. Fare for å forveklse innholdet med klassen `Inntektsmelding`, så jeg gjør et lite bytte. Jeg gjør det også fordi jeg vil benytte nøkkelen til å sende klassen `Inntektsmelding`.