### PR TITLE
Endre link i sak til å peke på kvitteringsside når man sender inn inntekstmelding

### DIFF
--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/App.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/App.kt
@@ -67,7 +67,7 @@ fun RapidsConnection.createNotifikasjonRivers(
         OpprettSakLoeser(this, arbeidsgiverNotifikasjonKlient, linkUrl)
 
         logger.info("Starter ${SakFerdigLoeser::class.simpleName}...")
-        SakFerdigLoeser(this, arbeidsgiverNotifikasjonKlient)
+        SakFerdigLoeser(this, arbeidsgiverNotifikasjonKlient, linkUrl)
 
         logger.info("Starter ${OpprettOppgaveLoeser::class.simpleName}...")
         OpprettOppgaveLoeser(this, arbeidsgiverNotifikasjonKlient, linkUrl)

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -34,14 +34,14 @@ fun ArbeidsgiverNotifikasjonKlient.opprettSak(
         }
     }
 
-fun ArbeidsgiverNotifikasjonKlient.ferdigstillSak(sakId: String, linkUrl: String, forespoerselId: UUID) {
+fun ArbeidsgiverNotifikasjonKlient.ferdigstillSak(sakId: String, nyLenkeTilSak: String) {
     Metrics.agNotifikasjonRequest.recordTime(::nyStatusSak) {
         runBlocking {
             nyStatusSak(
                 id = sakId,
                 status = SaksStatus.FERDIG,
                 statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding",
-                nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/$forespoerselId"
+                nyLenkeTilSak = nyLenkeTilSak
             )
         }
     }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -34,13 +34,14 @@ fun ArbeidsgiverNotifikasjonKlient.opprettSak(
         }
     }
 
-fun ArbeidsgiverNotifikasjonKlient.ferdigstillSak(sakId: String) {
+fun ArbeidsgiverNotifikasjonKlient.ferdigstillSak(sakId: String, linkUrl: String, forespoerselId: UUID) {
     Metrics.agNotifikasjonRequest.recordTime(::nyStatusSak) {
         runBlocking {
             nyStatusSak(
                 id = sakId,
                 status = SaksStatus.FERDIG,
-                statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding"
+                statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding",
+                nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/$forespoerselId"
             )
         }
     }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeser.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeser.kt
@@ -27,7 +27,8 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 
 class SakFerdigLoeser(
     rapid: RapidsConnection,
-    private val agNotifikasjonKlient: ArbeidsgiverNotifikasjonKlient
+    private val agNotifikasjonKlient: ArbeidsgiverNotifikasjonKlient,
+    private val linkUrl: String
 ) : River.PacketListener {
 
     private val logger = logger()
@@ -84,7 +85,7 @@ class SakFerdigLoeser(
             Log.forespoerselId(forespoerselId),
             Log.transaksjonId(transaksjonId)
         ) {
-            agNotifikasjonKlient.ferdigstillSak(sakId)
+            agNotifikasjonKlient.ferdigstillSak(sakId, linkUrl, forespoerselId)
 
             context.publish(
                 Key.EVENT_NAME to EventName.SAK_FERDIGSTILT.toJson(),

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeser.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeser.kt
@@ -79,13 +79,14 @@ class SakFerdigLoeser(
         val sakId = Key.SAK_ID.les(String.serializer(), melding)
         val forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding)
         val transaksjonId = Key.UUID.les(UuidSerializer, melding)
+        val nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/$forespoerselId"
 
         MdcUtils.withLogFields(
             Log.sakId(sakId),
             Log.forespoerselId(forespoerselId),
             Log.transaksjonId(transaksjonId)
         ) {
-            agNotifikasjonKlient.ferdigstillSak(sakId, linkUrl, forespoerselId)
+            agNotifikasjonKlient.ferdigstillSak(sakId = sakId, nyLenkeTilSak = nyLenkeTilSak)
 
             context.publish(
                 Key.EVENT_NAME to EventName.SAK_FERDIGSTILT.toJson(),

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeserTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeserTest.kt
@@ -27,8 +27,8 @@ import java.util.UUID
 class SakFerdigLoeserTest : FunSpec({
     val testRapid = TestRapid()
     val mockAgNotifikasjonKlient = mockk<ArbeidsgiverNotifikasjonKlient>(relaxed = true)
-
-    SakFerdigLoeser(testRapid, mockAgNotifikasjonKlient)
+    val linkUrl = "dummyurl"
+    SakFerdigLoeser(testRapid, mockAgNotifikasjonKlient, linkUrl)
 
     beforeEach {
         testRapid.reset()
@@ -55,7 +55,8 @@ class SakFerdigLoeserTest : FunSpec({
             mockAgNotifikasjonKlient.nyStatusSak(
                 id = expected.sakId,
                 status = SaksStatus.FERDIG,
-                statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding"
+                statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding",
+                nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/${actual.forespoerselId}"
             )
         }
     }

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeserTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/SakFerdigLoeserTest.kt
@@ -56,7 +56,7 @@ class SakFerdigLoeserTest : FunSpec({
                 id = expected.sakId,
                 status = SaksStatus.FERDIG,
                 statusTekst = "Mottatt - Se kvittering eller korriger inntektsmelding",
-                nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/${actual.forespoerselId}"
+                nyLenkeTilSak = "$linkUrl/im-dialog/kvittering/${expected.forespoerselId}"
             )
         }
     }


### PR DESCRIPTION
**Bakgrunn**
Oppgaver som er ferdig løst linker fortsatt til `/im-dialog/{forespørselId}`, som etterhvert sender bruker videre til `/im-dialog/{forespørselId}`. Når en sak er ferdig løst kan vi sende brukeren direkte til kvitteringssiden sånn at han slipper et unødvendig pitstop innom `/im-dialog/{forespørselId}`.

**Løsning**
Endre sakens lenke til å peke på kvitteringssiden når en oppgave blir markert som ferdig.