### PR TITLE
Senk kostnad for feil under lesing fra melding

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtils.kt
@@ -67,7 +67,7 @@ fun <K : IKey, T : Any> K.les(
     melding: Map<K, JsonElement>,
 ): T =
     lesOrNull(serializer, melding)
-        ?: throw IllegalArgumentException("Felt '$this' mangler i JSON-map.")
+        ?: throw MeldingException("Felt '$this' mangler i JSON-map.")
 
 fun <K : IKey, T : Any> K.krev(
     krav: T,
@@ -76,8 +76,15 @@ fun <K : IKey, T : Any> K.krev(
 ): T =
     les(serializer, melding).also {
         if (it != krav) {
-            throw IllegalArgumentException("Nøkkel '$this' har verdi '$it', som ikke matcher med påkrevd verdi '$krav'.")
+            throw MeldingException("Nøkkel '$this' har verdi '$it', som ikke matcher med påkrevd verdi '$krav'.")
         }
     }
 
 fun Map<Key, JsonElement>.toPretty(): String = toJson().toPretty()
+
+// Exception uten stacktrace, som er billigere å kaste
+internal class MeldingException(
+    message: String,
+) : IllegalArgumentException(message) {
+    override fun fillInStackTrace(): Throwable? = null
+}

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
@@ -5,6 +5,8 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.Row2
 import io.kotest.data.row
 import io.kotest.datatest.withData
+import io.kotest.matchers.collections.shouldBeEmpty
+import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonNull
@@ -88,16 +90,18 @@ class KotlinxUtilsKtTest :
 
             withData(
                 mapOf(
-                    "gir IllegalArgumentException dersom nøkkel ikke finnes" to emptyMap(),
-                    "gir IllegalArgumentException dersom nøkkel finnes, men verdi er null-json" to mapOf(Key.EVENT_NAME to JsonNull),
+                    "gir MeldingException dersom nøkkel ikke finnes" to emptyMap(),
+                    "gir MeldingException dersom nøkkel finnes, men verdi er null-json" to mapOf(Key.EVENT_NAME to JsonNull),
                 ),
             ) { jsonMap ->
                 val e =
-                    shouldThrowExactly<IllegalArgumentException> {
+                    shouldThrowExactly<MeldingException> {
                         Key.EVENT_NAME.les(EventName.serializer(), jsonMap)
                     }
 
                 e.message shouldBe "Felt '${Key.EVENT_NAME}' mangler i JSON-map."
+                e.stackTrace.shouldBeEmpty()
+                e.fillInStackTrace().shouldBeNull()
             }
         }
     })


### PR DESCRIPTION
Det vil oppstå en feil under lesing av melding når en river leser meldinger fra rapid som ikke er de meldingene som riveren bryr seg om. For vårt system er det ikke kritisk at gjøre dette steget billigere, men det er jo fint med noe som er billig enn dyrt 😄