### PR TITLE
Slutt å bruke vår egen proxy for å kommunisere med Aareg 

### DIFF
--- a/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/Environment.kt
+++ b/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/Environment.kt
@@ -8,7 +8,7 @@ fun setUpEnvironment(): Environment {
         raw = System.getenv(),
         aaregUrl = getEnvVar("AAREG_URL"),
         oauth2Environment = OAuth2Environment(
-            scope = getEnvVar("PROXY_SCOPE"),
+            scope = getEnvVar("AAREG_SCOPE"),
             wellKnownUrl = getEnvVar("AZURE_APP_WELL_KNOWN_URL"),
             tokenEndpointUrl = getEnvVar("AZURE_OPENID_CONFIG_TOKEN_ENDPOINT"),
             clientId = getEnvVar("AZURE_APP_CLIENT_ID"),

--- a/config/aareg/dev-gcp.yml
+++ b/config/aareg/dev-gcp.yml
@@ -4,8 +4,8 @@ azure:
 ingress: https://helsearbeidsgiver-im-aareg.intern.dev.nav.no
 env:
 - name: AAREG_URL
-  value: "https://helsearbeidsgiver-proxy.dev-fss-pub.nais.io/aareg-arbeidsforhold"
+  value: "https://aareg-services.dev-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false"
 - name: PROXY_SCOPE
-  value: "api://dev-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+  value: "api://dev-fss.arbeidsforhold.aareg-services-nais/.default"
 externalHosts:
-  - helsearbeidsgiver-proxy.dev-fss-pub.nais.io
+  - aareg-services.dev-fss-pub.nais.io

--- a/config/aareg/dev-gcp.yml
+++ b/config/aareg/dev-gcp.yml
@@ -5,7 +5,7 @@ ingress: https://helsearbeidsgiver-im-aareg.intern.dev.nav.no
 env:
 - name: AAREG_URL
   value: "https://aareg-services.dev-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false"
-- name: PROXY_SCOPE
+- name: AAREG_SCOPE
   value: "api://dev-fss.arbeidsforhold.aareg-services-nais/.default"
 externalHosts:
   - aareg-services.dev-fss-pub.nais.io

--- a/config/aareg/prod-gcp.yml
+++ b/config/aareg/prod-gcp.yml
@@ -3,8 +3,8 @@ azure:
   enabled: true
 env:
 - name: AAREG_URL
-  value: "https://helsearbeidsgiver-proxy.prod-fss-pub.nais.io/aareg-arbeidsforhold"
-- name: PROXY_SCOPE
-  value: "api://prod-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+  value: "https://aareg-services.prod-fss-pub.nais.io/api/v1/arbeidstaker/arbeidsforhold?sporingsinformasjon=false&historikk=false"
+- name: AAREG_SCOPE
+  value: "api://prod-fss.arbeidsforhold.aareg-services-nais/.default"
 externalHosts:
-  - helsearbeidsgiver-proxy.prod-fss-pub.nais.io
+  - aareg-services.prod-fss-pub.nais.io

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,7 +21,7 @@ tokenProviderVersion=0.4.0
 utilsVersion=0.9.0
 
 # Client dependency versions
-aaregClientVersion=0.6.0
+aaregClientVersion=0.7.0
 altinnClientVersion=0.3.0
 arbeidsgiverNotifikasjonKlientVersion=2.4.0
 brregKlientVersion=0.5.0


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å slutte og bruke vår egen proxy (https://github.com/navikt/helsearbeidsgiver-proxy/tree/master) når vi kommuniserer med Aareg.

**Løsning**
1. Bytt ut Aareg url, scope og external hosts i dev og prod.
2. Ta i bruk nyeste versjon (0.7.0) av aareg-client, hvor Nav-Consumer-Token ikke lenger sendes med (https://github.com/navikt/helsearbeidsgiver-aareg-client/pull/6).