### PR TITLE
Forhindre samtidige deploys til et miljø (v2)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -153,6 +153,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate_vars.outputs.deploy_matrix) }}
+    concurrency:
+      group: deploy-dev-${{ matrix.project }}
     steps:
       - name: Check if docker image exists
         run: |

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -151,6 +151,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix: ${{ fromJSON(needs.generate_vars.outputs.deploy_matrix) }}
+    concurrency:
+      group: deploy-prod-${{ matrix.project }}
     steps:
       - name: Check if docker image exists
         run: |


### PR DESCRIPTION
Gjør et nytt forsøk fordi `concurrency` ikke fungerte som forventet sammen med `matrix`.

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#concurrency

Lager to deploy-grupper **per app**: én for dev og én for prod. For hver gruppe kan man ha en deploy-jobb kjørende. Dersom en ny deploy-jobb skulle bli satt i gang så vil den settes på vent. Hvis enda en deploy-jobb skulle bli satt i gang så vil den ventende jobben kanselleres og den nyeste jobben overta venteposisjonen. Når den kjørende jobben er ferdig så vil den ventende jobben kjøres.

Legger dette til slik at vi unngår flere sammenfiltrede deploys, der vi ender opp med en situasjon der noen apper stammer fra jobb A og noen stammer fra jobb B. Denne tilstanden kan selvfølgelig oppstå uansett, men nå er det litt mindre sannsynlig.

Forrige forsøk finnes i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/500.
