### PR TITLE
Tillat innkommende trafikk fra spinntektsmelding-frontend

### DIFF
--- a/config/api/dev-gcp.yml
+++ b/config/api/dev-gcp.yml
@@ -9,4 +9,6 @@ env:
     value: redis://helsearbeidsgiver-redis.helsearbeidsgiver.svc.cluster.local:6379/0
 apps:
   - name: helsearbeidsgiver-redis
+inboundApps:
+  - name: spinntektsmelding-frontend
 

--- a/config/api/prod-gcp.yml
+++ b/config/api/prod-gcp.yml
@@ -9,3 +9,5 @@ env:
     value: redis://helsearbeidsgiver-redis.helsearbeidsgiver.svc.cluster.local:6379/0
 apps:
   - name: helsearbeidsgiver-redis
+inboundApps:
+  - name: spinntektsmelding-frontend

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -115,11 +115,13 @@ spec:
           namespace: {{ app.namespace }}
           {{/if}}
         {{/each}}{{/if}}
+    {{#if inboundApps}}
     inbound:
       rules:
-        {{#if inboundApps}}{{# each inboundApps as |app| }}
+        {{# each inboundApps as |app| }}
         - application: {{ app.name }}
           {{#if app.namespace}}
           namespace: {{ app.namespace }}
           {{/if}}
-        {{/each}}{{/if}}
+        {{/each}}
+    {{/if}}

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -115,3 +115,15 @@ spec:
           namespace: {{ app.namespace }}
           {{/if}}
         {{/each}}{{/if}}
+    inbound:
+      external:
+      {{#if externalHosts}}{{# each externalHosts as |item| }}
+          - host: {{ item }}
+      {{/each}}{{/if}}
+      rules:
+        {{#if inboundApps}}{{# each inboundApps as |app| }}
+        - application: {{ app.name }}
+          {{#if app.namespace}}
+          namespace: {{ app.namespace }}
+          {{/if}}
+        {{/each}}{{/if}}

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -116,10 +116,6 @@ spec:
           {{/if}}
         {{/each}}{{/if}}
     inbound:
-      external:
-      {{#if externalHosts}}{{# each externalHosts as |item| }}
-          - host: {{ item }}
-      {{/each}}{{/if}}
       rules:
         {{#if inboundApps}}{{# each inboundApps as |app| }}
         - application: {{ app.name }}


### PR DESCRIPTION
**Bakgrunn**
Fordi det er bestemt at ikke-utviklere ikke lenger skal ha tilgang til Nais-device, må frontenden flyttes ut av det clusteret som den deler med backenden i dag. Dermed må innkommende trafikk inn til backend eksplisitt tillates.

**Løsning**
Tillat innkommende trafikk fra `spinntektsmelding-frontend`.