### PR TITLE
Forenkle startsteg i ServiceRiver

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
@@ -33,6 +33,7 @@ class InntektSelvbestemtProducer(
             rapid.publish(
                 Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
                 Key.UUID to transaksjonId.toJson(),
+                Key.DATA to "".toJson(),
                 Key.FNR to request.sykmeldtFnr.toJson(Fnr.serializer()),
                 Key.ORGNRUNDERENHET to request.orgnr.toJson(Orgnr.serializer()),
                 Key.SKJAERINGSTIDSPUNKT to request.inntektsdato.toJson()

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducer.kt
@@ -23,6 +23,7 @@ class TrengerProducer(
         rapid.publish(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(EventName.serializer()),
             Key.UUID to transaksjonId.toString().toJson(),
+            Key.DATA to "".toJson(),
             Key.FORESPOERSEL_ID to request.uuid.toJson(),
             Key.ARBEIDSGIVER_ID to arbeidsgiverFnr.toJson()
         )

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
@@ -30,6 +30,7 @@ class InntektSelvbestemtProducerTest : FunSpec({
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(
             Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
             Key.UUID to transaksjonId.toJson(),
+            Key.DATA to "".toJson(),
             Key.FNR to sykmeldtFnr.toJson(Fnr.serializer()),
             Key.ORGNRUNDERENHET to orgnr.toJson(Orgnr.serializer()),
             Key.SKJAERINGSTIDSPUNKT to inntektsdato.toJson()

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducerTest.kt
@@ -28,6 +28,7 @@ class TrengerProducerTest : FunSpec({
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
             Key.UUID to transaksjonId.toJson(),
+            Key.DATA to "".toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
             Key.ARBEIDSGIVER_ID to avsenderFnr.toJson()
         )

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
@@ -12,7 +12,6 @@ abstract class Service {
     abstract val startKeys: Set<Key>
     abstract val dataKeys: Set<Key>
 
-    abstract fun onStart(melding: Map<Key, JsonElement>)
     abstract fun onData(melding: Map<Key, JsonElement>)
     abstract fun onError(melding: Map<Key, JsonElement>, fail: Fail)
 

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceMelding.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceMelding.kt
@@ -8,12 +8,6 @@ import java.util.UUID
 
 sealed class ServiceMelding
 
-data class StartMelding(
-    val eventName: EventName,
-    val transaksjonId: UUID,
-    val startDataMap: Map<Key, JsonElement>
-) : ServiceMelding()
-
 data class DataMelding(
     val eventName: EventName,
     val transaksjonId: UUID,

--- a/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
+++ b/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
@@ -113,6 +113,7 @@ fun mockStartMelding(transaksjonId: UUID): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
         Key.UUID to transaksjonId.toJson(),
+        Key.DATA to "".toJson(),
         Key.FNR to Fnr.genererGyldig().toJson(Fnr.serializer()),
         Key.ORGNRUNDERENHET to Orgnr.genererGyldig().toJson(Orgnr.serializer()),
         Key.SKJAERINGSTIDSPUNKT to 14.april.toJson()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
@@ -33,6 +33,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
         publish(
             Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
             Key.UUID to Mock.transaksjonId.toJson(),
+            Key.DATA to "".toJson(),
             Key.FNR to Mock.fnr.toJson(Fnr.serializer()),
             Key.ORGNRUNDERENHET to Mock.orgnr.toJson(Orgnr.serializer()),
             Key.SKJAERINGSTIDSPUNKT to Mock.inntektsdato.toJson()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TrengerIT.kt
@@ -40,6 +40,7 @@ class TrengerIT : EndToEndTest() {
         publish(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
             Key.UUID to transaksjonId.toJson(UuidSerializer),
+            Key.DATA to "".toJson(),
             Key.ARBEIDSGIVER_ID to Fnr.genererGyldig().toJson(Fnr.serializer()),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(UuidSerializer)
         )


### PR DESCRIPTION
Nå som ServiceRiver ikke lenger har client-ID eller genererer ny transaksjon-ID ved startmelding så kan håndtering av startmelding forenkles til noe nærmere en datamelding.