### PR TITLE
Bytt fra vår proxy til dokarkiv proxy

### DIFF
--- a/config/joark/dev-gcp.yml
+++ b/config/joark/dev-gcp.yml
@@ -6,6 +6,6 @@ env:
 - name: PROXY_SCOPE
   value: "api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default"
 - name: DOKARKIV_URL
-  value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost?forsoekFerdigstill=$ferdigstill"
+  value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/"
 externalHosts:
   - dokarkiv.dev-fss-pub.nais.io

--- a/config/joark/dev-gcp.yml
+++ b/config/joark/dev-gcp.yml
@@ -3,7 +3,7 @@ azure:
   enabled: true
 ingress: https://helsearbeidsgiver-im-joark.intern.dev.nav.no
 env:
-- name: PROXY_SCOPE
+- name: DOKARKIV_SCOPE
   value: "api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default"
 - name: DOKARKIV_URL
   value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1"

--- a/config/joark/dev-gcp.yml
+++ b/config/joark/dev-gcp.yml
@@ -6,6 +6,6 @@ env:
 - name: PROXY_SCOPE
   value: "api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default"
 - name: DOKARKIV_URL
-  value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/"
+  value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1"
 externalHosts:
   - dokarkiv.dev-fss-pub.nais.io

--- a/config/joark/dev-gcp.yml
+++ b/config/joark/dev-gcp.yml
@@ -4,8 +4,8 @@ azure:
 ingress: https://helsearbeidsgiver-im-joark.intern.dev.nav.no
 env:
 - name: PROXY_SCOPE
-  value: "api://dev-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+  value: "api://dev-fss.teamdokumenthandtering.dokarkiv-q1/.default"
 - name: DOKARKIV_URL
-  value: "https://helsearbeidsgiver-proxy.dev-fss-pub.nais.io/dokarkiv/rest/journalpostapi/v1/"
+  value: "https://dokarkiv.dev-fss-pub.nais.io/rest/journalpostapi/v1/journalpost?forsoekFerdigstill=$ferdigstill"
 externalHosts:
-  - helsearbeidsgiver-proxy.dev-fss-pub.nais.io
+  - dokarkiv.dev-fss-pub.nais.io

--- a/config/joark/prod-gcp.yml
+++ b/config/joark/prod-gcp.yml
@@ -5,6 +5,6 @@ env:
 - name: DOKARKIV_SCOPE
   value: "api://dev-fss.teamdokumenthandtering.dokarkiv/.default"
 - name: DOKARKIV_URL
-  value: "https://dokarkiv.prod-fss-pub.nais.io/dokarkiv/rest/journalpostapi/v1"
+  value: "https://dokarkiv.prod-fss-pub.nais.io/rest/journalpostapi/v1"
 externalHosts:
   - dokarkiv.prod-fss-pub.nais.io

--- a/config/joark/prod-gcp.yml
+++ b/config/joark/prod-gcp.yml
@@ -2,9 +2,9 @@ kafkaPool: nav-prod
 azure:
   enabled: true
 env:
-- name: PROXY_SCOPE
-  value: "api://prod-fss.helsearbeidsgiver.helsearbeidsgiver-proxy/.default"
+- name: DOKARKIV_SCOPE
+  value: "api://dev-fss.teamdokumenthandtering.dokarkiv/.default"
 - name: DOKARKIV_URL
-  value: "https://helsearbeidsgiver-proxy.prod-fss-pub.nais.io/dokarkiv/rest/journalpostapi/v1/"
+  value: "https://dokarkiv.prod-fss-pub.nais.io/dokarkiv/rest/journalpostapi/v1"
 externalHosts:
-  - helsearbeidsgiver-proxy.prod-fss-pub.nais.io
+  - dokarkiv.prod-fss-pub.nais.io

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/Env.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/Env.kt
@@ -7,7 +7,7 @@ object Env {
     val dokArkivUrl = "DOKARKIV_URL".fromEnv()
 
     val oauth2Environment = OAuth2Environment(
-        scope = "PROXY_SCOPE".fromEnv(),
+        scope = "DOKARKIV_SCOPE".fromEnv(),
         wellKnownUrl = "AZURE_APP_WELL_KNOWN_URL".fromEnv(),
         tokenEndpointUrl = "AZURE_OPENID_CONFIG_TOKEN_ENDPOINT".fromEnv(),
         clientId = "AZURE_APP_CLIENT_ID".fromEnv(),


### PR DESCRIPTION
Det viste seg at im-joark allerede er lagt inn med tilgang til dokarkiv
https://github.com/navikt/dokarkiv/blob/930b88c062345c253fa60c7e96cbbdba42a2eb6b/nais/p-config.json#L181-L183

Så tenker det er greit å bytte så kan vi kvitte oss med helsearbeidsgiver-proxy snart.

Testet ok i dev