### PR TITLE
Erstatt workflow-action for dependency submission

### DIFF
--- a/.github/workflows/gradle-dependabot.yml
+++ b/.github/workflows/gradle-dependabot.yml
@@ -1,14 +1,15 @@
 name: Submit dependency graph
+
 on:
   push:
     branches:
       - main
-permissions:
-  contents: write
 
 jobs:
-  build:
+  dependency-submission:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4
@@ -17,28 +18,7 @@ jobs:
           distribution: temurin
           cache: gradle
 
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-
-      - name: Setup Gradle to generate and submit dependency graphs
-        uses: gradle/actions/setup-gradle@v3
-        with:
-          dependency-graph: generate-and-submit
-
-      - name: Run a build
-        run: ./gradlew build -x test
+      - name: Generate and submit dependency graph
+        uses: gradle/actions/dependency-submission@v3
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Jeg ødela den eksisterende workflowen med noen endringer til build-filen. Da jeg skulle lese litt på hvordan workflowen fungerte så kom jeg over en annen workflow-action som var anbefalt over den vi hadde: https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#github-dependency-graph-support