### PR TITLE
Krev transaksjon-ID i datamelding

### DIFF
--- a/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/EksternInntektsmeldingLoeser.kt
+++ b/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/EksternInntektsmeldingLoeser.kt
@@ -5,6 +5,7 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
@@ -42,7 +43,7 @@ class EksternInntektsmeldingLoeser(
         try {
             val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-            val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+            val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
             logger.info("Løser behov $BEHOV med transaksjonId $transaksjonId")
 

--- a/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/EksternInntektsmeldingLoeserTest.kt
+++ b/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/EksternInntektsmeldingLoeserTest.kt
@@ -47,7 +47,8 @@ class EksternInntektsmeldingLoeserTest : FunSpec({
     test("Ved når inntektsmeldingId mangler skal feil publiseres") {
         testRapid.sendJson(
             Key.EVENT_NAME to EventName.FORESPOERSEL_BESVART.toJson(),
-            Key.BEHOV to BehovType.HENT_EKSTERN_INNTEKTSMELDING.name.toJson()
+            Key.BEHOV to BehovType.HENT_EKSTERN_INNTEKTSMELDING.name.toJson(),
+            Key.UUID to UUID.randomUUID().toJson()
         )
 
         val actual = testRapid.firstMessage().readFail()
@@ -64,6 +65,7 @@ class EksternInntektsmeldingLoeserTest : FunSpec({
         testRapid.sendJson(
             Key.EVENT_NAME to EventName.FORESPOERSEL_BESVART.toJson(),
             Key.BEHOV to BehovType.HENT_EKSTERN_INNTEKTSMELDING.name.toJson(),
+            Key.UUID to UUID.randomUUID().toJson(),
             Key.SPINN_INNTEKTSMELDING_ID to UUID.randomUUID().toJson()
         )
 
@@ -80,6 +82,7 @@ class EksternInntektsmeldingLoeserTest : FunSpec({
         testRapid.sendJson(
             Key.EVENT_NAME to EventName.FORESPOERSEL_BESVART.toJson(),
             Key.BEHOV to BehovType.HENT_EKSTERN_INNTEKTSMELDING.name.toJson(),
+            Key.UUID to UUID.randomUUID().toJson(),
             Key.SPINN_INNTEKTSMELDING_ID to UUID.randomUUID().toJson()
         )
 
@@ -97,6 +100,7 @@ class EksternInntektsmeldingLoeserTest : FunSpec({
         testRapid.sendJson(
             Key.EVENT_NAME to EventName.FORESPOERSEL_BESVART.toJson(),
             Key.BEHOV to BehovType.HENT_EKSTERN_INNTEKTSMELDING.name.toJson(),
+            Key.UUID to UUID.randomUUID().toJson(),
             Key.SPINN_INNTEKTSMELDING_ID to UUID.randomUUID().toJson()
         )
 

--- a/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeser.kt
+++ b/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/VirksomhetLoeser.kt
@@ -10,7 +10,7 @@ import no.nav.helsearbeidsgiver.brreg.BrregClient
 import no.nav.helsearbeidsgiver.brreg.Virksomhet
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
+import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
@@ -83,7 +83,7 @@ class VirksomhetLoeser(
     override fun onBehov(behov: Behov) {
         val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-        val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+        val transaksjonId = Key.UUID.les(UuidSerializer, json)
         val orgnr: List<String> =
             if (behov[Key.ORGNRUNDERENHETER].isEmpty) {
                 listOf(

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentPersistertLoeser.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentPersistertLoeser.kt
@@ -6,7 +6,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmeldin
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.Key
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
+import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
@@ -64,7 +64,7 @@ class HentPersistertLoeser(rapidsConnection: RapidsConnection, private val repos
 
                 val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-                val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+                val transaksjonId = Key.UUID.les(UuidSerializer, json)
 
                 rapidsConnection.publishData(
                     eventName = behov.event,

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterImLoeser.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterImLoeser.kt
@@ -7,7 +7,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmeldin
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.demandValues
@@ -47,7 +46,7 @@ class PersisterImLoeser(rapidsConnection: RapidsConnection, private val reposito
         try {
             val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-            val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+            val transaksjonId = Key.UUID.les(UuidSerializer, json)
             val inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json)
 
             val sisteIm = repository.hentNyeste(forespoerselId)

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterSakLoeser.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/PersisterSakLoeser.kt
@@ -6,7 +6,6 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.Loeser
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Behov
@@ -35,7 +34,7 @@ class PersisterSakLoeser(
     override fun onBehov(behov: Behov) {
         val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-        val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+        val transaksjonId = Key.UUID.les(UuidSerializer, json)
         val sakId = Key.SAK_ID.les(String.serializer(), json)
 
         val forespoerselId = behov.forespoerselId!!.let(UUID::fromString)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Data.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/Data.kt
@@ -18,12 +18,11 @@ private val sikkerLogger = sikkerLogger()
 
 fun MessageContext.publishData(
     eventName: EventName,
-    transaksjonId: UUID?,
+    transaksjonId: UUID,
     forespoerselId: UUID?,
     vararg messageFields: Pair<Key, JsonElement?>
 ): JsonElement {
     val optionalIdFields = mapOf(
-        Key.UUID to transaksjonId,
         Key.FORESPOERSEL_ID to forespoerselId
     )
         .mapValuesNotNull { it?.toJson() }
@@ -34,6 +33,7 @@ fun MessageContext.publishData(
 
     return publish(
         Key.EVENT_NAME to eventName.toJson(),
+        Key.UUID to transaksjonId.toJson(),
         Key.DATA to nonNullMessageFields.toJson(),
         *optionalIdFields,
         *nonNullMessageFields.toList().toTypedArray()

--- a/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/FulltNavnLoeser.kt
+++ b/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/FulltNavnLoeser.kt
@@ -8,6 +8,7 @@ import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.PersonDato
+import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
@@ -51,7 +52,7 @@ class FulltNavnLoeser(
     override fun onBehov(behov: Behov) {
         val json = behov.jsonMessage.toJson().parseJson().toMap()
 
-        val transaksjonId = Key.UUID.lesOrNull(UuidSerializer, json)
+        val transaksjonId = Key.UUID.les(UuidSerializer, json)
         val arbeidstakerId = Key.IDENTITETSNUMMER.lesOrNull(String.serializer(), json).orEmpty()
         val arbeidsgiverId = Key.ARBEIDSGIVER_ID.lesOrNull(String.serializer(), json).orEmpty()
 


### PR DESCRIPTION
Transaksjon-ID har vært tilsynelatende valgfritt, men det blir alltid sendt og avsender av behovmeldingen krever å få transaksjon-ID tilbake.