### PR TITLE
Legg til metrikk for responstid ved innsending av inntektsmelding

### DIFF
--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -120,6 +120,11 @@ class InnsendingService(
         val forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding)
         val skjema = Key.SKJEMA_INNTEKTSMELDING.les(Innsending.serializer(), melding)
 
+        if (Key.FORESPOERSEL_SVAR in melding.keys) {
+            // Logger for å danne et bilde av tiden det tar å hente forespørsler.
+            logger.info("InnsendingService: forespørsel svar mottatt")
+        }
+
         if (step1Keys.all(melding::containsKey)) {
             val forespoersel = Key.FORESPOERSEL_SVAR.les(Forespoersel.serializer(), melding)
             val virksomhetNavn = Key.VIRKSOMHET.les(String.serializer(), melding)


### PR DESCRIPTION
**Bakgrunn**
Vi ønsker å gjøre innsending raskere, og vil ha på plass en metrikk og litt ekstra logging før vi setter i gang med tiltak.

**Løsning**
Legg til metrikk for innsendingsendepunkt som kan legges inn i Grafana-grafene våre, så samme måte som i `KvitteringRoute`.

Bonus: Legg til en ekstra logglinje i `InnsendingsService` sin `inProgress`-metode for å kunne danne et bilde av hvor lang tid "hent forespørsel"-delen av innsendingen tar (ved å se på tidsdifferansen mellom logglinja `InnsendingService: emitting behov HENT_TRENGER_IM` og den nye logglinja).