### PR TITLE
Forhindre samtidige deploys til et miljø

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -146,6 +146,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-dev
     permissions:
       id-token: write
     needs: [generate_vars, build]

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -144,6 +144,8 @@ jobs:
 
   deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: deploy-prod
     permissions:
       id-token: write
     needs: [generate_vars, build]


### PR DESCRIPTION
https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Lager to deploy-grupper: én for dev og én for prod. For hver gruppe kan man ha en deploy-jobb kjørende. Dersom en ny deploy-jobb skulle bli satt i gang så vil den settes på vent. Hvis enda en deploy-jobb skulle bli satt i gang så vil den ventende jobben kanselleres og den nyeste jobben overta venteposisjonen. Når den kjørende jobben er ferdig så vil den ventende jobben kjøres.

Legger dette til slik at vi unngår flere sammenfiltrede deploys, der vi ender opp med en situasjon der noen apper stammer fra jobb A og noen stammer fra jobb B. Denne tilstanden kan selvfølgelig oppstå uansett, men nå er det litt mindre sannsynlig.