### PR TITLE
Beregn bestemmende fraværsdag dersom kun refusjon etterspørs

### DIFF
--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
@@ -55,7 +55,10 @@ fun mapInntektsmelding(
         }
 
     val bestemmendeFravaersdag =
-        if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
+        if (
+            forespoersel.forespurtData.arbeidsgiverperiode.paakrevd ||
+            (!forespoersel.forespurtData.inntekt.paakrevd && forespoersel.forespurtData.refusjon.paakrevd)
+        ) {
             bestemmendeFravaersdag(
                 arbeidsgiverperioder = arbeidsgiverperioder,
                 sykmeldingsperioder = forespoersel.sykmeldingsperioder,

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/MapInntektsmeldingKtTest.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/MapInntektsmeldingKtTest.kt
@@ -26,6 +26,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.tilForespoersel
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
+import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.juli
 import no.nav.helsearbeidsgiver.utils.test.date.juni
 import no.nav.helsearbeidsgiver.utils.test.date.mai
@@ -292,6 +293,48 @@ class MapInntektsmeldingKtTest :
                     )
 
                 inntektsmelding.bestemmendeFraværsdag shouldBe 12.mai
+                inntektsmelding.bestemmendeFraværsdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
+            }
+
+            test("bruker beregnet bestemmende fraværsdag dersom kun refusjon er påkrevd") {
+                val forespoersel =
+                    Mock
+                        .forespoersel()
+                        .utenPaakrevdAGP()
+                        .utenPaakrevdInntekt()
+                        .let {
+                            it.copy(
+                                sykmeldingsperioder =
+                                    listOf(
+                                        5.januar til 10.januar,
+                                        14.januar til 28.januar,
+                                    ),
+                                bestemmendeFravaersdager =
+                                    mapOf(
+                                        it.orgnr to 3.januar,
+                                    ),
+                            )
+                        }
+
+                val skjema =
+                    Mock.skjema().copy(
+                        arbeidsgiverperioder =
+                            listOf(
+                                5.januar til 10.januar,
+                                14.januar til 23.januar,
+                            ),
+                    )
+
+                val inntektsmelding =
+                    mapInntektsmelding(
+                        forespoersel = forespoersel,
+                        skjema = skjema,
+                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        virksomhetNavn = "Skrekkinngytende smaker LLC",
+                        innsenderNavn = "Hege fra HR",
+                    )
+
+                inntektsmelding.bestemmendeFraværsdag shouldBe 14.januar
                 inntektsmelding.bestemmendeFraværsdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
             }
 


### PR DESCRIPTION
Dette løser et problem der sykmeldt har flere AG og sykmeldinger som overlapper hull hos ulike AG. Gjelder kun når det bare etterspørs refusjon. Da bør vi ikke velge bestemmende fraværsdag ut i fra Spleis sine forslag, men heller regne ut selv.