### PR TITLE
Slutt å bruke vår egen proxy for kommunikasjon med pdl i prod

### DIFF
--- a/config/pdl/dev-gcp.yml
+++ b/config/pdl/dev-gcp.yml
@@ -5,7 +5,7 @@ ingress: https://helsearbeidsgiver-im-pdl.intern.dev.nav.no
 env:
 - name: PDL_URL
   value: "https://pdl-api.dev-fss-pub.nais.io/graphql"
-- name: PROXY_SCOPE
+- name: PDL_SCOPE
   value: "api://dev-fss.pdl.pdl-api/.default"
 externalHosts:
   - pdl-api.dev-fss-pub.nais.io

--- a/config/pdl/prod-gcp.yml
+++ b/config/pdl/prod-gcp.yml
@@ -3,8 +3,8 @@ azure:
   enabled: true
 env:
 - name: PDL_URL
-  value: "https://helsearbeidsgiver-proxy.prod-fss-pub.nais.io/pdl"
-- name: PROXY_SCOPE
-  value: "api://prod-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+  value: "https://pdl-api.prod-fss-pub.nais.io/graphql"
+- name: PDL_SCOPE
+  value: "api://prod-fss.pdl.pdl-api/.default"
 externalHosts:
-  - helsearbeidsgiver-proxy.prod-fss-pub.nais.io
+  - pdl-api.prod-fss-pub.nais.io

--- a/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/Environment.kt
+++ b/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/Environment.kt
@@ -7,7 +7,7 @@ fun setUpEnvironment(): Environment {
     return Environment(
         pdlUrl = getEnvVar("PDL_URL"),
         oauth2Environment = OAuth2Environment(
-            scope = getEnvVar("PROXY_SCOPE"),
+            scope = getEnvVar("PDL_SCOPE"),
             wellKnownUrl = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
             tokenEndpointUrl = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
             clientId = getEnvVar("AZURE_APP_CLIENT_ID"),


### PR DESCRIPTION
Etter denne (https://github.com/navikt/pdl/commit/b0d860a10b88bbfea7c66fa29d1a8775e647a051) endringen i PDL, så skal vi nå kunne slutte å bruke vår egen proxy for å kommunisere med PDL i prod.