### PR TITLE
Slutt å bruke vår egen proxytjeneste for å kommunisere med pdl i dev

### DIFF
--- a/config/pdl/dev-gcp.yml
+++ b/config/pdl/dev-gcp.yml
@@ -4,8 +4,8 @@ azure:
 ingress: https://helsearbeidsgiver-im-pdl.intern.dev.nav.no
 env:
 - name: PDL_URL
-  value: "https://helsearbeidsgiver-proxy.dev-fss-pub.nais.io/pdl"
+  value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
 - name: PROXY_SCOPE
-  value: "api://dev-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+  value: "api://dev-fss.pdl.pdl-api/.default"
 externalHosts:
-  - helsearbeidsgiver-proxy.dev-fss-pub.nais.io
+  - pdl-api.dev-fss-pub.nais.io


### PR DESCRIPTION
**Bakgrunn**
I dag har vi en egen proxytjeneste i helse arbeidsgiver for kommunikasjon mot pdl. Denne er vi interessert i å fase ut bruken av.

**Løsning**
Etter at vi har fått tilgang til pdl sitt api fra `im-pdl` i dev i https://github.com/navikt/pdl/pull/2722, så kan vi nå kommunisere med pdl uten å gå gjennom proxytjenesten vår (heller gjennom proxytjenesten til pdl).