### PR TITLE
Reduser maks linjelengde for inntektsmelding-pdfer

### DIFF
--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/Utils.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/Utils.kt
@@ -53,7 +53,7 @@ fun BegrunnelseIngenEllerRedusertUtbetalingKode.tekst(): String {
     return begrunnelseRefusjonTilTekst.getOrDefault(this, this.name)
 }
 
-private const val MAX_LINJELENGDE = 37
+private const val MAX_LINJELENGDE = 36
 
 fun String.delOppLangeNavn(): List<String> {
     return when {

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/Utils.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/Utils.kt
@@ -53,7 +53,7 @@ fun BegrunnelseIngenEllerRedusertUtbetalingKode.tekst(): String {
     return begrunnelseRefusjonTilTekst.getOrDefault(this, this.name)
 }
 
-private const val MAX_LINJELENGDE = 40
+private const val MAX_LINJELENGDE = 37
 
 fun String.delOppLangeNavn(): List<String> {
     return when {

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -132,13 +132,13 @@ class PdfDokumentTest {
     }
 
     @Test
-    fun `med langt innsendernavn over flere linjer`() {
+    fun `med langt innsendernavn med store bokstaver over flere linjer`() {
         val imLangNavn = im.copy(
-            innsenderNavn = "Innsender som har veldig veldig langt navn"
+            innsenderNavn = "ANNASENDER CAPSLOCKUMSEN TEKSTBREKKSON"
         )
-        val forventetInnhold = "Innsender som har veldig veldig langt${System.lineSeparator()}navn"
+        val forventetInnhold = "ANNASENDER CAPSLOCKUMSEN${System.lineSeparator()}TEKSTBREKKSON"
         val pdfTekst = extractTextFromPdf(PdfDokument(imLangNavn).export())
-        writePDF("med langt innsendernavn over flere linjer", imLangNavn)
+        writePDF("med langt innsendernavn med store bokstaver over flere linjer", imLangNavn)
         assert(pdfTekst!!.contains(forventetInnhold))
     }
 

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/UtilsTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/UtilsTest.kt
@@ -29,7 +29,7 @@ class UtilsTest {
     fun `del opp lange navn - del opp i jevne lengder hvis ingen mellomrom`() {
         val tekst = "HA"
         val tekstBuilder = StringBuilder()
-        repeat(20) {
+        repeat(18) {
             tekstBuilder.append(tekst)
         }
         val liste = (tekstBuilder.toString() + tekstBuilder.toString() + tekst).delOppLangeNavn()


### PR DESCRIPTION
**Bakgrunn**
Navn i PDFen kan være skrevet i store bokstaver og dermed kan 40 tegn, som er dagens maksbredde, overskride tilgjengelig bredde. 

**Løsning**

- Reduser til 36 tegn, som ser ut til å løse problemet gitt et "normalt" navn (navn med veldig mange Mer og Wer kan fortsatt overskride bredden). 
- Oppdaterer testen for innsendernavn til store bokstaver med 37 tegn.
- Jeg vurderer dette som en enklere løsning enn å begynne å tukle med store og små bokstaver i navnet, fordi stor bokstav i navn ikke nødvendigvis er helt rett frem (f.eks. med bindestrek-navn eller navn som ikke skal starte på stor bokstav).

| Før | Etter  | 
| ------- | --- | 
| <img width="614" alt="image" src="https://github.com/navikt/helsearbeidsgiver-inntektsmelding/assets/41949947/ae988eb4-0049-4619-a2f3-7c1daf9f373b">| <img width="614" alt="image" src="https://github.com/navikt/helsearbeidsgiver-inntektsmelding/assets/41949947/ff13ebe0-4d8f-421e-995e-a69c5cd0b456">| 