### PR TITLE
Bump Kotlin til 2.0.0

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,6 @@ jobs:
       - uses: gradle/actions/setup-gradle@v3
 
       - name: Test
-        run: ./gradlew test --tests --parallel --build-cache '*Test' jacocoTestReport
+        run: ./gradlew test --tests --parallel --build-cache '*Test' jacocoTestReport -Dorg.gradle.jvmargs=-Xmx32g
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,4 @@
-import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     kotlin("jvm")
@@ -23,14 +23,14 @@ dependencies {
         }
 }
 
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_21
+    }
+}
+
 allprojects {
     tasks {
-        val jvmTargetVersion: String by project
-
-        withType<KotlinCompile> {
-            kotlinOptions.jvmTarget = jvmTargetVersion
-        }
-
         withType<Test> {
             useJUnitPlatform()
             testLogging {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,7 @@
 kotlin.code.style=official
 
-# Build versions
-jvmTargetVersion=21
-
 # Plugin versions
-kotlinVersion=1.9.24
+kotlinVersion=2.0.0
 kotlinterVersion=4.3.0
 
 # Dependency versions


### PR DESCRIPTION
Kotlins daemon går tom for minne når testene kjøres i parallell. Å fjerne parallell kjøringer fikser problemet. Det gjør også å øke minnet til Gradle sin daemon (hvis instillinger [Kotlins daemon arver fra](https://kotlinlang.org/docs/gradle-compilation-and-caches.html#gradle-daemon-arguments-inheritance)). Jeg gikk for sistnevnte.