### PR TITLE
feillytter - støtte for transaksjoner som går over flere behov.

### DIFF
--- a/config/db/dev-gcp.yml
+++ b/config/db/dev-gcp.yml
@@ -5,6 +5,7 @@ database:
   - name: inntektsmelding
     users: [ simba_datastream_bruker ]
 logical_decoding: true
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-db

--- a/config/db/prod-gcp.yml
+++ b/config/db/prod-gcp.yml
@@ -5,6 +5,7 @@ database:
   - name: inntektsmelding
     users: [ simba_datastream_bruker ]
 logical_decoding: true
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-db

--- a/config/feil-behandler/dev-gcp.yml
+++ b/config/feil-behandler/dev-gcp.yml
@@ -3,6 +3,7 @@ azure:
   enabled: true
 database:
   - name: im-error-recovery
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-feil-behandler

--- a/config/feil-behandler/prod-gcp.yml
+++ b/config/feil-behandler/prod-gcp.yml
@@ -3,6 +3,7 @@ azure:
   enabled: true
 database:
   - name: im-error-recovery
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-feil-behandler

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -57,6 +57,7 @@ spec:
   gcp:
     sqlInstances:
       - type: POSTGRES_14
+        tier: {{ dbTier }}
         databases:
           {{#each database as |db| }}
           - name: {{ db.name }}

--- a/config/notifikasjon/dev-gcp.yml
+++ b/config/notifikasjon/dev-gcp.yml
@@ -4,6 +4,7 @@ azure:
 database:
   - name: notifikasjon
 logical_decoding: true
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-notifikasjon

--- a/config/notifikasjon/prod-gcp.yml
+++ b/config/notifikasjon/prod-gcp.yml
@@ -4,6 +4,7 @@ azure:
 database:
   - name: notifikasjon
 logical_decoding: true
+dbTier: db-f1-micro
 envFrom:
   - type: secret
     name: google-sql-im-notifikasjon

--- a/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -9,6 +9,7 @@ import no.nav.helse.rapids_rivers.RapidsConnection
 import no.nav.helse.rapids_rivers.River
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.ModelUtils.toFailOrNull
@@ -16,8 +17,11 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.toPretty
 import no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.prosessor.FeilProsessor
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.sql.SQLException
+import java.util.UUID
 
 class FeilLytter(
     rapidsConnection: RapidsConnection,
@@ -66,7 +70,9 @@ class FeilLytter(
             if (eksisterendeJobb != null) {
                 if (fail.utloesendeMelding.toMap()[Key.BEHOV] != eksisterendeJobb.data.parseJson().toMap()[Key.BEHOV]) {
                     sikkerLogger.info("Id $jobbId finnes fra før med annet behov. Lagrer en ny jobb.")
-                    lagre(Bakgrunnsjobb(type = jobbType, data = fail.utloesendeMelding.toString()))
+                    val nyTransaksjonId = UUID.randomUUID()
+                    val utloesendeMeldingMedNyTransaksjonId = fail.utloesendeMelding.toMap() + mapOf(Key.UUID to nyTransaksjonId.toJson(UuidSerializer))
+                    lagre(Bakgrunnsjobb(nyTransaksjonId, type = jobbType, data = utloesendeMeldingMedNyTransaksjonId.toJson().toString()))
                 } else {
                     oppdater(eksisterendeJobb)
                 }


### PR DESCRIPTION
En svakhet i feillytter gjorde at det ble laget nye jobber heller enn å oppdatere eksisterende, i spesialtilfeller der flere steg / behov feilet i den samme simba-transaksjonen (Steg i Service).

I tillegg krever nais-konfig nå at dbTier settes eksplisitt, oppdatert dette for alle instanser.