### PR TITLE
Inkluder egenmeldinger ved beregning av bestemmende fraværsdag og inntektsdato

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -131,7 +131,7 @@ private fun Inntektsmelding.tilKvitteringSimba(): KvitteringSimba =
         behandlingsdager = behandlingsdager,
         egenmeldingsperioder = egenmeldingsperioder,
         arbeidsgiverperioder = arbeidsgiverperioder,
-        bestemmendeFraværsdag = bestemmendeFraværsdag,
+        bestemmendeFraværsdag = inntektsdato ?: bestemmendeFraværsdag, // Frontend tolker feltet bestemmendeFraværsdag som om det var inntektsdato. Vil bli orden på dette ved overgang til v1.Inntektsmelding, som kun har inntektsdato (ikke bestemmende fraværsdag).
         fraværsperioder = fraværsperioder,
         inntekt =
             Inntekt(

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -131,7 +131,9 @@ private fun Inntektsmelding.tilKvitteringSimba(): KvitteringSimba =
         behandlingsdager = behandlingsdager,
         egenmeldingsperioder = egenmeldingsperioder,
         arbeidsgiverperioder = arbeidsgiverperioder,
-        bestemmendeFraværsdag = inntektsdato ?: bestemmendeFraværsdag, // Frontend tolker feltet bestemmendeFraværsdag som om det var inntektsdato. Vil bli orden på dette ved overgang til v1.Inntektsmelding, som kun har inntektsdato (ikke bestemmende fraværsdag).
+        // Frontend tolker feltet bestemmendeFraværsdag som om det var inntektsdato.
+        // Vi vil slippe denne hacken ved overgang til v1.Inntektsmelding, som kun inneholder inntektsdato (ikke bestemmende fraværsdag).
+        bestemmendeFraværsdag = inntektsdato ?: bestemmendeFraværsdag,
         fraværsperioder = fraværsperioder,
         inntekt =
             Inntekt(

--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/UtledBestemmendeFravaersdag.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/UtledBestemmendeFravaersdag.kt
@@ -23,7 +23,7 @@ fun utledBestemmendeFravaersdag(
     ) {
         bestemmendeFravaersdag(
             arbeidsgiverperioder = inntektsmelding.agp?.perioder.orEmpty(),
-            sykmeldingsperioder = forespoersel.sykmeldingsperioder,
+            sykefravaersperioder = forespoersel.sykmeldingsperioder,
         )
     } else {
         forespoersel.forslagBestemmendeFravaersdag()

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -47,12 +47,12 @@ data class Forespoersel(
         bestemmendeFravaersdager.minus(orgnr).minOfOrNull {
             it.value
         }
-}
 
-private fun finnTidligste(
-    spleisForslag: LocalDate?,
-    beregnet: LocalDate,
-): LocalDate = listOfNotNull(spleisForslag, beregnet).min()
+    private fun finnTidligste(
+        spleisForslag: LocalDate?,
+        beregnet: LocalDate,
+    ): LocalDate = listOfNotNull(spleisForslag, beregnet).min()
+}
 
 enum class ForespoerselType {
     KOMPLETT,

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -24,21 +24,35 @@ data class Forespoersel(
     val erBesvart: Boolean,
 ) {
     fun forslagBestemmendeFravaersdag(): LocalDate =
-        bestemmendeFravaersdager[orgnr]
-            ?: bestemmendeFravaersdag(
-                arbeidsgiverperioder = emptyList(),
-                sykmeldingsperioder = sykmeldingsperioder,
-            )
+        finnTidligste(
+            spleisForslag = bestemmendeFravaersdager[orgnr],
+            beregnet =
+                bestemmendeFravaersdag(
+                    arbeidsgiverperioder = emptyList(),
+                    sykmeldingsperioder = sykmeldingsperioder + egenmeldingsperioder,
+                ),
+        )
 
     fun forslagInntektsdato(): LocalDate =
-        bestemmendeFravaersdager.minOfOrNull { it.value }
-            ?: bestemmendeFravaersdag(
-                arbeidsgiverperioder = emptyList(),
-                sykmeldingsperioder = sykmeldingsperioder,
-            )
+        finnTidligste(
+            spleisForslag = bestemmendeFravaersdager.minOfOrNull { it.value },
+            beregnet =
+                bestemmendeFravaersdag(
+                    arbeidsgiverperioder = emptyList(),
+                    sykmeldingsperioder = sykmeldingsperioder + egenmeldingsperioder,
+                ),
+        )
 
-    fun eksternBestemmendeFravaersdag(): LocalDate? = bestemmendeFravaersdager.minus(orgnr).minOfOrNull { it.value }
+    fun eksternBestemmendeFravaersdag(): LocalDate? =
+        bestemmendeFravaersdager.minus(orgnr).minOfOrNull {
+            it.value
+        }
 }
+
+private fun finnTidligste(
+    spleisForslag: LocalDate?,
+    beregnet: LocalDate,
+): LocalDate = listOfNotNull(spleisForslag, beregnet).min()
 
 enum class ForespoerselType {
     KOMPLETT,

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -29,7 +29,7 @@ data class Forespoersel(
             beregnet =
                 bestemmendeFravaersdag(
                     arbeidsgiverperioder = emptyList(),
-                    sykmeldingsperioder = sykmeldingsperioder + egenmeldingsperioder,
+                    sykefravaersperioder = sykmeldingsperioder + egenmeldingsperioder,
                 ),
         )
 
@@ -39,7 +39,7 @@ data class Forespoersel(
             beregnet =
                 bestemmendeFravaersdag(
                     arbeidsgiverperioder = emptyList(),
-                    sykmeldingsperioder = sykmeldingsperioder + egenmeldingsperioder,
+                    sykefravaersperioder = sykmeldingsperioder + egenmeldingsperioder,
                 ),
         )
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-# Plugin  versions
+# Plugin versions
 kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.1
+hagDomeneInntektsmeldingVersion=0.1.2
 junitJupiterVersion=5.10.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-# Plugin versions
+# Plugin  versions
 kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 


### PR DESCRIPTION
**Bakgrunn**
Spleis inkluderer ikke lenger egenmeldingsperioder når de sender oss forslag til bestemmende fraværsdag gjennom inntektsmeldingforespørslene.

**Løsning**
1. Beregn bestemmende fraværsdag med utgangspunkt i _både_ sykmeldingsperioder og egenmeldingsperioder. Bruk den tidligste av den beregnede og den Spleis-foreslåtte datoen.
2. Det kom fram etter samtaler med frontend-teamet at feltet `bestemmendeFraværsdag` brukes på kvitteringssiden i frontend som om det er inntektsdato (disse kan være ulike ved flere arbeidsforhold). Dette gjorde at vi viste frem feil dato på kvitteringen. Inntil vi får gjort jobben med å bytte til nytt `v1.Inntektsmelding`-objekt er en workaround at vi gir frontend inntektsdatoen på dette feltet dersom den eksisterer.