### PR TITLE
Legg til kolonne for å lagre im skjema

### DIFF
--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
@@ -1,6 +1,7 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.db.tabell
 
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import org.jetbrains.exposed.sql.Table
@@ -24,6 +25,12 @@ object InntektsmeldingEntitet : Table("inntektsmelding") {
             name = "ekstern_inntektsmelding",
             jsonConfig = jsonConfig,
             kSerializer = EksternInntektsmelding.serializer(),
+        ).nullable()
+    val skjema =
+        jsonb<SkjemaInntektsmelding>(
+            name = "skjema",
+            jsonConfig = jsonConfig,
+            kSerializer = SkjemaInntektsmelding.serializer(),
         ).nullable()
     val innsendt = datetime("innsendt")
     val journalpostId = varchar("journalpostid", 30).nullable()

--- a/db/src/main/resources/db/migration/V16__inntektsmelding_skjema.sql
+++ b/db/src/main/resources/db/migration/V16__inntektsmelding_skjema.sql
@@ -1,0 +1,2 @@
+ALTER TABLE inntektsmelding
+    ADD COLUMN skjema jsonb;


### PR DESCRIPTION
Vi ønsker å splitte opp flyten for innsending av inntektsmeldinger i to steg, med lagring av skjema i steg 1 og beriking i steg 2 (se `Del opp innsending i et synkront og et asynkront steg` https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/582).

For å gjøre testing av https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/582 enklere i dev, så ønsker vi å ta inn databasemigreringen i main først.