### PR TITLE
Bump til nyeste domene for å gjøre selvbestemt innsending bakoverkompatibel

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.4
+hagDomeneInntektsmeldingVersion=0.1.5-SNAPSHOT
 junitJupiterVersion=5.10.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,8 +4,8 @@ kotlin.code.style=official
 kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 
-# Dependency  versions
-hagDomeneInntektsmeldingVersion=0.1.5-SNAPSHOT
+# Dependency versions
+hagDomeneInntektsmeldingVersion=0.1.5
 junitJupiterVersion=5.10.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.8.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ kotlin.code.style=official
 kotlinVersion=2.0.0
 kotlinterVersion=4.4.0
 
-# Dependency versions
+# Dependency  versions
 hagDomeneInntektsmeldingVersion=0.1.5-SNAPSHOT
 junitJupiterVersion=5.10.3
 kotestVersion=5.9.1


### PR DESCRIPTION
Det viste seg at uten en defaultverdi for vedtaksperiodeId, så brakk vi innsendingen for selvbestemte IMer. Se https://github.com/navikt/hag-domene-inntektsmelding/pull/32
