### PR TITLE
Rens vekk logging av bestemmende fraværsdag som vi ikke trenger lenger

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -225,19 +225,9 @@ class BerikInntektsmeldingService(
                 sikkerLogger.error(it)
             }
         }
-        val gammeltFormat = inntektsmelding.convert()
-        val defaultUtregnetGammeltFormat = gammeltFormat.bestemmendeFraværsdag
-        if (bestemmendeFravaersdag != defaultUtregnetGammeltFormat) {
-            (
-                "Utledning av bestemmendeFraværsdag er ikke konsistent for id ${inntektsmelding.id}. " +
-                    "Utledet var: $bestemmendeFravaersdag, konvertert gir: $defaultUtregnetGammeltFormat"
-            ).also {
-                logger.error(it)
-                sikkerLogger.error(it)
-            }
-        }
-        // TODO: hvorfor utleder vi to ganger!? Droppe copy..?
-        val inntektsmeldingGammeltFormat = gammeltFormat.copy(bestemmendeFraværsdag = bestemmendeFravaersdag)
+
+        val inntektsmeldingGammeltFormat = inntektsmelding.convert().copy(bestemmendeFraværsdag = bestemmendeFravaersdag)
+
         rapid
             .publish(
                 Key.EVENT_NAME to eventName.toJson(),


### PR DESCRIPTION
**Bakgrunn**
Jeg og @mortenbyhring var litt usikre på om den praktiske forskjellen mellom utledningen av bestemmende fraværsdag og defaultverdien som settes når man bruker `.convert()` for å konvertere fra ny IM-dataklasse til gammel. Det viser seg (som mistenkt) at de ikke alltid er like, og at den utledede gir den mest presise verdien (tar hensyn til agp og egenmeldingsdager).

**Løsning**
Fjern ekstra logging.