### PR TITLE
bump hag-domene til 0.1.4 - setter vedtaksperiode til default null

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.3
+hagDomeneInntektsmeldingVersion=0.1.4
 junitJupiterVersion=5.10.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.8.1


### PR DESCRIPTION
0.1.3 innførte vedtaksperiodeID i InntektsmeldingV1-formatet, som oversettes fra selvbestemt-payload. 
Selvbestemt payloaden har ikke vedtaksperiodeID satt i allerede innsendte (eller de nye, inntil dette kommer fra frontend), så deserialisering fra database leder til MissingFieldException. 
Versjon 0.1.4 setter vedtaksperiodeID til defaultverdi null i v1.Inntektsmelding
