### PR TITLE
Map ny skjemaklasse til inntektsmelding

### DIFF
--- a/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
+++ b/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
@@ -9,21 +9,24 @@ import no.nav.helsearbeidsgiver.felles.domene.ForslagInntekt
 import no.nav.helsearbeidsgiver.felles.domene.ForslagRefusjon
 import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.januar
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
 
 fun mockForespoersel(): Forespoersel {
-    val orgnr = "789789789"
+    val orgnr = Orgnr.genererGyldig()
     return Forespoersel(
         type = ForespoerselType.KOMPLETT,
-        orgnr = orgnr,
-        fnr = "15055012345",
+        orgnr = orgnr.verdi,
+        fnr = Fnr.genererGyldig().verdi,
         vedtaksperiodeId = UUID.randomUUID(),
         sykmeldingsperioder = listOf(2.januar til 31.januar),
         egenmeldingsperioder = listOf(1.januar til 1.januar),
         bestemmendeFravaersdager =
             mapOf(
-                orgnr to 1.januar,
-                "555767555" to 5.januar,
+                orgnr.verdi to 1.januar,
+                Orgnr.genererGyldig().verdi to 5.januar,
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,

--- a/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
+++ b/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
@@ -97,18 +97,21 @@ fun mockInntektsmeldingV1(): InntektsmeldingV1 =
             ),
         agp =
             Arbeidsgiverperiode(
-                listOf(
-                    5.oktober til 15.oktober,
-                    20.oktober til 22.oktober,
-                ),
-                listOf(
-                    28.september til 28.september,
-                    30.september til 30.september,
-                ),
-                RedusertLoennIAgp(
-                    beloep = 300.3,
-                    begrunnelse = RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering,
-                ),
+                perioder =
+                    listOf(
+                        5.oktober til 15.oktober,
+                        20.oktober til 22.oktober,
+                    ),
+                egenmeldinger =
+                    listOf(
+                        28.september til 28.september,
+                        30.september til 30.september,
+                    ),
+                redusertLoennIAgp =
+                    RedusertLoennIAgp(
+                        beloep = 300.3,
+                        begrunnelse = RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering,
+                    ),
             ),
         inntekt =
             InntektV1(

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/MapInntektsmelding.kt
@@ -1,126 +1,82 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.innsending
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.FullLoennIArbeidsgiverPerioden
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Innsending
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntekt
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Refusjon
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.domene.ForslagInntekt
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.ZonedDateTime
+import java.util.UUID
 
 fun mapInntektsmelding(
     forespoersel: Forespoersel,
-    skjema: Innsending,
-    fulltnavnArbeidstaker: String,
+    skjema: SkjemaInntektsmelding,
+    aarsakInnsending: AarsakInnsending,
     virksomhetNavn: String,
-    innsenderNavn: String,
+    sykmeldtNavn: String,
+    avsenderNavn: String,
 ): Inntektsmelding {
-    val egenmeldingsperioder =
+    val agp =
         if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
-            skjema.egenmeldingsperioder
-        } else {
-            forespoersel.egenmeldingsperioder
-        }
-
-    val arbeidsgiverperioder =
-        if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
-            skjema.arbeidsgiverperioder
-        } else {
-            emptyList()
-        }
-
-    val fullLoennIArbeidsgiverPerioden =
-        if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
-            if (skjema.fullLønnIArbeidsgiverPerioden?.utbetalerFullLønn == false) {
-                skjema.fullLønnIArbeidsgiverPerioden
-            } else {
-                FullLoennIArbeidsgiverPerioden(
-                    utbetalerFullLønn = true,
-                    begrunnelse = null,
-                    utbetalt = null,
-                )
-            }
+            skjema.agp
         } else {
             null
         }
 
-    val inntektsdato =
-        if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
-            // NB!: 'skjema.bestemmendeFraværsdag' inneholder egentlig inntektsdato og ikke bestemmende fraværsdag. Utbedring kommer.
-            skjema.bestemmendeFraværsdag
-        } else {
-            forespoersel.forslagInntektsdato()
-        }
-
-    val bestemmendeFravaersdag =
-        if (
-            forespoersel.forespurtData.arbeidsgiverperiode.paakrevd ||
-            (!forespoersel.forespurtData.inntekt.paakrevd && forespoersel.forespurtData.refusjon.paakrevd)
-        ) {
-            bestemmendeFravaersdag(
-                arbeidsgiverperioder = arbeidsgiverperioder,
-                sykmeldingsperioder = forespoersel.sykmeldingsperioder,
-            )
-        } else {
-            forespoersel.forslagBestemmendeFravaersdag()
-        }
-
     val inntekt =
         if (forespoersel.forespurtData.inntekt.paakrevd) {
-            skjema.inntekt
+            if (forespoersel.forespurtData.arbeidsgiverperiode.paakrevd) {
+                skjema.inntekt
+            } else {
+                skjema.inntekt?.copy(
+                    inntektsdato = forespoersel.forslagInntektsdato(),
+                )
+            }
         } else {
             Inntekt(
-                bekreftet = true,
-                beregnetInntekt = (forespoersel.forespurtData.inntekt.forslag as ForslagInntekt.Fastsatt).fastsattInntekt,
-                endringÅrsak = null,
-                manueltKorrigert = true,
+                beloep = (forespoersel.forespurtData.inntekt.forslag as ForslagInntekt.Fastsatt).fastsattInntekt,
+                inntektsdato = forespoersel.forslagInntektsdato(),
+                naturalytelser = emptyList(),
+                endringAarsak = null,
             )
         }
 
     val refusjon =
-        if (forespoersel.forespurtData.refusjon.paakrevd && skjema.refusjon.utbetalerHeleEllerDeler) {
+        if (forespoersel.forespurtData.refusjon.paakrevd) {
             skjema.refusjon
         } else {
-            Refusjon(
-                utbetalerHeleEllerDeler = false,
-                refusjonPrMnd = null,
-                refusjonOpphører = null,
-                refusjonEndringer = null,
-            )
+            null
         }
 
-    val forespurtData =
-        mapOf(
-            "arbeidsgiverperiode" to forespoersel.forespurtData.arbeidsgiverperiode.paakrevd,
-            "inntekt" to forespoersel.forespurtData.inntekt.paakrevd,
-            "refusjon" to forespoersel.forespurtData.refusjon.paakrevd,
-        ).filterValues { it }
-            .keys
-            .toList()
-
     return Inntektsmelding(
-        vedtaksperiodeId = forespoersel.vedtaksperiodeId,
-        orgnrUnderenhet = forespoersel.orgnr,
-        identitetsnummer = forespoersel.fnr,
-        fulltNavn = fulltnavnArbeidstaker,
-        virksomhetNavn = virksomhetNavn,
-        behandlingsdager = emptyList(),
-        egenmeldingsperioder = egenmeldingsperioder,
-        fraværsperioder = forespoersel.sykmeldingsperioder,
-        arbeidsgiverperioder = arbeidsgiverperioder,
-        beregnetInntekt = inntekt.beregnetInntekt,
-        inntektsdato = inntektsdato,
+        id = UUID.randomUUID(),
+        type =
+            Inntektsmelding.Type.Forespurt(
+                id = skjema.forespoerselId,
+                vedtaksperiodeId = forespoersel.vedtaksperiodeId,
+            ),
+        sykmeldt =
+            Sykmeldt(
+                fnr = forespoersel.fnr.let(::Fnr),
+                navn = sykmeldtNavn,
+            ),
+        avsender =
+            Avsender(
+                orgnr = forespoersel.orgnr.let(::Orgnr),
+                orgNavn = virksomhetNavn,
+                navn = avsenderNavn,
+                tlf = skjema.avsenderTlf,
+            ),
+        sykmeldingsperioder = forespoersel.sykmeldingsperioder,
+        agp = agp,
         inntekt = inntekt,
-        fullLønnIArbeidsgiverPerioden = fullLoennIArbeidsgiverPerioden,
         refusjon = refusjon,
-        naturalytelser = skjema.naturalytelser,
-        tidspunkt = ZonedDateTime.now().toOffsetDateTime(),
-        årsakInnsending = skjema.årsakInnsending,
-        innsenderNavn = innsenderNavn,
-        telefonnummer = skjema.telefonnummer,
-        forespurtData = forespurtData,
-        bestemmendeFraværsdag = bestemmendeFravaersdag,
+        aarsakInnsending = aarsakInnsending,
+        mottatt = ZonedDateTime.now().toOffsetDateTime(),
     )
 }

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/UtledBestemmendeFravaersdag.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/UtledBestemmendeFravaersdag.kt
@@ -5,6 +5,14 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import java.time.LocalDate
 
+/**
+ * Vi bruker Spleis sitt forslag til bestemmende fraværsdag (BF), med to unntak der vi må beregne BF selv:
+ * - Vi ber om AGP. Da kan AGP inneholde info som Spleis ikke vet om, f. eks. egenmeldinger.
+ * - Vi ber kun om refusjon. Da kan Spleis sitt forslag inneholde feil`*` dersom sykmeldt har mer enn én arbeidsgiver.
+ *
+ * `*` Det er ikke feil, men forslagene fra Spleis er egentlig inntektsdatoer, ikke BF-er.
+ * For én arbeidsgiver så er disse datoene like, men det er de nødvendigvis ikke ved mer enn én arbeidsgiver.
+*/
 fun utledBestemmendeFravaersdag(
     forespoersel: Forespoersel,
     inntektsmelding: Inntektsmelding,

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/UtledBestemmendeFravaersdag.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/UtledBestemmendeFravaersdag.kt
@@ -1,0 +1,22 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.innsending
+
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
+import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import java.time.LocalDate
+
+fun utledBestemmendeFravaersdag(
+    forespoersel: Forespoersel,
+    inntektsmelding: Inntektsmelding,
+): LocalDate =
+    if (
+        forespoersel.forespurtData.arbeidsgiverperiode.paakrevd ||
+        (!forespoersel.forespurtData.inntekt.paakrevd && forespoersel.forespurtData.refusjon.paakrevd)
+    ) {
+        bestemmendeFravaersdag(
+            arbeidsgiverperioder = inntektsmelding.agp?.perioder.orEmpty(),
+            sykmeldingsperioder = forespoersel.sykmeldingsperioder,
+        )
+    } else {
+        forespoersel.forslagBestemmendeFravaersdag()
+    }

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/ForespoerselUtils.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/ForespoerselUtils.kt
@@ -1,0 +1,48 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.innsending
+
+import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespurtData
+import no.nav.helsearbeidsgiver.felles.domene.ForslagInntekt
+import no.nav.helsearbeidsgiver.felles.domene.ForslagRefusjon
+
+fun Forespoersel.utenPaakrevdAGP(): Forespoersel =
+    copy(
+        forespurtData =
+            forespurtData.copy(
+                arbeidsgiverperiode =
+                    ForespurtData.Arbeidsgiverperiode(
+                        paakrevd = false,
+                    ),
+            ),
+    )
+
+fun Forespoersel.utenPaakrevdInntekt(): Forespoersel =
+    copy(
+        forespurtData =
+            forespurtData.copy(
+                inntekt =
+                    ForespurtData.Inntekt(
+                        paakrevd = false,
+                        forslag =
+                            ForslagInntekt.Fastsatt(
+                                fastsattInntekt = 8795.0,
+                            ),
+                    ),
+            ),
+    )
+
+fun Forespoersel.utenPaakrevdRefusjon(): Forespoersel =
+    copy(
+        forespurtData =
+            forespurtData.copy(
+                refusjon =
+                    ForespurtData.Refusjon(
+                        paakrevd = false,
+                        forslag =
+                            ForslagRefusjon(
+                                perioder = emptyList(),
+                                opphoersdato = null,
+                            ),
+                    ),
+            ),
+    )

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/MapInntektsmeldingKtTest.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/MapInntektsmeldingKtTest.kt
@@ -8,33 +8,19 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.AarsakInnsending
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.BegrunnelseIngenEllerRedusertUtbetalingKode
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Ferie
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.FullLoennIArbeidsgiverPerioden
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Innsending
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntekt
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Naturalytelse
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.NaturalytelseKode
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Refusjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
-import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselType
-import no.nav.helsearbeidsgiver.felles.domene.ForespurtData
-import no.nav.helsearbeidsgiver.felles.domene.ForslagInntekt
-import no.nav.helsearbeidsgiver.felles.domene.ForslagRefusjon
-import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
-import no.nav.helsearbeidsgiver.utils.test.date.april
+import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
+import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.desember
-import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.juli
-import no.nav.helsearbeidsgiver.utils.test.date.juni
-import no.nav.helsearbeidsgiver.utils.test.date.mai
-import no.nav.helsearbeidsgiver.utils.test.date.mars
-import no.nav.helsearbeidsgiver.utils.test.date.september
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.ZonedDateTime
-import java.util.UUID
 import kotlin.time.Duration.Companion.seconds
 import kotlin.time.toJavaDuration
 
@@ -43,127 +29,138 @@ class MapInntektsmeldingKtTest :
 
         context(::mapInntektsmelding.name) {
 
-            test("inntektsmelding mappes korrekt") {
-                val forespoersel = Mock.forespoersel()
-                val skjema = Mock.skjema()
-                val sykmeldtNavn = "Runar fra Regnskap"
-                val innsenderNavn = "Hege fra HR"
+            test("inntektsmelding mappes korrekt med AGP, inntekt og refusjon påkrevd") {
+                val forespoersel = mockForespoersel()
+                val skjema = mockSkjemaInntektsmelding()
                 val virksomhetNavn = "Skrekkinngytende smaker LLC"
+                val sykmeldtNavn = "Runar fra Regnskap"
+                val avsenderNavn = "Hege fra HR"
 
                 val inntektsmelding =
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = sykmeldtNavn,
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = virksomhetNavn,
-                        innsenderNavn = innsenderNavn,
+                        sykmeldtNavn = sykmeldtNavn,
+                        avsenderNavn = avsenderNavn,
                     )
 
                 inntektsmelding.apply {
-                    // Matcher forespørsel
-                    vedtaksperiodeId shouldBe forespoersel.vedtaksperiodeId
-                    orgnrUnderenhet shouldBe forespoersel.orgnr
-                    identitetsnummer shouldBe forespoersel.fnr
-                    fraværsperioder shouldBe forespoersel.sykmeldingsperioder
-                    forespurtData shouldBe
-                        listOf(
-                            "arbeidsgiverperiode",
-                            "inntekt",
-                            "refusjon",
+                    type shouldBe
+                        Inntektsmelding.Type.Forespurt(
+                            id = skjema.forespoerselId,
+                            vedtaksperiodeId = forespoersel.vedtaksperiodeId,
                         )
 
-                    // Matcher skjema
-                    egenmeldingsperioder shouldBe skjema.egenmeldingsperioder
-                    arbeidsgiverperioder shouldBe skjema.arbeidsgiverperioder
+                    sykmeldt shouldBe
+                        Sykmeldt(
+                            fnr = forespoersel.fnr.let(::Fnr),
+                            navn = sykmeldtNavn,
+                        )
+
+                    avsender shouldBe
+                        Avsender(
+                            orgnr = forespoersel.orgnr.let(::Orgnr),
+                            orgNavn = virksomhetNavn,
+                            navn = avsenderNavn,
+                            tlf = skjema.avsenderTlf,
+                        )
+
+                    sykmeldingsperioder.shouldNotBeEmpty()
+                    sykmeldingsperioder shouldBe forespoersel.sykmeldingsperioder
+
+                    agp.shouldNotBeNull()
+                    agp shouldBe skjema.agp
+
+                    inntekt.shouldNotBeNull()
                     inntekt shouldBe skjema.inntekt
-                    beregnetInntekt shouldBe skjema.inntekt.beregnetInntekt
-                    inntektsdato shouldBe skjema.bestemmendeFraværsdag
-                    fullLønnIArbeidsgiverPerioden shouldBe skjema.fullLønnIArbeidsgiverPerioden
+
+                    refusjon.shouldNotBeNull()
                     refusjon shouldBe skjema.refusjon
-                    naturalytelser shouldBe skjema.naturalytelser
-                    årsakInnsending shouldBe skjema.årsakInnsending
-                    telefonnummer shouldBe skjema.telefonnummer
 
-                    // Matcher andre argumenter
-                    fulltNavn shouldBe sykmeldtNavn
-                    virksomhetNavn shouldBe virksomhetNavn
-                    innsenderNavn shouldBe innsenderNavn
+                    aarsakInnsending shouldBe AarsakInnsending.Endring
 
-                    // Matcher faste verdier
-                    behandlingsdager.shouldBeEmpty()
-                    tidspunkt.shouldBeWithin(5.seconds.toJavaDuration(), ZonedDateTime.now().toOffsetDateTime())
-
-                    // Mathcer utregnet verdi
-                    bestemmendeFraværsdag shouldBe 6.april
+                    mottatt.shouldBeWithin(5.seconds.toJavaDuration(), ZonedDateTime.now().toOffsetDateTime())
                 }
             }
 
-            test("erstatter egenmeldingsperioder fra skjema med forespoersel dersom AGP _ikke_ er påkrevd") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdAGP()
+            test("beholder tomme verdier for AGP, inntekt og refusjon") {
+                val forespoersel = mockForespoersel()
                 val skjema =
-                    Mock.skjema().copy(
-                        egenmeldingsperioder =
-                            listOf(
-                                23.mars til 23.mars,
-                                26.mars til 28.mars,
-                            ),
+                    mockSkjemaInntektsmelding().copy(
+                        agp = null,
+                        inntekt = null,
+                        refusjon = null,
                     )
 
                 val inntektsmelding =
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                inntektsmelding.egenmeldingsperioder shouldNotBe skjema.egenmeldingsperioder
-                inntektsmelding.egenmeldingsperioder shouldBe forespoersel.egenmeldingsperioder
+                inntektsmelding.agp.shouldBeNull()
+                inntektsmelding.inntekt.shouldBeNull()
+                inntektsmelding.refusjon.shouldBeNull()
             }
 
             test("fjerner AGP dersom AGP _ikke_ er påkrevd") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdAGP()
-                val skjema = Mock.skjema()
+                val forespoersel = mockForespoersel().utenPaakrevdAGP()
+                val skjema = mockSkjemaInntektsmelding()
 
                 val inntektsmelding =
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                skjema.arbeidsgiverperioder.shouldNotBeEmpty()
-                inntektsmelding.arbeidsgiverperioder.shouldBeEmpty()
+                skjema.agp.shouldNotBeNull()
+                inntektsmelding.agp.shouldBeNull()
             }
 
-            test("fjerner 'fullLoennIArbeidsgiverPerioden' dersom AGP _ikke_ er påkrevd") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdAGP()
-                val skjema = Mock.skjema()
+            test("bruker fastsatt inntekt (fra Spleis) dersom inntekt _ikke_ er påkrevd") {
+                val forespoersel = mockForespoersel().utenPaakrevdInntekt()
+                val skjema = mockSkjemaInntektsmelding()
 
                 val inntektsmelding =
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                skjema.fullLønnIArbeidsgiverPerioden.shouldNotBeNull()
-                inntektsmelding.fullLønnIArbeidsgiverPerioden.shouldBeNull()
+                val fastsattInntekt = 8795.0
+
+                inntektsmelding.inntekt shouldNotBe skjema.inntekt
+                inntektsmelding.inntekt.also {
+                    it.shouldNotBeNull()
+                    it.beloep shouldBe fastsattInntekt
+                    it.inntektsdato shouldBe forespoersel.forslagInntektsdato()
+                    it.naturalytelser.shouldBeEmpty()
+                    it.endringAarsak.shouldBeNull()
+                }
             }
 
-            test("fjerner ugyldige verdier fra 'fullLoennIArbeidsgiverPerioden' dersom AG utbetaler full lønn i AGP") {
-                val forespoersel = Mock.forespoersel()
+            test("bruker innsendt inntektsdato dersom AGP er påkrevd") {
+                val forespoersel = mockForespoersel()
                 val skjema =
-                    Mock.skjema().let {
+                    mockSkjemaInntektsmelding().let {
                         it.copy(
-                            fullLønnIArbeidsgiverPerioden =
-                                it.fullLønnIArbeidsgiverPerioden?.copy(
-                                    utbetalerFullLønn = true,
+                            inntekt =
+                                it.inntekt?.copy(
+                                    inntektsdato = 8.desember,
                                 ),
                         )
                     }
@@ -172,69 +169,51 @@ class MapInntektsmeldingKtTest :
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                skjema.fullLønnIArbeidsgiverPerioden shouldBe
-                    FullLoennIArbeidsgiverPerioden(
-                        utbetalerFullLønn = true,
-                        begrunnelse = BegrunnelseIngenEllerRedusertUtbetalingKode.FravaerUtenGyldigGrunn,
-                        utbetalt = 4444.0,
-                    )
-
-                inntektsmelding.fullLønnIArbeidsgiverPerioden shouldBe
-                    FullLoennIArbeidsgiverPerioden(
-                        utbetalerFullLønn = true,
-                        begrunnelse = null,
-                        utbetalt = null,
-                    )
-            }
-
-            test("bruker innsendt inntektsdato dersom AGP er påkrevd") {
-                val forespoersel = Mock.forespoersel()
-                val skjema =
-                    Mock.skjema().copy(
-                        bestemmendeFraværsdag = 8.desember,
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.inntektsdato shouldBe skjema.bestemmendeFraværsdag
-                inntektsmelding.inntektsdato shouldNotBe forespoersel.forslagInntektsdato()
+                inntektsmelding.inntekt.also {
+                    it.shouldNotBeNull()
+                    it.inntektsdato shouldBe skjema.inntekt?.inntektsdato
+                    it.inntektsdato shouldNotBe forespoersel.forslagInntektsdato()
+                }
             }
 
             test("overser innsendt inntektsdato og bruker forslag (fra Spleis) dersom AGP _ikke_ er påkrevd") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdAGP()
+                val forespoersel = mockForespoersel().utenPaakrevdAGP()
                 val skjema =
-                    Mock.skjema().copy(
-                        bestemmendeFraværsdag = 14.desember,
-                    )
+                    mockSkjemaInntektsmelding().let {
+                        it.copy(
+                            inntekt =
+                                it.inntekt?.copy(
+                                    inntektsdato = 14.desember,
+                                ),
+                        )
+                    }
 
                 val inntektsmelding =
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                inntektsmelding.inntektsdato shouldNotBe skjema.bestemmendeFraværsdag
-                inntektsmelding.inntektsdato shouldBe forespoersel.forslagInntektsdato()
+                inntektsmelding.inntekt.also {
+                    it.shouldNotBeNull()
+                    it.inntektsdato shouldNotBe skjema.inntekt?.inntektsdato
+                    it.inntektsdato shouldBe forespoersel.forslagInntektsdato()
+                }
             }
 
             test("bruker beregnet bestemmende fraværsdag som inntektsdato dersom forslag (fra Spleis) til inntektsdato mangler og AGP _ikke_ er påkrevd") {
                 val forespoersel =
-                    Mock.forespoersel().utenPaakrevdAGP().copy(
+                    mockForespoersel().utenPaakrevdAGP().copy(
                         sykmeldingsperioder =
                             listOf(
                                 4.juli til 28.juli,
@@ -242,259 +221,11 @@ class MapInntektsmeldingKtTest :
                         bestemmendeFravaersdager = emptyMap(),
                     )
                 val skjema =
-                    Mock.skjema().copy(
-                        bestemmendeFraværsdag = 3.august,
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.inntektsdato shouldNotBe skjema.bestemmendeFraværsdag
-                inntektsmelding.inntektsdato shouldBe forespoersel.forslagInntektsdato()
-                inntektsmelding.inntektsdato shouldBe 4.juli
-            }
-
-            test("bruker beregnet bestemmende fraværsdag dersom AGP er påkrevd") {
-                val forespoersel =
-                    Mock.forespoersel().let {
+                    mockSkjemaInntektsmelding().let {
                         it.copy(
-                            sykmeldingsperioder =
-                                listOf(
-                                    6.mai til 9.mai,
-                                    12.mai til 27.mai,
-                                ),
-                            bestemmendeFravaersdager =
-                                mapOf(
-                                    it.orgnr to 1.mai,
-                                ),
-                        )
-                    }
-                val skjema =
-                    Mock.skjema().copy(
-                        arbeidsgiverperioder =
-                            listOf(
-                                5.mai til 9.mai,
-                                12.mai til 22.mai,
-                            ),
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.bestemmendeFraværsdag shouldBe 12.mai
-                inntektsmelding.bestemmendeFraværsdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
-            }
-
-            test("bruker beregnet bestemmende fraværsdag dersom kun refusjon er påkrevd") {
-                val forespoersel =
-                    Mock
-                        .forespoersel()
-                        .utenPaakrevdAGP()
-                        .utenPaakrevdInntekt()
-                        .let {
-                            it.copy(
-                                sykmeldingsperioder =
-                                    listOf(
-                                        5.januar til 10.januar,
-                                        14.januar til 28.januar,
-                                    ),
-                                bestemmendeFravaersdager =
-                                    mapOf(
-                                        it.orgnr to 3.januar,
-                                    ),
-                            )
-                        }
-
-                val skjema =
-                    Mock.skjema().copy(
-                        arbeidsgiverperioder =
-                            listOf(
-                                5.januar til 10.januar,
-                                14.januar til 23.januar,
-                            ),
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.bestemmendeFraværsdag shouldBe 14.januar
-                inntektsmelding.bestemmendeFraværsdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
-            }
-
-            test("bruker forslag (fra Spleis) som bestemmende fraværsdag dersom AGP _ikke_ er påkrevd") {
-                val forespoersel =
-                    Mock.forespoersel().utenPaakrevdAGP().let {
-                        it.copy(
-                            bestemmendeFravaersdager =
-                                mapOf(
-                                    it.orgnr to 8.mai,
-                                ),
-                        )
-                    }
-                val skjema =
-                    Mock.skjema().copy(
-                        fraværsperioder =
-                            listOf(
-                                15.mai til 17.juni,
-                            ),
-                        arbeidsgiverperioder = emptyList(),
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.bestemmendeFraværsdag shouldNotBe 15.mai
-                inntektsmelding.bestemmendeFraværsdag shouldBe forespoersel.forslagBestemmendeFravaersdag()
-            }
-
-            test("bruker beregnet bestemmende fraværsdag dersom forslag (fra Spleis) til bestemmende fraværsdag mangler og AGP _ikke_ er påkrevd") {
-                val forespoersel =
-                    Mock.forespoersel().utenPaakrevdAGP().copy(
-                        sykmeldingsperioder =
-                            listOf(
-                                10.august til 31.august,
-                            ),
-                        bestemmendeFravaersdager = emptyMap(),
-                    )
-                val skjema =
-                    Mock.skjema().copy(
-                        fraværsperioder =
-                            listOf(
-                                7.september til 25.september,
-                            ),
-                        arbeidsgiverperioder = emptyList(),
-                    )
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.bestemmendeFraværsdag shouldNotBe 7.september
-                inntektsmelding.bestemmendeFraværsdag shouldBe forespoersel.forslagBestemmendeFravaersdag()
-                inntektsmelding.bestemmendeFraværsdag shouldBe 10.august
-            }
-
-            test("bruker innsendt inntekt dersom inntekt er påkrevd") {
-                val forespoersel = Mock.forespoersel()
-                val skjema = Mock.skjema()
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.inntekt shouldBe skjema.inntekt
-                inntektsmelding.beregnetInntekt shouldBe skjema.inntekt.beregnetInntekt
-            }
-
-            test("bruker fastsatt inntekt (fra Spleis) dersom inntekt _ikke_ er påkrevd") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdInntekt()
-                val skjema = Mock.skjema()
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                val fastsattInntekt = 8795.0
-
-                inntektsmelding.inntekt shouldNotBe skjema.inntekt
-                inntektsmelding.beregnetInntekt shouldNotBe skjema.inntekt.beregnetInntekt
-
-                inntektsmelding.inntekt shouldBe
-                    Inntekt(
-                        bekreftet = true,
-                        beregnetInntekt = fastsattInntekt,
-                        endringÅrsak = null,
-                        manueltKorrigert = true,
-                    )
-                inntektsmelding.beregnetInntekt shouldBe fastsattInntekt
-            }
-
-            test("bruker innsendt refusjon dersom refusjon er påkrevd og AG utbetaler hele eller deler av sykepengene") {
-                val forespoersel = Mock.forespoersel()
-                val skjema = Mock.skjema()
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.refusjon shouldBe skjema.refusjon
-            }
-
-            test("bruker tom refusjon dersom refusjon _ikke_ er påkrevd, selv om skjema påstår at AG utbetaler hele eller deler av sykepengene") {
-                val forespoersel = Mock.forespoersel().utenPaakrevdRefusjon()
-                val skjema = Mock.skjema()
-
-                val inntektsmelding =
-                    mapInntektsmelding(
-                        forespoersel = forespoersel,
-                        skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
-                        virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
-                    )
-
-                inntektsmelding.refusjon shouldNotBe skjema.refusjon
-                inntektsmelding.refusjon shouldBe
-                    Refusjon(
-                        utbetalerHeleEllerDeler = false,
-                        refusjonPrMnd = null,
-                        refusjonOpphører = null,
-                        refusjonEndringer = null,
-                    )
-            }
-
-            test("bruker tom refusjon dersom refusjon er påkrevd, men AG _ikke_ utbetaler hele eller deler av sykepengene") {
-                val forespoersel = Mock.forespoersel()
-                val skjema =
-                    Mock.skjema().let {
-                        it.copy(
-                            refusjon =
-                                it.refusjon.copy(
-                                    utbetalerHeleEllerDeler = false,
+                            inntekt =
+                                it.inntekt?.copy(
+                                    inntektsdato = 3.august,
                                 ),
                         )
                     }
@@ -503,136 +234,36 @@ class MapInntektsmeldingKtTest :
                     mapInntektsmelding(
                         forespoersel = forespoersel,
                         skjema = skjema,
-                        fulltnavnArbeidstaker = "Runar fra Regnskap",
+                        aarsakInnsending = AarsakInnsending.Endring,
                         virksomhetNavn = "Skrekkinngytende smaker LLC",
-                        innsenderNavn = "Hege fra HR",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
 
-                inntektsmelding.refusjon shouldNotBe skjema.refusjon
-                inntektsmelding.refusjon shouldBe
-                    Refusjon(
-                        utbetalerHeleEllerDeler = false,
-                        refusjonPrMnd = null,
-                        refusjonOpphører = null,
-                        refusjonEndringer = null,
+                inntektsmelding.inntekt.also {
+                    it.shouldNotBeNull()
+                    it.inntektsdato shouldNotBe skjema.inntekt?.inntektsdato
+                    it.inntektsdato shouldBe forespoersel.forslagInntektsdato()
+                    it.inntektsdato shouldBe 4.juli
+                }
+            }
+
+            test("bruker tom refusjon dersom refusjon _ikke_ er påkrevd") {
+                val forespoersel = mockForespoersel().utenPaakrevdRefusjon()
+                val skjema = mockSkjemaInntektsmelding()
+
+                val inntektsmelding =
+                    mapInntektsmelding(
+                        forespoersel = forespoersel,
+                        skjema = skjema,
+                        aarsakInnsending = AarsakInnsending.Endring,
+                        virksomhetNavn = "Skrekkinngytende smaker LLC",
+                        sykmeldtNavn = "Runar fra Regnskap",
+                        avsenderNavn = "Hege fra HR",
                     )
+
+                skjema.refusjon.shouldNotBeNull()
+                inntektsmelding.refusjon.shouldBeNull()
             }
         }
     })
-
-private object Mock {
-    fun skjema(): Innsending =
-        Innsending(
-            orgnrUnderenhet = "671589013",
-            identitetsnummer = "13117800123",
-            behandlingsdager = emptyList(),
-            egenmeldingsperioder =
-                listOf(
-                    2.april til 4.april,
-                ),
-            fraværsperioder =
-                listOf(
-                    6.april til 12.april,
-                    13.april til 28.april,
-                ),
-            arbeidsgiverperioder =
-                listOf(
-                    2.april til 4.april,
-                    6.april til 18.april,
-                ),
-            bestemmendeFraværsdag = 6.april,
-            inntekt =
-                Inntekt(
-                    bekreftet = true,
-                    beregnetInntekt = 32100.0,
-                    endringÅrsak =
-                        Ferie(
-                            liste = listOf(10.mars til 20.mars),
-                        ),
-                    manueltKorrigert = true,
-                ),
-            fullLønnIArbeidsgiverPerioden =
-                FullLoennIArbeidsgiverPerioden(
-                    utbetalerFullLønn = false,
-                    begrunnelse = BegrunnelseIngenEllerRedusertUtbetalingKode.FravaerUtenGyldigGrunn,
-                    utbetalt = 4444.0,
-                ),
-            refusjon =
-                Refusjon(
-                    utbetalerHeleEllerDeler = true,
-                    refusjonPrMnd = 333.0,
-                    refusjonOpphører = 21.april,
-                ),
-            naturalytelser =
-                listOf(
-                    Naturalytelse(
-                        naturalytelse = NaturalytelseKode.KOSTDOEGN,
-                        dato = 23.april,
-                        beløp = 222.0,
-                    ),
-                ),
-            årsakInnsending = AarsakInnsending.ENDRING,
-            bekreftOpplysninger = true,
-        )
-
-    fun forespoersel(): Forespoersel {
-        val skjema = skjema()
-        return Forespoersel(
-            type = ForespoerselType.KOMPLETT,
-            orgnr = skjema.orgnrUnderenhet,
-            fnr = skjema.identitetsnummer,
-            vedtaksperiodeId = UUID.randomUUID(),
-            sykmeldingsperioder = skjema.fraværsperioder,
-            egenmeldingsperioder = skjema.egenmeldingsperioder,
-            bestemmendeFravaersdager =
-                skjema.fraværsperioder
-                    .lastOrNull()
-                    ?.let { mapOf(skjema.orgnrUnderenhet to it.fom) }
-                    .orEmpty(),
-            forespurtData = mockForespurtData(),
-            erBesvart = false,
-        )
-    }
-}
-
-private fun Forespoersel.utenPaakrevdAGP(): Forespoersel =
-    copy(
-        forespurtData =
-            forespurtData.copy(
-                arbeidsgiverperiode =
-                    ForespurtData.Arbeidsgiverperiode(
-                        paakrevd = false,
-                    ),
-            ),
-    )
-
-private fun Forespoersel.utenPaakrevdInntekt(): Forespoersel =
-    copy(
-        forespurtData =
-            forespurtData.copy(
-                inntekt =
-                    ForespurtData.Inntekt(
-                        paakrevd = false,
-                        forslag =
-                            ForslagInntekt.Fastsatt(
-                                fastsattInntekt = 8795.0,
-                            ),
-                    ),
-            ),
-    )
-
-private fun Forespoersel.utenPaakrevdRefusjon(): Forespoersel =
-    copy(
-        forespurtData =
-            forespurtData.copy(
-                refusjon =
-                    ForespurtData.Refusjon(
-                        paakrevd = false,
-                        forslag =
-                            ForslagRefusjon(
-                                perioder = emptyList(),
-                                opphoersdato = null,
-                            ),
-                    ),
-            ),
-    )

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/UtledBestemmendeFravaersdagKtTest.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/UtledBestemmendeFravaersdagKtTest.kt
@@ -1,0 +1,152 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.innsending
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
+import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
+import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
+import no.nav.helsearbeidsgiver.utils.test.date.august
+import no.nav.helsearbeidsgiver.utils.test.date.januar
+import no.nav.helsearbeidsgiver.utils.test.date.juni
+import no.nav.helsearbeidsgiver.utils.test.date.mai
+
+class UtledBestemmendeFravaersdagKtTest :
+    FunSpec({
+
+        context(::utledBestemmendeFravaersdag.name) {
+
+            test("bruker beregnet bestemmende fraværsdag dersom AGP er påkrevd") {
+                val forespoersel =
+                    mockForespoersel().let {
+                        it.copy(
+                            sykmeldingsperioder =
+                                listOf(
+                                    6.mai til 9.mai,
+                                    12.mai til 27.mai,
+                                ),
+                            bestemmendeFravaersdager =
+                                mapOf(
+                                    it.orgnr to 1.mai,
+                                ),
+                        )
+                    }
+                val inntektsmelding =
+                    mockInntektsmeldingV1().let {
+                        it.copy(
+                            agp =
+                                it.agp?.copy(
+                                    perioder =
+                                        listOf(
+                                            5.mai til 9.mai,
+                                            12.mai til 22.mai,
+                                        ),
+                                ),
+                        )
+                    }
+
+                val bestemmendeFravaersdag = utledBestemmendeFravaersdag(forespoersel, inntektsmelding)
+
+                bestemmendeFravaersdag shouldBe 12.mai
+                bestemmendeFravaersdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
+            }
+
+            test("bruker beregnet bestemmende fraværsdag dersom kun refusjon er påkrevd") {
+                val forespoersel =
+                    mockForespoersel()
+                        .utenPaakrevdAGP()
+                        .utenPaakrevdInntekt()
+                        .let {
+                            it.copy(
+                                sykmeldingsperioder =
+                                    listOf(
+                                        5.januar til 10.januar,
+                                        14.januar til 28.januar,
+                                    ),
+                                bestemmendeFravaersdager =
+                                    mapOf(
+                                        it.orgnr to 3.januar,
+                                    ),
+                            )
+                        }
+
+                val inntektsmelding =
+                    mockInntektsmeldingV1().let {
+                        it.copy(
+                            agp =
+                                it.agp?.copy(
+                                    perioder =
+                                        listOf(
+                                            5.januar til 10.januar,
+                                            14.januar til 23.januar,
+                                        ),
+                                ),
+                        )
+                    }
+
+                val bestemmendeFravaersdag = utledBestemmendeFravaersdag(forespoersel, inntektsmelding)
+
+                bestemmendeFravaersdag shouldBe 14.januar
+                bestemmendeFravaersdag shouldNotBe forespoersel.forslagBestemmendeFravaersdag()
+            }
+
+            test("bruker forslag (fra Spleis) som bestemmende fraværsdag dersom AGP _ikke_ er påkrevd og ikke kun refusjon påkrevd") {
+                val forespoersel =
+                    mockForespoersel().utenPaakrevdAGP().let {
+                        it.copy(
+                            sykmeldingsperioder =
+                                listOf(
+                                    15.mai til 17.juni,
+                                ),
+                            bestemmendeFravaersdager =
+                                mapOf(
+                                    it.orgnr to 8.mai,
+                                ),
+                        )
+                    }
+                val inntektsmelding =
+                    mockInntektsmeldingV1().let {
+                        it.copy(
+                            agp =
+                                it.agp?.copy(
+                                    perioder = emptyList(),
+                                ),
+                        )
+                    }
+
+                val bestemmendeFravaersdag = utledBestemmendeFravaersdag(forespoersel, inntektsmelding)
+
+                bestemmendeFravaersdag shouldNotBe 15.mai
+                bestemmendeFravaersdag shouldBe forespoersel.forslagBestemmendeFravaersdag()
+            }
+
+            test("bruker beregnet bestemmende fraværsdag dersom forslag (fra Spleis) mangler og AGP _ikke_ er påkrevd og ikke kun refusjon påkrevd") {
+                val forespoersel =
+                    mockForespoersel().utenPaakrevdAGP().copy(
+                        sykmeldingsperioder =
+                            listOf(
+                                10.august til 31.august,
+                            ),
+                        bestemmendeFravaersdager = emptyMap(),
+                    )
+                val inntektsmelding =
+                    mockInntektsmeldingV1().let {
+                        it.copy(
+                            agp =
+                                it.agp?.copy(
+                                    perioder =
+                                        listOf(
+                                            5.august til 20.august,
+                                        ),
+                                ),
+                        )
+                    }
+
+                val bestemmendeFravaersdag = utledBestemmendeFravaersdag(forespoersel, inntektsmelding)
+
+                bestemmendeFravaersdag shouldNotBe 5.august
+                bestemmendeFravaersdag shouldBe forespoersel.forslagBestemmendeFravaersdag()
+                bestemmendeFravaersdag shouldBe 10.august
+            }
+        }
+    })

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -275,15 +275,12 @@ class InnsendingIT : EndToEndTest() {
         val innsendtInntektsmelding =
             mapInntektsmelding(
                 forespoersel = forespoersel,
-                skjema =
-                    skjema.convert(
-                        sykmeldingsperioder = forespoersel.sykmeldingsperioder,
-                        aarsakInnsending = AarsakInnsending.Endring,
-                    ),
-                fulltnavnArbeidstaker = bjarneBetjent.navn.fulltNavn(),
+                skjema = skjema,
+                aarsakInnsending = AarsakInnsending.Endring,
                 virksomhetNavn = "Bedrift A/S",
-                innsenderNavn = maxMekker.navn.fulltNavn(),
-            )
+                sykmeldtNavn = bjarneBetjent.navn.fulltNavn(),
+                avsenderNavn = maxMekker.navn.fulltNavn(),
+            ).convert()
 
         val forespoerselSvar =
             ForespoerselSvar.Suksess(


### PR DESCRIPTION
Appen `im-api` har tatt i bruk ny skjemaklasse, og sender den til `InnsendingService`. Tar i bruk den nye klassen i sistnevnte, som forenkler mapping fra skjema til inntektsmelding.

Merk at man fremdeles sender inntektsmelding på gammelt format videre fra `InnsendingService`.