### PR TITLE
Bruk ny redis store i redis poller

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -32,6 +32,5 @@ dependencies {
     testImplementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     testImplementation("io.ktor:ktor-client-core:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
-    testImplementation("io.lettuce:lettuce-core:$lettuceVersion")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
 }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
@@ -2,8 +2,8 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api
 
 import kotlinx.coroutines.delay
 import kotlinx.serialization.json.JsonElement
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
-import no.nav.helsearbeidsgiver.utils.json.parseJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
@@ -11,33 +11,19 @@ private const val MAX_RETRIES = 10
 private const val WAIT_MILLIS = 500L
 
 // TODO Bruke kotlin.Result istedenfor exceptions?
-class RedisPoller {
+class RedisPoller(
+    private val redisStore: RedisStoreClassSpecific,
+) {
     private val sikkerLogger = sikkerLogger()
 
-    private val redis = RedisConnection(Env.Redis.url)
-
     suspend fun hent(key: UUID): JsonElement {
-        val json = hentJsonString(key)
-
-        sikkerLogger.info("Hentet verdi for: '$key' = $json")
-
-        return try {
-            json.parseJson()
-        } catch (e: Exception) {
-            "JSON-parsing feilet.".let {
-                sikkerLogger.error("$it key=$key json=$json", e)
-                throw RedisPollerJsonParseException("$it key='$key'", e)
-            }
-        }
-    }
-
-    private suspend fun hentJsonString(key: UUID): String {
         repeat(MAX_RETRIES) {
             sikkerLogger.debug("Polling redis: $it time(s) for key $key")
 
-            val result = redis.get(key.toString())
+            val result = redisStore.get(RedisKey.of(key))
 
             if (result != null) {
+                sikkerLogger.info("Hentet verdi for: '$key' = $result")
                 return result
             } else {
                 delay(WAIT_MILLIS)
@@ -46,24 +32,8 @@ class RedisPoller {
 
         throw RedisPollerTimeoutException(key)
     }
-
-    fun close() {
-        redis.close()
-    }
 }
-
-sealed class RedisPollerException(
-    message: String,
-    cause: Throwable? = null,
-) : Exception(message, cause)
-
-class RedisPollerJsonParseException(
-    message: String,
-    cause: Throwable,
-) : RedisPollerException(message, cause)
 
 class RedisPollerTimeoutException(
     uuid: UUID,
-) : RedisPollerException(
-        "Brukte for lang tid på å svare ($uuid).",
-    )
+) : Exception("Brukte for lang tid på å svare ($uuid).")

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -18,6 +18,9 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permisjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
 import no.nav.helsearbeidsgiver.felles.ResultJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
@@ -40,9 +43,10 @@ import java.util.UUID
 fun Route.hentSelvbestemtImRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val producer = HentSelvbestemtImProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.HentSelvbestemtImService).let(::RedisPoller)
 
     get(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID) {
         val transaksjonId = UUID.randomUUID()

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -12,6 +12,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Innsending
 import no.nav.helsearbeidsgiver.felles.ResultJson
 import no.nav.helsearbeidsgiver.felles.Tekst
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
@@ -35,9 +38,10 @@ import kotlin.system.measureTimeMillis
 fun Route.innsendingRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val producer = InnsendingProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.InnsendingService).let(::RedisPoller)
 
     val requestLatency =
         Summary

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
@@ -12,6 +12,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helsearbeidsgiver.felles.Inntekt
 import no.nav.helsearbeidsgiver.felles.ResultJson
 import no.nav.helsearbeidsgiver.felles.Tekst
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
@@ -30,9 +33,10 @@ import java.util.UUID
 fun Route.inntektRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val inntektProducer = InntektProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.InntektService).let(::RedisPoller)
 
     post(Routes.INNTEKT) {
         val transaksjonId = UUID.randomUUID()

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
@@ -12,6 +12,9 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helsearbeidsgiver.felles.Inntekt
 import no.nav.helsearbeidsgiver.felles.ResultJson
 import no.nav.helsearbeidsgiver.felles.Tekst
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
@@ -29,9 +32,10 @@ import java.util.UUID
 fun Route.inntektSelvbestemtRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val inntektSelvbestemtProducer = InntektSelvbestemtProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.InntektSelvbestemtService).let(::RedisPoller)
 
     post(Routes.INNTEKT_SELVBESTEMT) {
         val transaksjonId = UUID.randomUUID()

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -16,6 +16,9 @@ import no.nav.helsearbeidsgiver.felles.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.InnsendtInntektsmelding
 import no.nav.helsearbeidsgiver.felles.ResultJson
 import no.nav.helsearbeidsgiver.felles.Tekst
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
@@ -40,9 +43,10 @@ import kotlin.system.measureTimeMillis
 fun Route.kvitteringRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val kvitteringProducer = KvitteringProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.KvitteringService).let(::RedisPoller)
 
     val requestLatency =
         Summary

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
@@ -20,6 +20,9 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.ResultJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
@@ -48,9 +51,10 @@ import java.util.UUID
 fun Route.lagreSelvbestemtImRoute(
     rapid: RapidsConnection,
     tilgangskontroll: Tilgangskontroll,
-    redisPoller: RedisPoller,
+    redisConnection: RedisConnection,
 ) {
     val producer = LagreSelvbestemtImProducer(rapid)
+    val redisPoller = RedisStoreClassSpecific(redisConnection, RedisPrefix.LagreSelvbestemtImService).let(::RedisPoller)
 
     post(Routes.SELVBESTEMT_INNTEKTSMELDING) {
         val transaksjonId = UUID.randomUUID()

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
@@ -2,24 +2,24 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-import io.lettuce.core.RedisClient
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.felles.Forespoersel
 import no.nav.helsearbeidsgiver.felles.ForespurtData
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStoreClassSpecific
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
 import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
-import no.nav.helsearbeidsgiver.utils.test.mock.mockConstructor
-import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
+import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 import org.junit.jupiter.api.assertThrows
 import java.util.UUID
 
@@ -28,79 +28,59 @@ class RedisPollerTest :
         // For å skippe kall til 'delay'
         coroutineTestScope = true
 
+        val mockRedisStore = mockk<RedisStoreClassSpecific>()
+        val redisPoller = RedisPoller(mockRedisStore)
+
         val key = UUID.randomUUID()
         val dataJson = "noe data".toJson()
-        val dataJsonString = dataJson.toString()
 
         beforeEach {
             clearAllMocks()
         }
 
         test("skal finne med tillatt antall forsøk") {
-            mockConstructor(RedisConnection::class) {
-                every { anyConstructed<RedisConnection>().get(any()) } returnsMany answers(answerOnAttemptNo = 10, answer = dataJsonString)
+            every { mockRedisStore.get(any()) } returnsMany answers(answerOnAttemptNo = 10, answer = dataJson)
 
-                val redisPoller =
-                    mockStatic(RedisClient::class) {
-                        every { RedisClient.create(any<String>()) } returns mockk(relaxed = true)
-                        RedisPoller()
-                    }
+            val json = redisPoller.hent(key)
 
-                val json = redisPoller.hent(key)
-
-                json shouldBe dataJson
-            }
+            json shouldBe dataJson
         }
 
         test("skal ikke finne etter maks forsøk") {
-            mockConstructor(RedisConnection::class) {
-                every { anyConstructed<RedisConnection>().get(any()) } returnsMany answers(answerOnAttemptNo = 11, answer = dataJsonString)
+            every { mockRedisStore.get(any()) } returnsMany answers(answerOnAttemptNo = 11, answer = dataJson)
 
-                val redisPoller =
-                    mockStatic(RedisClient::class) {
-                        every { RedisClient.create(any<String>()) } returns mockk(relaxed = true)
-                        RedisPoller()
-                    }
-
-                assertThrows<RedisPollerTimeoutException> {
-                    redisPoller.hent(key)
-                }
+            assertThrows<RedisPollerTimeoutException> {
+                redisPoller.hent(key)
             }
         }
 
         test("skal parse forespurt data korrekt") {
             val expected = mockForespoersel()
-            val expectedJson = """
-            {
-                "type": "${expected.type}",
-                "orgnr": "${expected.orgnr}",
-                "fnr": "${expected.fnr}",
-                "vedtaksperiodeId": ${expected.vedtaksperiodeId.toJson()},
-                "sykmeldingsperioder": ${expected.sykmeldingsperioder.toJsonStr(Periode.serializer().list())},
-                "egenmeldingsperioder": ${expected.egenmeldingsperioder.toJsonStr(Periode.serializer().list())},
-                "bestemmendeFravaersdager": ${expected.bestemmendeFravaersdager.toJsonStr(MapSerializer(String.serializer(), LocalDateSerializer))},
-                "forespurtData": ${expected.forespurtData.toJsonStr(ForespurtData.serializer())},
-                "erBesvart": ${expected.erBesvart}
-            }
-        """
+            val expectedJson =
+                """
+                {
+                    "type": "${expected.type}",
+                    "orgnr": "${expected.orgnr}",
+                    "fnr": "${expected.fnr}",
+                    "vedtaksperiodeId": ${expected.vedtaksperiodeId.toJson()},
+                    "sykmeldingsperioder": ${expected.sykmeldingsperioder.toJsonStr(Periode.serializer().list())},
+                    "egenmeldingsperioder": ${expected.egenmeldingsperioder.toJsonStr(Periode.serializer().list())},
+                    "bestemmendeFravaersdager": ${expected.bestemmendeFravaersdager.toJsonStr(MapSerializer(String.serializer(), LocalDateSerializer))},
+                    "forespurtData": ${expected.forespurtData.toJsonStr(ForespurtData.serializer())},
+                    "erBesvart": ${expected.erBesvart}
+                }
+                """.removeJsonWhitespace()
+                    .parseJson()
 
-            mockConstructor(RedisConnection::class) {
-                every { anyConstructed<RedisConnection>().get(any()) } returnsMany answers(answerOnAttemptNo = 1, answer = expectedJson)
+            every { mockRedisStore.get(any()) } returnsMany answers(answerOnAttemptNo = 1, answer = expectedJson)
 
-                val redisPoller =
-                    mockStatic(RedisClient::class) {
-                        every { RedisClient.create(any<String>()) } returns mockk(relaxed = true)
-                        RedisPoller()
-                    }
+            val resultat = redisPoller.hent(key).fromJson(Forespoersel.serializer())
 
-                val resultat = redisPoller.hent(key).fromJson(Forespoersel.serializer())
-
-                resultat shouldBe expected
-            }
+            resultat shouldBe expected
         }
     })
 
 private fun answers(
     answerOnAttemptNo: Int,
-    answer: String,
-): List<String?> = List(answerOnAttemptNo - 1) { null }.plus(answer)
+    answer: JsonElement,
+): List<JsonElement?> = List(answerOnAttemptNo - 1) { null }.plus(answer)

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
@@ -32,10 +32,11 @@ class AktiveOrgnrRouteKtTest : ApiTest() {
     @Test
     fun `skal godta og returnere liste med organisasjoner`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns
+            coEvery { mockRedisConnection.get(any()) } returns
                 ResultJson(
                     success = Mock.GYLDIG_AKTIVE_ORGNR_RESPONSE.parseJson(),
                 ).toJson(ResultJson.serializer())
+                    .toString()
 
             val requestBody = """
             {"identitetsnummer":"${Fnr.genererGyldig()}"}
@@ -57,10 +58,11 @@ class AktiveOrgnrRouteKtTest : ApiTest() {
                     underenheter = emptyList(),
                 )
 
-            coEvery { mockRedisPoller.hent(any()) } returns
+            coEvery { mockRedisConnection.get(any()) } returns
                 ResultJson(
                     success = resultatUtenArbeidsforhold.toJson(AktiveArbeidsgivere.serializer()),
                 ).toJson(ResultJson.serializer())
+                    .toString()
 
             val response = post(path, AktiveOrgnrRequest(Fnr.genererGyldig()), AktiveOrgnrRequest.serializer())
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -57,7 +57,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
         testApi {
             val expectedJson = Mock.responseJson()
 
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     Mock.resultatOkJson,
@@ -76,7 +76,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
         testApi {
             val expectedJson = Mock.responseBareInntektJson()
 
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     Mock.resultatOkMedForrigeInntektJson,
@@ -93,7 +93,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Internal server error hvis Redis timer ut`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
+            coEvery { mockRedisConnection.get(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
 
             val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
 
@@ -129,7 +129,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Forbidden hvis feil ikke tilgang`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns ikkeTilgangResultat
+            coEvery { mockRedisConnection.get(any()) } returns ikkeTilgangResultat
 
             val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -138,10 +138,11 @@ class HentForespoerselRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Forbidden hvis feil i Tilgangsresultet`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns
+            coEvery { mockRedisConnection.get(any()) } returns
                 TilgangResultat(
                     feilmelding = "Noe er riv ruskende galt!",
                 ).toJson(TilgangResultat.serializer())
+                    .toString()
 
             val response = post(PATH, Mock.request, HentForespoerselRequest.serializer())
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -202,6 +203,7 @@ private object Mock {
                     feil = emptyMap(),
                 ).toJson(HentForespoerselResultat.serializer()),
         ).toJson(ResultJson.serializer())
+            .toString()
 
     val resultatOkMedForrigeInntektJson =
         ResultJson(
@@ -218,6 +220,7 @@ private object Mock {
                     feil = emptyMap(),
                 ).toJson(HentForespoerselResultat.serializer()),
         ).toJson(ResultJson.serializer())
+            .toString()
 
     fun responseJson(): String =
         """

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/TrengerRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/TrengerRouteKtTest.kt
@@ -57,7 +57,7 @@ class TrengerRouteKtTest : ApiTest() {
         testApi {
             val expectedJson = MockTrenger.responseJson()
 
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     MockTrenger.resultatOkJson,
@@ -76,7 +76,7 @@ class TrengerRouteKtTest : ApiTest() {
         testApi {
             val expectedJson = MockTrenger.responseBareInntektJson()
 
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     MockTrenger.resultatOkMedForrigeInntektJson,
@@ -93,7 +93,7 @@ class TrengerRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Internal server error hvis Redis timer ut`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
+            coEvery { mockRedisConnection.get(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
 
             val response = post(PATH, MockTrenger.request, HentForespoerselRequest.serializer())
 
@@ -129,7 +129,7 @@ class TrengerRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Forbidden hvis feil ikke tilgang`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns ikkeTilgangResultat
+            coEvery { mockRedisConnection.get(any()) } returns ikkeTilgangResultat
 
             val response = post(PATH, MockTrenger.request, HentForespoerselRequest.serializer())
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -138,10 +138,11 @@ class TrengerRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere Forbidden hvis feil i Tilgangsresultet`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns
+            coEvery { mockRedisConnection.get(any()) } returns
                 TilgangResultat(
                     feilmelding = "Noe er riv ruskende galt!",
                 ).toJson(TilgangResultat.serializer())
+                    .toString()
 
             val response = post(PATH, MockTrenger.request, HentForespoerselRequest.serializer())
             assertEquals(HttpStatusCode.Forbidden, response.status)
@@ -202,6 +203,7 @@ private object MockTrenger {
                     feil = emptyMap(),
                 ).toJson(HentForespoerselResultat.serializer()),
         ).toJson(ResultJson.serializer())
+            .toString()
 
     val resultatOkMedForrigeInntektJson =
         ResultJson(
@@ -218,6 +220,7 @@ private object MockTrenger {
                     feil = emptyMap(),
                 ).toJson(HentForespoerselResultat.serializer()),
         ).toJson(ResultJson.serializer())
+            .toString()
 
     fun responseJson(): String =
         """

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
@@ -41,12 +41,13 @@ class InnsendingRouteKtTest : ApiTest() {
     @Test
     fun `mottar inntektsmelding og svarer OK`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     ResultJson(
                         success = mockInntektsmelding().toJson(Inntektsmelding.serializer()),
-                    ).toJson(ResultJson.serializer()),
+                    ).toJson(ResultJson.serializer())
+                        .toString(),
                 )
 
             val response = post(path, gyldigRequest)
@@ -58,12 +59,13 @@ class InnsendingRouteKtTest : ApiTest() {
     @Test
     fun `mottar delvis inntektsmelding og svarer OK`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     ResultJson(
                         success = mockDelvisInntektsmeldingDokument().toJson(Inntektsmelding.serializer()),
-                    ).toJson(ResultJson.serializer()),
+                    ).toJson(ResultJson.serializer())
+                        .toString(),
                 )
 
             val response = post(path, gyldigDelvisRequest)
@@ -87,7 +89,7 @@ class InnsendingRouteKtTest : ApiTest() {
     @Test
     fun `skal returnere feilmelding ved timeout fra Redis`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(Mock.forespoerselId)
+            coEvery { mockRedisConnection.get(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(Mock.forespoerselId)
 
             val response = post(path, gyldigRequest)
 

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
@@ -33,12 +33,13 @@ class KvitteringRouteKtTest : ApiTest() {
     @Test
     fun `skal godta gyldig uuid`() =
         testApi {
-            coEvery { mockRedisPoller.hent(any()) } returnsMany
+            coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
                     harTilgangResultat,
                     ResultJson(
                         success = resultatMedInntektsmelding.parseJson(),
-                    ).toJson(ResultJson.serializer()),
+                    ).toJson(ResultJson.serializer())
+                        .toString(),
                 )
 
             val response = get(PATH + "?uuid=" + UUID.randomUUID())

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
@@ -19,22 +19,22 @@ import kotlinx.serialization.KSerializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.Tilgang
 import no.nav.helsearbeidsgiver.felles.TilgangResultat
-import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.inntektsmelding.api.apiModule
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import org.junit.jupiter.api.AfterEach
 
-val harTilgangResultat = TilgangResultat(Tilgang.HAR_TILGANG).toJson(TilgangResultat.serializer())
-val ikkeTilgangResultat = TilgangResultat(Tilgang.IKKE_TILGANG).toJson(TilgangResultat.serializer())
+val harTilgangResultat = TilgangResultat(Tilgang.HAR_TILGANG).toJson(TilgangResultat.serializer()).toString()
+val ikkeTilgangResultat = TilgangResultat(Tilgang.IKKE_TILGANG).toJson(TilgangResultat.serializer()).toString()
 
 abstract class ApiTest : MockAuthToken() {
-    val mockRedisPoller = mockk<RedisPoller>()
+    val mockRedisConnection = mockk<RedisConnection>()
 
     fun testApi(block: suspend TestClient.() -> Unit): Unit =
         testApplication {
             application {
-                apiModule(mockk(relaxed = true), mockRedisPoller)
+                apiModule(mockk(relaxed = true), mockRedisConnection)
             }
 
             val testClient = TestClient(this, ::mockAuthToken)

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/ResultJson.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/ResultJson.kt
@@ -2,12 +2,9 @@ package no.nav.helsearbeidsgiver.felles
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
-import no.nav.helsearbeidsgiver.utils.json.toJsonStr
 
 @Serializable
 data class ResultJson(
     val success: JsonElement? = null,
     val failure: JsonElement? = null,
-) {
-    fun toJsonStr(): String = toJsonStr(serializer())
-}
+)

--- a/innsending/build.gradle.kts
+++ b/innsending/build.gradle.kts
@@ -1,5 +1,0 @@
-val lettuceVersion: String by project
-
-dependencies {
-    implementation("io.lettuce:lettuce-core:$lettuceVersion")
-}


### PR DESCRIPTION
Gjør at redis polleren leser fra korrekt adresse i fremtiden, når bakoverkompatilitet fjernes fra ny redis store.