### PR TITLE
Støtt ny skjemaklasse

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
@@ -166,6 +166,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.sendResponse(resultat
         }
 }
 
+// TODO slett når frontend bruker korrekte navn
 private fun JsonElement.fromJsonBackup(error: Throwable): SkjemaInntektsmeldingSelvbestemt {
     val skjemaJson = jsonObject
     val inntektJson = skjemaJson[SkjemaInntektsmeldingSelvbestemt::inntekt.name]!!.jsonObject


### PR DESCRIPTION
Vi ønsker å bytte fra `Innsending` til `SkjemaInntektsmelding`. Denne endringen gjør at vi kan lese begge klasser, slik at frontend kan bytte uten at backend tryner.