### PR TITLE
Bruk enklere mocking i route-tester

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducer.kt
@@ -6,7 +6,6 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.utils.Log
-import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.inntektsmelding.api.logger
 import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -20,8 +19,7 @@ class AktiveOrgnrProducer(
     init {
         logger.info("Starter ${AktiveOrgnrProducer::class.simpleName}...")
     }
-    fun publish(arbeidsgiverFnr: String, arbeidstagerFnr: String): UUID {
-        val clientId = randomUuid()
+    fun publish(clientId: UUID, arbeidsgiverFnr: String, arbeidstagerFnr: String) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.AKTIVE_ORGNR_REQUESTED),
@@ -40,6 +38,5 @@ class AktiveOrgnrProducer(
                     }
                 }
         }
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
@@ -20,6 +20,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import java.util.UUID
 
 fun Route.aktiveOrgnrRoute(
     connection: RapidsConnection,
@@ -27,11 +28,13 @@ fun Route.aktiveOrgnrRoute(
 ) {
     val aktiveOrgnrProducer = AktiveOrgnrProducer(connection)
     post(Routes.AKTIVEORGNR) {
+        val clientId = UUID.randomUUID()
+
         try {
             val request = call.receive<AktiveOrgnrRequest>()
             val arbeidsgiverFnr = call.request.lesFnrFraAuthToken()
 
-            val clientId = aktiveOrgnrProducer.publish(arbeidsgiverFnr = arbeidsgiverFnr, arbeidstagerFnr = request.identitetsnummer)
+            aktiveOrgnrProducer.publish(clientId, arbeidsgiverFnr = arbeidsgiverFnr, arbeidstagerFnr = request.identitetsnummer)
 
             val resultatJson = redis.hent(clientId).fromJson(ResultJson.serializer())
 

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducer.kt
@@ -20,9 +20,7 @@ class HentSelvbestemtImProducer(
         logger.info("Starter ${HentSelvbestemtImProducer::class.simpleName}...")
     }
 
-    fun publish(selvbestemtId: UUID): UUID {
-        val transaksjonId = UUID.randomUUID()
-
+    fun publish(transaksjonId: UUID, selvbestemtId: UUID) {
         MdcUtils.withLogFields(
             Log.event(EventName.SELVBESTEMT_IM_REQUESTED),
             Log.transaksjonId(transaksjonId),
@@ -39,7 +37,5 @@ class HentSelvbestemtImProducer(
                     sikkerLogger.info("Publiserte til kafka:\n${it.toPretty()}")
                 }
         }
-
-        return transaksjonId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -35,6 +35,8 @@ fun Route.hentSelvbestemtImRoute(
     val producer = HentSelvbestemtImProducer(rapid)
 
     get(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID) {
+        val transaksjonId = UUID.randomUUID()
+
         val selvbestemtId = call.parameters["selvbestemtId"]
             ?.runCatching(UUID::fromString)
             ?.getOrNull()
@@ -48,9 +50,10 @@ fun Route.hentSelvbestemtImRoute(
         } else {
             MdcUtils.withLogFields(
                 Log.apiRoute(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID),
-                Log.selvbestemtId(selvbestemtId)
+                Log.selvbestemtId(selvbestemtId),
+                Log.transaksjonId(transaksjonId)
             ) {
-                val transaksjonId = producer.publish(selvbestemtId)
+                producer.publish(transaksjonId, selvbestemtId)
 
                 MdcUtils.withLogFields(
                     Log.transaksjonId(transaksjonId)

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
@@ -19,9 +19,7 @@ class InnsendingProducer(
         logger.info("Starter ${InnsendingProducer::class.simpleName}...")
     }
 
-    fun publish(forespoerselId: UUID, request: Innsending, arbeidsgiverFnr: String): UUID {
-        val clientId = UUID.randomUUID()
-
+    fun publish(clientId: UUID, forespoerselId: UUID, request: Innsending, arbeidsgiverFnr: String) {
         rapid.publish(
             Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
             Key.CLIENT_ID to clientId.toJson(),
@@ -35,7 +33,5 @@ class InnsendingProducer(
                 logger.info("Publiserte til kafka forespørselId: $forespoerselId og clientId=$clientId")
                 sikkerLogger.info("Publiserte til kafka forespørselId: $forespoerselId json=${it.toPretty()}")
             }
-
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -45,6 +45,8 @@ fun Route.innsendingRoute(
         .register()
 
     post(Routes.INNSENDING + "/{forespoerselId}") {
+        val clientId = UUID.randomUUID()
+
         val forespoerselId = call.parameters["forespoerselId"]
             ?.runCatching(UUID::fromString)
             ?.getOrNull()
@@ -67,7 +69,7 @@ fun Route.innsendingRoute(
 
                     request.validate()
                     val innloggerFnr = call.request.lesFnrFraAuthToken()
-                    val clientId = producer.publish(forespoerselId, request, innloggerFnr)
+                    producer.publish(clientId, forespoerselId, request, innloggerFnr)
                     logger.info("Publiserte til rapid med forespørselId: $forespoerselId og clientId=$clientId")
 
                     val resultatJson = redisPoller.hent(clientId).fromJson(ResultJson.serializer())

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducer.kt
@@ -6,7 +6,6 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.utils.Log
-import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.inntektsmelding.api.logger
 import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -21,9 +20,7 @@ class InntektProducer(
         logger.info("Starter ${InntektProducer::class.simpleName}...")
     }
 
-    fun publish(request: InntektRequest): UUID {
-        val clientId = randomUuid()
-
+    fun publish(clientId: UUID, request: InntektRequest) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.INNTEKT_REQUESTED),
@@ -43,7 +40,5 @@ class InntektProducer(
                     }
                 }
         }
-
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
@@ -24,6 +24,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondForbidden
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import java.util.UUID
 
 // TODO Mangler tester
 fun Route.inntektRoute(
@@ -34,6 +35,8 @@ fun Route.inntektRoute(
     val inntektProducer = InntektProducer(rapid)
 
     post(Routes.INNTEKT) {
+        val clientId = UUID.randomUUID()
+
         val request = call.receive<InntektRequest>()
 
         tilgangskontroll.validerTilgangTilForespoersel(call.request, request.forespoerselId)
@@ -44,7 +47,7 @@ fun Route.inntektRoute(
         }
 
         try {
-            val clientId = inntektProducer.publish(request)
+            inntektProducer.publish(clientId, request)
 
             val resultatJson = redisPoller.hent(clientId).fromJson(ResultJson.serializer())
             sikkerLogger.info("Fikk inntektresultat:\n$resultatJson")

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
@@ -22,9 +22,7 @@ class InntektSelvbestemtProducer(
         logger.info("Starter ${InntektSelvbestemtProducer::class.simpleName}...")
     }
 
-    fun publish(request: InntektSelvbestemtRequest): UUID {
-        val transaksjonId = UUID.randomUUID()
-
+    fun publish(transaksjonId: UUID, request: InntektSelvbestemtRequest) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.INNTEKT_SELVBESTEMT_REQUESTED),
@@ -45,7 +43,5 @@ class InntektSelvbestemtProducer(
                     }
                 }
         }
-
-        return transaksjonId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
@@ -24,6 +24,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondForbidden
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import java.util.UUID
 
 fun Route.inntektSelvbestemtRoute(
     rapid: RapidsConnection,
@@ -33,6 +34,8 @@ fun Route.inntektSelvbestemtRoute(
     val inntektSelvbestemtProducer = InntektSelvbestemtProducer(rapid)
 
     post(Routes.INNTEKT_SELVBESTEMT) {
+        val transaksjonId = UUID.randomUUID()
+
         val request = call.receive<InntektSelvbestemtRequest>()
 
         tilgangskontroll.validerTilgangTilOrg(call.request, request.orgnr.verdi)
@@ -43,7 +46,7 @@ fun Route.inntektSelvbestemtRoute(
         }
 
         try {
-            val transaksjonId = inntektSelvbestemtProducer.publish(request)
+            inntektSelvbestemtProducer.publish(transaksjonId, request)
 
             val resultatJson = redisPoller.hent(transaksjonId).fromJson(ResultJson.serializer())
             sikkerLogger.info("Fikk inntektsresultat for selvbestemt inntektsmelding:\n$resultatJson")

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducer.kt
@@ -14,8 +14,7 @@ class KvitteringProducer(
         logger.info("Starter ${KvitteringProducer::class.simpleName}...")
     }
 
-    fun publish(foresporselId: UUID): UUID {
-        val clientId = UUID.randomUUID()
+    fun publish(clientId: UUID, foresporselId: UUID) {
         val packet: JsonMessage = JsonMessage.newMessage(
             mapOf(
                 Key.EVENT_NAME.str to EventName.KVITTERING_REQUESTED.name,
@@ -25,6 +24,5 @@ class KvitteringProducer(
         )
         rapid.publish(packet.toJson())
         logger.info("Publiserte kvittering requested, forespørselid=$foresporselId")
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -50,6 +50,8 @@ fun Route.kvitteringRoute(
         .register()
 
     get(Routes.KVITTERING) {
+        val clientId = UUID.randomUUID()
+
         val forespoerselId = call.parameters["uuid"]
             ?.let(::fjernLedendeSlash)
             ?.runCatching(UUID::fromString)
@@ -71,7 +73,7 @@ fun Route.kvitteringRoute(
                         logger.info("Authorize took $it")
                     }
 
-                    val clientId = kvitteringProducer.publish(forespoerselId)
+                    kvitteringProducer.publish(clientId, forespoerselId)
                     val resultatJson = redisPoller.hent(clientId).fromJson(ResultJson.serializer())
 
                     sikkerLogger.info("Resultat for henting av kvittering for $forespoerselId: $resultatJson")

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducer.kt
@@ -21,9 +21,7 @@ class LagreSelvbestemtImProducer(
         logger.info("Starter ${LagreSelvbestemtImProducer::class.simpleName}...")
     }
 
-    fun publish(skjema: SkjemaInntektsmeldingSelvbestemt, avsenderFnr: String): UUID {
-        val clientId = UUID.randomUUID()
-
+    fun publish(clientId: UUID, skjema: SkjemaInntektsmeldingSelvbestemt, avsenderFnr: String) {
         MdcUtils.withLogFields(
             Log.event(EventName.SELVBESTEMT_IM_MOTTATT),
             Log.clientId(clientId)
@@ -39,7 +37,5 @@ class LagreSelvbestemtImProducer(
                     sikkerLogger.info("Publiserte til kafka:\n${it.toPretty()}")
                 }
         }
-
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgang/TilgangProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgang/TilgangProducer.kt
@@ -7,7 +7,6 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.utils.Log
-import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.inntektsmelding.api.logger
 import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -22,23 +21,23 @@ class TilgangProducer(
         logger.info("Starter ${TilgangProducer::class.simpleName}...")
     }
 
-    fun publishForespoerselId(forespoerselId: UUID, fnr: String): UUID =
+    fun publishForespoerselId(clientId: UUID, fnr: String, forespoerselId: UUID) =
         publish(
             EventName.TILGANG_FORESPOERSEL_REQUESTED,
-            Key.FORESPOERSEL_ID to forespoerselId.toJson(),
-            Key.FNR to fnr.toJson()
+            clientId,
+            Key.FNR to fnr.toJson(),
+            Key.FORESPOERSEL_ID to forespoerselId.toJson()
         )
 
-    fun publishOrgnr(orgnr: String, fnr: String): UUID =
+    fun publishOrgnr(clientId: UUID, fnr: String, orgnr: String) =
         publish(
             EventName.TILGANG_ORG_REQUESTED,
-            Key.ORGNRUNDERENHET to orgnr.toJson(),
-            Key.FNR to fnr.toJson()
+            clientId,
+            Key.FNR to fnr.toJson(),
+            Key.ORGNRUNDERENHET to orgnr.toJson()
         )
 
-    private fun publish(eventName: EventName, vararg messageFields: Pair<Key, JsonElement>): UUID {
-        val clientId = randomUuid()
-
+    private fun publish(eventName: EventName, clientId: UUID, vararg messageFields: Pair<Key, JsonElement>) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
@@ -56,7 +55,5 @@ class TilgangProducer(
                     }
                 }
         }
-
-        return clientId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducer.kt
@@ -17,9 +17,7 @@ class TrengerProducer(
         logger.info("Starter ${TrengerProducer::class.simpleName}...")
     }
 
-    fun publish(request: HentForespoerselRequest, arbeidsgiverFnr: String): UUID {
-        val transaksjonId = UUID.randomUUID()
-
+    fun publish(transaksjonId: UUID, request: HentForespoerselRequest, arbeidsgiverFnr: String) {
         rapid.publish(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(EventName.serializer()),
             Key.UUID to transaksjonId.toString().toJson(),
@@ -31,7 +29,5 @@ class TrengerProducer(
                 logger.info("Publiserte trenger behov med transaksjonId=$transaksjonId")
                 sikkerLogger.info("Publiserte trenger behov med transaksjonId=$transaksjonId json=${it.toPretty()}")
             }
-
-        return transaksjonId
     }
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerRoute.kt
@@ -29,6 +29,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.validation.ValidationError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.validation.ValidationResponse
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import java.util.UUID
 
 fun Route.trengerRoute(
     rapid: RapidsConnection,
@@ -42,6 +43,8 @@ fun Route.trengerRoute(
         .register()
 
     post(Routes.TRENGER) {
+        val transaksjonId = UUID.randomUUID()
+
         val requestTimer = requestLatency.startTimer()
         runCatching {
             receive(HentForespoerselRequest.serializer())
@@ -53,7 +56,7 @@ fun Route.trengerRoute(
 
                     val arbeidsgiverFnr = call.request.lesFnrFraAuthToken()
 
-                    val transaksjonId = trengerProducer.publish(request, arbeidsgiverFnr)
+                    trengerProducer.publish(transaksjonId, request, arbeidsgiverFnr)
 
                     val resultatJson = redisPoller.hent(transaksjonId).fromJson(ResultJson.serializer())
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/AuthorizationTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/AuthorizationTest.kt
@@ -64,7 +64,7 @@ class AuthorizationTest : ApiTest() {
             }
         }
 
-        val testClient = TestClient(this, mockk()) { mockAuthToken() }
+        val testClient = TestClient(this, ::mockAuthToken)
 
         val response = testClient.get(path)
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
@@ -1,23 +1,42 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api
 
-import io.mockk.every
-import io.mockk.mockk
-import no.nav.helse.rapids_rivers.RapidsConnection
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeExactly
+import io.kotest.matchers.maps.shouldContainExactly
+import no.nav.helse.rapids_rivers.testsupport.TestRapid
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Innsending
+import no.nav.helsearbeidsgiver.felles.EventName
+import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.mock.GYLDIG_INNSENDING_REQUEST
+import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.inntektsmelding.api.innsending.InnsendingProducer
-import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Test
+import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
-class InnsendingProducerTest {
+class InnsendingProducerTest : FunSpec({
+    val testRapid = TestRapid()
+    val producer = InnsendingProducer(testRapid)
 
-    @Test
-    fun skal_returnere_uuid() {
-        val rapidsConnection = mockk<RapidsConnection>()
-        val producer = InnsendingProducer(rapidsConnection)
-        every {
-            rapidsConnection.publish(any())
-        } returns Unit
-        assertNotNull(producer.publish(UUID.randomUUID(), GYLDIG_INNSENDING_REQUEST, "gyldig-fnr"))
+    test("publiserer melding på forventet format") {
+        val clientId = UUID.randomUUID()
+        val forespoerselId = UUID.randomUUID()
+        val avsenderFnr = Fnr.genererGyldig().verdi
+
+        producer.publish(clientId, forespoerselId, GYLDIG_INNSENDING_REQUEST, avsenderFnr)
+
+        testRapid.inspektør.size shouldBeExactly 1
+        testRapid.firstMessage().toMap() shouldContainExactly mapOf(
+            Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
+            Key.CLIENT_ID to clientId.toJson(),
+            Key.FORESPOERSEL_ID to forespoerselId.toJson(),
+            Key.ORGNRUNDERENHET to GYLDIG_INNSENDING_REQUEST.orgnrUnderenhet.toJson(),
+            Key.IDENTITETSNUMMER to GYLDIG_INNSENDING_REQUEST.identitetsnummer.toJson(),
+            Key.ARBEIDSGIVER_ID to avsenderFnr.toJson(),
+            Key.SKJEMA_INNTEKTSMELDING to GYLDIG_INNSENDING_REQUEST.toJson(Innsending.serializer())
+        )
     }
-}
+})

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
@@ -1,39 +1,36 @@
-package no.nav.helsearbeidsgiver.inntektsmelding.api.lagreselvbestemtim
+package no.nav.helsearbeidsgiver.inntektsmelding.api.aktiveorgnr
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
-import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
-class LagreSelvbestemtImProducerTest : FunSpec({
-
+class AktiveOrgnrProducerTest : FunSpec({
     val testRapid = TestRapid()
-    val producer = LagreSelvbestemtImProducer(testRapid)
+    val producer = AktiveOrgnrProducer(testRapid)
 
     test("publiserer melding på forventet format") {
         val clientId = UUID.randomUUID()
-        val avsenderFnr = Fnr.genererGyldig().verdi
-        val skjema = mockSkjemaInntektsmeldingSelvbestemt()
+        val arbeidsgiverFnr = Fnr.genererGyldig().verdi
+        val arbeidstagerFnr = Fnr.genererGyldig().verdi
 
-        producer.publish(clientId, skjema, avsenderFnr)
+        producer.publish(clientId, arbeidsgiverFnr, arbeidstagerFnr)
 
         testRapid.inspektør.size shouldBeExactly 1
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(
-            Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
+            Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
             Key.CLIENT_ID to clientId.toJson(),
-            Key.SKJEMA_INNTEKTSMELDING to skjema.toJson(SkjemaInntektsmeldingSelvbestemt.serializer()),
-            Key.ARBEIDSGIVER_FNR to avsenderFnr.toJson()
+            Key.ARBEIDSGIVER_FNR to arbeidsgiverFnr.toJson(),
+            Key.FNR to arbeidstagerFnr.toJson()
         )
     }
 })

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentselvbestemtim
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.maps.shouldContainExactly
-import io.mockk.every
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -11,7 +10,6 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import java.util.UUID
 
 class HentSelvbestemtImProducerTest : FunSpec({
@@ -23,11 +21,7 @@ class HentSelvbestemtImProducerTest : FunSpec({
         val transaksjonId = UUID.randomUUID()
         val selvbestemtId = UUID.randomUUID()
 
-        mockStatic(UUID::randomUUID) {
-            every { UUID.randomUUID() } returns transaksjonId
-
-            producer.publish(selvbestemtId)
-        }
+        producer.publish(transaksjonId, selvbestemtId)
 
         testRapid.inspektør.size shouldBeExactly 1
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
@@ -2,17 +2,14 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.inntekt
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldContainAll
-import io.mockk.every
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
-import no.nav.helsearbeidsgiver.felles.utils.randomUuid
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.januar
-import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 import java.util.UUID
 
 class InntektProducerTest : FunSpec({
@@ -20,20 +17,16 @@ class InntektProducerTest : FunSpec({
     val inntektProducer = InntektProducer(testRapid)
 
     test("Publiserer melding på forventet format") {
-        val expectedClientId = UUID.randomUUID()
+        val clientId = UUID.randomUUID()
         val request = InntektRequest(UUID.randomUUID(), 18.januar)
 
-        mockStatic(::randomUuid) {
-            every { randomUuid() } returns expectedClientId
-
-            inntektProducer.publish(request)
-        }
+        inntektProducer.publish(clientId, request)
 
         val publisert = testRapid.firstMessage().toMap()
 
         publisert shouldContainAll mapOf(
             Key.EVENT_NAME to EventName.INNTEKT_REQUESTED.toJson(),
-            Key.CLIENT_ID to expectedClientId.toJson(),
+            Key.CLIENT_ID to clientId.toJson(),
             Key.FORESPOERSEL_ID to request.forespoerselId.toJson(),
             Key.SKJAERINGSTIDSPUNKT to request.skjaeringstidspunkt.toJson()
         )

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
@@ -14,17 +14,19 @@ import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.util.UUID
 
 class InntektSelvbestemtProducerTest : FunSpec({
     val testRapid = TestRapid()
     val producer = InntektSelvbestemtProducer(testRapid)
 
     test("publiserer melding på forventet format") {
+        val transaksjonId = UUID.randomUUID()
         val sykmeldtFnr = Fnr.genererGyldig()
         val orgnr = Orgnr.genererGyldig()
         val inntektsdato = 12.april
 
-        val transaksjonId = producer.publish(InntektSelvbestemtRequest(sykmeldtFnr, orgnr, inntektsdato))
+        producer.publish(transaksjonId, InntektSelvbestemtRequest(sykmeldtFnr, orgnr, inntektsdato))
 
         testRapid.inspektør.size shouldBeExactly 1
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
@@ -5,24 +5,23 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.Inntekt
 import no.nav.helsearbeidsgiver.felles.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.ResultJson
-import no.nav.helsearbeidsgiver.felles.Tilgang
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.RedisTimeoutResponse
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.harTilgangResultat
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ikkeTilgangResultat
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.juni
 import no.nav.helsearbeidsgiver.utils.test.date.mai
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
-import no.nav.helsearbeidsgiver.utils.test.mock.mockConstructor
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -41,18 +40,14 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `gi OK med inntekt`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedInntekt = Mock.inntekt
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returnsMany listOf(
+            harTilgangResultat,
+            Mock.successResult(expectedInntekt)
+        )
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } returns Mock.successResult(expectedInntekt)
-
-        val response = mockConstructor(InntektSelvbestemtProducer::class) {
-            every { anyConstructed<InntektSelvbestemtProducer>().publish(any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -62,7 +57,7 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `manglende tilgang gir 500-feil`() = testApi {
-        mockTilgang(Tilgang.IKKE_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returns ikkeTilgangResultat
 
         val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
@@ -74,18 +69,14 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `feilresultat gir 500-feil`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedFeilmelding = "Du får vente til freddan'!"
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returnsMany listOf(
+            harTilgangResultat,
+            Mock.failureResult(expectedFeilmelding)
+        )
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } returns Mock.failureResult(expectedFeilmelding)
-
-        val response = mockConstructor(InntektSelvbestemtProducer::class) {
-            every { anyConstructed<InntektSelvbestemtProducer>().publish(any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -95,18 +86,11 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `timeout mot redis gir 500-feil`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedFeilJson = RedisTimeoutResponse().toJsonStr(RedisTimeoutResponse.serializer())
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } throws RedisPollerTimeoutException(UUID.randomUUID())
-
-        val response = mockConstructor(InntektSelvbestemtProducer::class) {
-            every { anyConstructed<InntektSelvbestemtProducer>().publish(any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -116,18 +100,11 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `ukjent feil mot redis gir 500-feil`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedFeilJson = "Error 500: java.lang.IllegalStateException".toJsonStr(String.serializer())
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows IllegalStateException()
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } throws IllegalStateException()
-
-        val response = mockConstructor(InntektSelvbestemtProducer::class) {
-            every { anyConstructed<InntektSelvbestemtProducer>().publish(any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -137,13 +114,9 @@ class InntektSelvbestemtRouteKtTest : ApiTest() {
 
     @Test
     fun `ukjent feil gir 500-feil`() = testApi {
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } throws NullPointerException()
 
-        val response = mockConstructor(InntektSelvbestemtProducer::class) {
-            every { anyConstructed<InntektSelvbestemtProducer>().publish(any()) } throws NullPointerException()
-
-            post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, InntektSelvbestemtRequest.serializer())
 
         val actualJson = response.bodyAsText()
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerProducerTest.kt
@@ -19,10 +19,11 @@ class TrengerProducerTest : FunSpec({
     val producer = TrengerProducer(testRapid)
 
     test("publiserer melding på forventet format") {
+        val transaksjonId = UUID.randomUUID()
         val forespoerselId = UUID.randomUUID()
         val avsenderFnr = Fnr.genererGyldig().verdi
 
-        val transaksjonId = producer.publish(HentForespoerselRequest(forespoerselId), avsenderFnr)
+        producer.publish(transaksjonId, HentForespoerselRequest(forespoerselId), avsenderFnr)
 
         testRapid.inspektør.size shouldBeExactly 1
         testRapid.firstMessage().toMap() shouldContainExactly mapOf(

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/trenger/TrengerRouteKtTest.kt
@@ -4,7 +4,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonObject
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
@@ -19,15 +18,15 @@ import no.nav.helsearbeidsgiver.felles.HentForespoerselResultat
 import no.nav.helsearbeidsgiver.felles.Inntekt
 import no.nav.helsearbeidsgiver.felles.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.ResultJson
-import no.nav.helsearbeidsgiver.felles.Tilgang
 import no.nav.helsearbeidsgiver.felles.TilgangResultat
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtDataMedForrigeInntekt
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
-import no.nav.helsearbeidsgiver.inntektsmelding.api.tilgang.TilgangProducer
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.harTilgangResultat
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.hardcodedJson
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ikkeTilgangResultat
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.jsonStrOrNull
 import no.nav.helsearbeidsgiver.inntektsmelding.api.validation.ValidationResponse
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -38,7 +37,6 @@ import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
-import no.nav.helsearbeidsgiver.utils.test.mock.mockConstructor
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
 import org.junit.jupiter.api.Assertions.assertNull
@@ -57,18 +55,14 @@ class TrengerRouteKtTest : ApiTest() {
 
     @Test
     fun `skal returnere resultat og status CREATED når trenger virker`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedJson = Mock.responseJson()
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returnsMany listOf(
+            harTilgangResultat,
+            Mock.resultatOkJson
+        )
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } returns Mock.resultatOkJson
-
-        val response = mockConstructor(TrengerProducer::class) {
-            every { anyConstructed<TrengerProducer>().publish(any(), any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, HentForespoerselRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -78,18 +72,14 @@ class TrengerRouteKtTest : ApiTest() {
 
     @Test
     fun `skal returnere resultat og status CREATED når trenger virker med forespørsel bare inntekt`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
         val expectedJson = Mock.responseBareInntektJson()
 
-        mockTilgang(Tilgang.HAR_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returnsMany listOf(
+            harTilgangResultat,
+            Mock.resultatOkMedForrigeInntektJson
+        )
 
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } returns Mock.resultatOkMedForrigeInntektJson
-
-        val response = mockConstructor(TrengerProducer::class) {
-            every { anyConstructed<TrengerProducer>().publish(any(), any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, HentForespoerselRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
 
         val actualJson = response.bodyAsText()
 
@@ -99,17 +89,9 @@ class TrengerRouteKtTest : ApiTest() {
 
     @Test
     fun `skal returnere Internal server error hvis Redis timer ut`() = testApi {
-        val mockTransaksjonId = UUID.randomUUID()
+        coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
 
-        mockTilgang(Tilgang.HAR_TILGANG)
-
-        coEvery { mockRedisPoller.hent(mockTransaksjonId) } throws RedisPollerTimeoutException(UUID.randomUUID())
-
-        val response = mockConstructor(TrengerProducer::class) {
-            every { anyConstructed<TrengerProducer>().publish(any(), any()) } returns mockTransaksjonId
-
-            post(PATH, Mock.request, HentForespoerselRequest.serializer())
-        }
+        val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
 
         assertEquals(HttpStatusCode.InternalServerError, response.status)
     }
@@ -140,7 +122,7 @@ class TrengerRouteKtTest : ApiTest() {
 
     @Test
     fun `skal returnere Forbidden hvis feil ikke tilgang`() = testApi {
-        mockTilgang(Tilgang.IKKE_TILGANG)
+        coEvery { mockRedisPoller.hent(any()) } returns ikkeTilgangResultat
 
         val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
         assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -148,11 +130,7 @@ class TrengerRouteKtTest : ApiTest() {
 
     @Test
     fun `skal returnere Forbidden hvis feil i Tilgangsresultet`() = testApi {
-        val mockTilgangClientId = UUID.randomUUID()
-
-        every { anyConstructed<TilgangProducer>().publishForespoerselId(any(), any()) } returns mockTilgangClientId
-
-        coEvery { mockRedisPoller.hent(mockTilgangClientId) } returns TilgangResultat(
+        coEvery { mockRedisPoller.hent(any()) } returns TilgangResultat(
             feilmelding = "Noe er riv ruskende galt!"
         ).toJson(TilgangResultat.serializer())
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
@@ -12,8 +12,6 @@ import io.ktor.http.contentType
 import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
-import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.mockk
 import io.prometheus.client.CollectorRegistry
 import kotlinx.coroutines.runBlocking
@@ -28,7 +26,9 @@ import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.mock.mockConstructor
 import org.junit.jupiter.api.AfterEach
-import java.util.UUID
+
+val harTilgangResultat = TilgangResultat(Tilgang.HAR_TILGANG).toJson(TilgangResultat.serializer())
+val ikkeTilgangResultat = TilgangResultat(Tilgang.IKKE_TILGANG).toJson(TilgangResultat.serializer())
 
 abstract class ApiTest : MockAuthToken() {
     val mockRedisPoller = mockk<RedisPoller>()
@@ -38,7 +38,7 @@ abstract class ApiTest : MockAuthToken() {
             apiModule(mockk(relaxed = true), mockRedisPoller)
         }
 
-        val testClient = TestClient(this, mockRedisPoller) { mockAuthToken() }
+        val testClient = TestClient(this, ::mockAuthToken)
 
         mockConstructor(TilgangProducer::class) {
             testClient.block()
@@ -53,22 +53,12 @@ abstract class ApiTest : MockAuthToken() {
 
 class TestClient(
     appTestBuilder: ApplicationTestBuilder,
-    private val mockRedisPoller: RedisPoller,
     private val authToken: () -> String
 ) {
     private val httpClient = appTestBuilder.createClient {
         install(ContentNegotiation) {
             json(jsonConfig)
         }
-    }
-
-    fun mockTilgang(tilgang: Tilgang) {
-        val mockTilgangClientId = UUID.randomUUID()
-
-        every { anyConstructed<TilgangProducer>().publishForespoerselId(any(), any()) } returns mockTilgangClientId
-        every { anyConstructed<TilgangProducer>().publishOrgnr(any(), any()) } returns mockTilgangClientId
-
-        coEvery { mockRedisPoller.hent(mockTilgangClientId) } returns TilgangResultat(tilgang).toJson(TilgangResultat.serializer())
     }
 
     fun get(

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
@@ -53,7 +53,7 @@ class TilgangskontrollIT : EndToEndTest() {
         mockStatic(::randomUuid) {
             every { randomUuid() } returns transaksjonId
 
-            tilgangProducer.publishForespoerselId(Mock.forespoerselId, Mock.INNLOGGET_FNR)
+            tilgangProducer.publishForespoerselId(UUID.randomUUID(), Mock.INNLOGGET_FNR, Mock.forespoerselId)
         }
 
         messages.filter(EventName.TILGANG_FORESPOERSEL_REQUESTED)
@@ -91,7 +91,7 @@ class TilgangskontrollIT : EndToEndTest() {
         mockStatic(::randomUuid) {
             every { randomUuid() } returns transaksjonId
 
-            tilgangProducer.publishForespoerselId(Mock.forespoerselId, Mock.INNLOGGET_FNR)
+            tilgangProducer.publishForespoerselId(UUID.randomUUID(), Mock.INNLOGGET_FNR, Mock.forespoerselId)
         }
 
         val result = messages.filter(EventName.TILGANG_FORESPOERSEL_REQUESTED)
@@ -107,7 +107,7 @@ class TilgangskontrollIT : EndToEndTest() {
 
     @Test
     fun `organisasjon - skal få tilgang`() {
-        tilgangProducer.publishOrgnr(Mock.ORGNR_MED_TILGANG, Mock.INNLOGGET_FNR)
+        tilgangProducer.publishOrgnr(UUID.randomUUID(), Mock.INNLOGGET_FNR, Mock.ORGNR_MED_TILGANG)
 
         val result = messages.filter(EventName.TILGANG_ORG_REQUESTED)
             .filter(Key.TILGANG)
@@ -122,7 +122,7 @@ class TilgangskontrollIT : EndToEndTest() {
 
     @Test
     fun `organisasjon - skal bli nektet tilgang`() {
-        tilgangProducer.publishOrgnr(Mock.ORGNR_UTEN_TILGANG, Mock.INNLOGGET_FNR)
+        tilgangProducer.publishOrgnr(UUID.randomUUID(), Mock.INNLOGGET_FNR, Mock.ORGNR_UTEN_TILGANG)
 
         val result = messages.filter(EventName.TILGANG_ORG_REQUESTED)
             .filter(Key.TILGANG)


### PR DESCRIPTION
Flytter også generering av `transaksjonId`/`clientId` fra producer til route.