### PR TITLE
Legg til endepunkt for å sjekke tilgang til orgnummer

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
@@ -29,6 +29,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.inntektselvbestemt.inntektSe
 import no.nav.helsearbeidsgiver.inntektsmelding.api.kvittering.kvitteringRoute
 import no.nav.helsearbeidsgiver.inntektsmelding.api.lagreselvbestemtim.lagreSelvbestemtImRoute
 import no.nav.helsearbeidsgiver.inntektsmelding.api.tilgang.TilgangProducer
+import no.nav.helsearbeidsgiver.inntektsmelding.api.tilgangorgnr.tilgangOrgnrRoute
 import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
@@ -51,6 +52,7 @@ object Routes {
     const val SELVBESTEMT_INNTEKTSMELDING_MED_ID = "$SELVBESTEMT_INNTEKTSMELDING/{selvbestemtId}"
     const val KVITTERING = "/kvittering"
     const val AKTIVEORGNR = "/aktiveorgnr"
+    const val TILGANG_ORGNR = "/tilgangorgnr/{orgnr}"
 }
 
 fun main() {
@@ -121,6 +123,7 @@ fun Application.apiModule(
                 lagreSelvbestemtImRoute(rapid, tilgangskontroll, redisConnection)
                 hentSelvbestemtImRoute(rapid, tilgangskontroll, redisConnection)
                 aktiveOrgnrRoute(rapid, redisConnection)
+                tilgangOrgnrRoute(tilgangskontroll)
             }
         }
     }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
@@ -1,0 +1,37 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.api.tilgangorgnr
+
+import io.ktor.http.HttpStatusCode
+import io.ktor.server.application.call
+import io.ktor.server.response.respond
+import io.ktor.server.routing.Route
+import io.ktor.server.routing.get
+import kotlinx.serialization.builtins.serializer
+import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
+import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
+import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.ManglerAltinnRettigheterException
+import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.Tilgangskontroll
+import no.nav.helsearbeidsgiver.inntektsmelding.api.logger
+import no.nav.helsearbeidsgiver.inntektsmelding.api.response.RedisTimeoutResponse
+import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondForbidden
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+
+fun Route.tilgangOrgnrRoute(tilgangskontroll: Tilgangskontroll) {
+    get(Routes.TILGANG_ORGNR) {
+        val orgnr = call.parameters["orgnr"]
+        try {
+            if (orgnr.isNullOrEmpty() || !Orgnr.erGyldig(orgnr)) {
+                call.respond(HttpStatusCode.BadRequest, "Ugyldig orgnr")
+            } else {
+                tilgangskontroll.validerTilgangTilOrg(call.request, orgnr)
+            }
+        } catch (e: ManglerAltinnRettigheterException) {
+            respondForbidden("Du har ikke rettigheter for organisasjon.", String.serializer())
+        } catch (_: RedisPollerTimeoutException) {
+            logger.error("Fikk timeout for tilgangsjekk orgnr.")
+            sikkerLogger.error("Fikk timeout for tilgangsjekk orgnr.")
+            respondInternalServerError(RedisTimeoutResponse(), RedisTimeoutResponse.serializer())
+        }
+    }
+}

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
@@ -5,16 +5,12 @@ import io.ktor.server.application.call
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
-import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.ManglerAltinnRettigheterException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.Tilgangskontroll
 import no.nav.helsearbeidsgiver.inntektsmelding.api.logger
-import no.nav.helsearbeidsgiver.inntektsmelding.api.response.RedisTimeoutResponse
 import no.nav.helsearbeidsgiver.inntektsmelding.api.sikkerLogger
-import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondForbidden
-import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 fun Route.tilgangOrgnrRoute(tilgangskontroll: Tilgangskontroll) {
@@ -25,13 +21,22 @@ fun Route.tilgangOrgnrRoute(tilgangskontroll: Tilgangskontroll) {
                 call.respond(HttpStatusCode.BadRequest, "Ugyldig orgnr")
             } else {
                 tilgangskontroll.validerTilgangTilOrg(call.request, orgnr)
+                call.respond(HttpStatusCode.OK)
             }
-        } catch (e: ManglerAltinnRettigheterException) {
-            respondForbidden("Du har ikke rettigheter for organisasjon.", String.serializer())
+        } catch (_: ManglerAltinnRettigheterException) {
+            call.respond(HttpStatusCode.Forbidden, "Du har ikke rettigheter for organisasjon.")
         } catch (_: RedisPollerTimeoutException) {
-            logger.error("Fikk timeout for tilgangsjekk orgnr.")
-            sikkerLogger.error("Fikk timeout for tilgangsjekk orgnr.")
-            respondInternalServerError(RedisTimeoutResponse(), RedisTimeoutResponse.serializer())
+            "Fikk timeout for tilgangsjekk orgnr.".also {
+                logger.error(it)
+                sikkerLogger.error(it)
+            }
+            call.respond(HttpStatusCode.InternalServerError, "Teknisk feil")
+        } catch (e: Exception) {
+            "Ukjent feil".also {
+                logger.error(it)
+                sikkerLogger.error(it, e)
+            }
+            call.respond(HttpStatusCode.InternalServerError, "Teknisk feil")
         }
     }
 }

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangselvbestemt/TilgangOrgnrRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangselvbestemt/TilgangOrgnrRouteKtTest.kt
@@ -1,0 +1,43 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.api.inntektselvbestemt
+
+import io.kotest.matchers.shouldBe
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.HttpStatusCode
+import io.mockk.clearAllMocks
+import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+private val pathMedUgyldigOrgnr =
+    Routes.PREFIX +
+        Routes.TILGANG_ORGNR.replaceFirst("{orgnr}", "heipådeg")
+
+private val pathUtenId =
+    Routes.PREFIX +
+        Routes.TILGANG_ORGNR.replaceFirst("{orgnr}", "")
+
+class TilgangOrgnrRouteKtTest : ApiTest() {
+    @BeforeEach
+    fun setup() {
+        clearAllMocks()
+    }
+
+    @Test
+    fun `ugyldig orgnr skal gi bad request`() =
+        testApi {
+            val response = get(pathMedUgyldigOrgnr)
+
+            val actualJson = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            actualJson shouldBe "Ugyldig orgnr"
+        }
+
+    @Test
+    fun `manglende orgnr skal gi 404 Not found`() =
+        testApi {
+            val response = get(pathUtenId)
+            response.status shouldBe HttpStatusCode.NotFound
+        }
+}

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangselvbestemt/TilgangOrgnrRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangselvbestemt/TilgangOrgnrRouteKtTest.kt
@@ -4,10 +4,21 @@ import io.kotest.matchers.shouldBe
 import io.ktor.client.statement.bodyAsText
 import io.ktor.http.HttpStatusCode
 import io.mockk.clearAllMocks
+import io.mockk.coEvery
+import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.harTilgangResultat
+import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ikkeTilgangResultat
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.util.UUID
+
+private val pathMedGyldigOrgnr =
+    Routes.PREFIX +
+        Routes.TILGANG_ORGNR.replaceFirst("{orgnr}", Orgnr.genererGyldig().toString())
 
 private val pathMedUgyldigOrgnr =
     Routes.PREFIX +
@@ -22,6 +33,32 @@ class TilgangOrgnrRouteKtTest : ApiTest() {
     fun setup() {
         clearAllMocks()
     }
+
+    @Test
+    fun `gyldig orgnr og tilgang skal gi 200 OK`() =
+        testApi {
+            coEvery { mockRedisConnection.get(any()) } returns harTilgangResultat
+
+            val response = get(pathMedGyldigOrgnr)
+
+            val actualJson = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.OK
+            actualJson shouldBe ""
+        }
+
+    @Test
+    fun `gyldig orgnr og manglende tilgang skal gi 403 Forbidden`() =
+        testApi {
+            coEvery { mockRedisConnection.get(any()) } returns ikkeTilgangResultat
+
+            val response = get(pathMedGyldigOrgnr)
+
+            val actualJson = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.Forbidden
+            actualJson shouldBe "Du har ikke rettigheter for organisasjon."
+        }
 
     @Test
     fun `ugyldig orgnr skal gi bad request`() =
@@ -39,5 +76,31 @@ class TilgangOrgnrRouteKtTest : ApiTest() {
         testApi {
             val response = get(pathUtenId)
             response.status shouldBe HttpStatusCode.NotFound
+        }
+
+    @Test
+    fun `timeout mot redis gir 500-feil`() =
+        testApi {
+            coEvery { mockRedisConnection.get(any()) } throws RedisPollerTimeoutException(UUID.randomUUID())
+
+            val response = get(pathMedGyldigOrgnr)
+
+            val actualJson = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.InternalServerError
+            actualJson shouldBe "Teknisk feil"
+        }
+
+    @Test
+    fun `ukjent feil gir 500-feil`() =
+        testApi {
+            coEvery { mockRedisConnection.get(any()) } throws NullPointerException()
+
+            val response = get(pathMedGyldigOrgnr)
+
+            val actualJson = response.bodyAsText()
+
+            response.status shouldBe HttpStatusCode.InternalServerError
+            actualJson shouldBe "Teknisk feil"
         }
 }


### PR DESCRIPTION
Dette trengs i forbindelse med selvbestemtskjema-flyten for å sikre at innsender faktisk har tilgang til å hente opplysninger fra Flex for det gitte orgnummeret.