### PR TITLE
Beregn bestemmende fraværsdag dersom forslag fra Spleis mangler

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/TrengerInntekt.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/TrengerInntekt.kt
@@ -5,6 +5,7 @@ package no.nav.helsearbeidsgiver.felles
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.time.LocalDate
@@ -23,11 +24,21 @@ data class TrengerInntekt(
     val forespurtData: ForespurtData,
     val erBesvart: Boolean
 ) {
-    fun forslagBestemmendeFravaersdag(): LocalDate? =
+    fun forslagBestemmendeFravaersdag(): LocalDate =
         bestemmendeFravaersdager[orgnr]
+            ?: bestemmendeFravaersdag(
+                arbeidsgiverperioder = emptyList(),
+                egenmeldingsperioder = egenmeldingsperioder,
+                sykmeldingsperioder = sykmeldingsperioder
+            )
 
-    fun forslagInntektsdato(): LocalDate? =
+    fun forslagInntektsdato(): LocalDate =
         bestemmendeFravaersdager.minOfOrNull { it.value }
+            ?: bestemmendeFravaersdag(
+                arbeidsgiverperioder = emptyList(),
+                egenmeldingsperioder = egenmeldingsperioder,
+                sykmeldingsperioder = sykmeldingsperioder
+            )
 
     fun eksternBestemmendeFravaersdag(): LocalDate? =
         bestemmendeFravaersdager.minus(orgnr).minOfOrNull { it.value }

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/TrengerInntektTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/TrengerInntektTest.kt
@@ -3,10 +3,12 @@ package no.nav.helsearbeidsgiver.felles
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.test.mock.mockTrengerInntekt
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.februar
+import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.juli
 import no.nav.helsearbeidsgiver.utils.test.date.juni
 import no.nav.helsearbeidsgiver.utils.test.date.mai
@@ -31,15 +33,19 @@ class TrengerInntektTest : FunSpec({
             forespoersel.forslagBestemmendeFravaersdag() shouldBe 1.juli
         }
 
-        test("gir 'null' dersom bestemmende fraværsdag mangler for eget orgnr") {
+        test("beregner bestemmende fraværsdag dersom det mangler for eget orgnr") {
             val forespoersel = mockTrengerInntekt().copy(
                 orgnr = "555898023",
+                egenmeldingsperioder = emptyList(),
+                sykmeldingsperioder = listOf(
+                    5.januar til 30.januar
+                ),
                 bestemmendeFravaersdager = mapOf(
                     "444707112" to 13.mai
                 )
             )
 
-            forespoersel.forslagBestemmendeFravaersdag().shouldBeNull()
+            forespoersel.forslagBestemmendeFravaersdag() shouldBe 5.januar
         }
     }
 
@@ -86,12 +92,16 @@ class TrengerInntektTest : FunSpec({
             forespoersel.forslagInntektsdato() shouldBe 5.juni
         }
 
-        test("gir 'null' dersom ingen bestemmende fraværsdager er tilstede") {
+        test("beregner bestemmende fraværsdag dersom ingen er tilstede") {
             val forespoersel = mockTrengerInntekt().copy(
+                egenmeldingsperioder = emptyList(),
+                sykmeldingsperioder = listOf(
+                    2.februar til 28.februar
+                ),
                 bestemmendeFravaersdager = emptyMap()
             )
 
-            forespoersel.forslagInntektsdato().shouldBeNull()
+            forespoersel.forslagInntektsdato() shouldBe 2.februar
         }
     }
 

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
@@ -48,7 +48,6 @@ fun mapInntektsmelding(
         skjema.bestemmendeFraværsdag
     } else {
         forespoersel.forslagInntektsdato()
-            ?: throw UgyldigForespoerselException()
     }
 
     val bestemmendeFravaersdag = if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
@@ -59,7 +58,6 @@ fun mapInntektsmelding(
         )
     } else {
         forespoersel.forslagBestemmendeFravaersdag()
-            ?: throw UgyldigForespoerselException()
     }
 
     val inntekt = if (forespoersel.forespurtData.inntekt.paakrevd) {
@@ -117,5 +115,3 @@ fun mapInntektsmelding(
         bestemmendeFraværsdag = bestemmendeFravaersdag
     )
 }
-
-class UgyldigForespoerselException : Exception("Forespørsel fra Spleis mangler nødvendige verdier.")

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/TrengerService.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.trengerservice
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helse.rapids_rivers.RapidsConnection
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.FeilReport
@@ -116,11 +115,6 @@ class TrengerService(
             )
 
             val inntektsdato = forespoersel.forslagInntektsdato()
-                ?: bestemmendeFravaersdag(
-                    arbeidsgiverperioder = emptyList(),
-                    egenmeldingsperioder = forespoersel.egenmeldingsperioder,
-                    sykmeldingsperioder = forespoersel.sykmeldingsperioder
-                )
 
             sikkerLogger.info("${simpleName()} Dispatcher INNTEKT for $transaksjonId")
             rapid.publish(


### PR DESCRIPTION
Den forrige løsningen tok ikke hensyn til nye IM-er på allerede besvarte forespørsler som ble opprettet før Spleis sendte oss alle bestemmende fraværsdager.