### PR TITLE
Kopier nøkkel til erstatning ved publisering

### DIFF
--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
@@ -32,6 +32,7 @@ class InntektProducerTest :
                     Key.DATA to "".toJson(),
                     Key.FORESPOERSEL_ID to request.forespoerselId.toJson(),
                     Key.SKJAERINGSTIDSPUNKT to request.skjaeringstidspunkt.toJson(),
+                    Key.INNTEKTSDATO to request.skjaeringstidspunkt.toJson(),
                 )
         }
     })

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
@@ -38,6 +38,7 @@ class InntektSelvbestemtProducerTest :
                     Key.FNR to sykmeldtFnr.toJson(),
                     Key.ORGNRUNDERENHET to orgnr.toJson(),
                     Key.SKJAERINGSTIDSPUNKT to inntektsdato.toJson(),
+                    Key.INNTEKTSDATO to inntektsdato.toJson(),
                 )
         }
     })

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -58,7 +58,17 @@ fun MessageContext.publishNotNull(messageFields: Map<Key, JsonElement?>): JsonEl
 
 fun MessageContext.publish(messageFields: Map<Key, JsonElement>): JsonElement =
     messageFields
-        .mapKeys { (key, _) -> key.toString() }
+        // TODO slett etter overgangsperiode: kopierer Key.SKJAERINGSTIDSPUNKT til Key.INNTEKTSDATO
+        .let { fields ->
+            if (Key.SKJAERINGSTIDSPUNKT in fields) {
+                fields
+                    .plus(
+                        Key.INNTEKTSDATO to fields[Key.SKJAERINGSTIDSPUNKT],
+                    ).mapValuesNotNull { it }
+            } else {
+                fields
+            }
+        }.mapKeys { (key, _) -> key.toString() }
         .filterValues { it !is JsonNull }
         .toJson()
         .toString()


### PR DESCRIPTION
Jeg vil bytte `Key.SKJAERINGSTIDSPUNKT` til `Key.INNTEKTSDATO`, og samtidig teste en måte å bytte nøkler på.

`publish` er en funksjon som brukes i hele Simba for å skrive meldinger til Kafka. Her kan vi kopiere fra gamle til nye nøkler, slik som her, slik at verdien er duplisert i begge nøklene. I neste steg kan vi da bytte alle de gamle nøklene til de nye, uten inflight-problemer og vi slipper å bytte en og en nøkkel.

Tanken er å endelig endre `Key.UUID` til noe fornuftig med denne metoden når den er testet.