### PR TITLE
Slutt å hente lagrede IMer i Beriktjenesten

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -12,14 +12,13 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.domene.Person
-import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed5Steg
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed4Steg
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -46,27 +45,21 @@ data class Steg1(
 )
 
 data class Steg2(
-    val aarsakInnsending: AarsakInnsending,
-    val tidligereInntektsmelding: ResultJson,
-    val tidligereEksternInntektsmelding: ResultJson,
-)
-
-data class Steg3(
     val orgnrMedNavn: Map<Orgnr, String>,
 )
 
-data class Steg4(
+data class Steg3(
     val personer: Map<Fnr, Person>,
 )
 
-data class Steg5(
+data class Steg4(
     val inntektsmelding: Inntektsmelding,
     val erDuplikat: Boolean,
 )
 
 class BerikInntektsmeldingService(
     private val rapid: RapidsConnection,
-) : ServiceMed5Steg<Steg0, Steg1, Steg2, Steg3, Steg4, Steg5>() {
+) : ServiceMed4Steg<Steg0, Steg1, Steg2, Steg3, Steg4>() {
     override val logger = logger()
     override val sikkerLogger = sikkerLogger()
 
@@ -85,37 +78,18 @@ class BerikInntektsmeldingService(
             forespoersel = Key.FORESPOERSEL_SVAR.les(Forespoersel.serializer(), melding),
         )
 
-    override fun lesSteg2(melding: Map<Key, JsonElement>): Steg2 {
-        // TODO: Fjern hele dette steget etter at vi har gått over til å bruke forespoersel.erBesvart til å avgjøre aarsakInnsending
-        val tidligereInntektsmelding = Key.LAGRET_INNTEKTSMELDING.les(ResultJson.serializer(), melding)
-        val tidligereEksternInntektsmelding = Key.EKSTERN_INNTEKTSMELDING.les(ResultJson.serializer(), melding)
-
-        val aarsakInnsending =
-            if (tidligereInntektsmelding.success == null && tidligereEksternInntektsmelding.success == null) {
-                AarsakInnsending.Ny
-            } else {
-                AarsakInnsending.Endring
-            }
-
-        return Steg2(
-            aarsakInnsending = aarsakInnsending,
-            tidligereInntektsmelding = tidligereInntektsmelding,
-            tidligereEksternInntektsmelding = tidligereEksternInntektsmelding,
+    override fun lesSteg2(melding: Map<Key, JsonElement>): Steg2 =
+        Steg2(
+            orgnrMedNavn = Key.VIRKSOMHETER.les(orgMapSerializer, melding),
         )
-    }
 
     override fun lesSteg3(melding: Map<Key, JsonElement>): Steg3 =
         Steg3(
-            orgnrMedNavn = Key.VIRKSOMHETER.les(orgMapSerializer, melding),
+            personer = Key.PERSONER.les(personMapSerializer, melding),
         )
 
     override fun lesSteg4(melding: Map<Key, JsonElement>): Steg4 =
         Steg4(
-            personer = Key.PERSONER.les(personMapSerializer, melding),
-        )
-
-    override fun lesSteg5(melding: Map<Key, JsonElement>): Steg5 =
-        Steg5(
             inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), melding),
             erDuplikat = Key.ER_DUPLIKAT_IM.les(Boolean.serializer(), melding),
         )
@@ -144,24 +118,6 @@ class BerikInntektsmeldingService(
         rapid
             .publish(
                 Key.EVENT_NAME to eventName.toJson(),
-                Key.BEHOV to BehovType.HENT_LAGRET_IM.toJson(),
-                Key.UUID to steg0.transaksjonId.toJson(),
-                Key.DATA to
-                    data
-                        .plus(Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson())
-                        .toJson(),
-            ).also { loggBehovPublisert(BehovType.HENT_LAGRET_IM, it) }
-    }
-
-    override fun utfoerSteg2(
-        data: Map<Key, JsonElement>,
-        steg0: Steg0,
-        steg1: Steg1,
-        steg2: Steg2,
-    ) {
-        rapid
-            .publish(
-                Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
                 Key.UUID to steg0.transaksjonId.toJson(),
                 Key.DATA to
@@ -171,12 +127,11 @@ class BerikInntektsmeldingService(
             ).also { loggBehovPublisert(BehovType.HENT_VIRKSOMHET_NAVN, it) }
     }
 
-    override fun utfoerSteg3(
+    override fun utfoerSteg2(
         data: Map<Key, JsonElement>,
         steg0: Steg0,
         steg1: Steg1,
         steg2: Steg2,
-        steg3: Steg3,
     ) {
         rapid
             .publish(
@@ -195,17 +150,16 @@ class BerikInntektsmeldingService(
             ).also { loggBehovPublisert(BehovType.HENT_PERSONER, it) }
     }
 
-    override fun utfoerSteg4(
+    override fun utfoerSteg3(
         data: Map<Key, JsonElement>,
         steg0: Steg0,
         steg1: Steg1,
         steg2: Steg2,
         steg3: Steg3,
-        steg4: Steg4,
     ) {
-        val orgNavn = steg3.orgnrMedNavn[steg1.forespoersel.orgnr.let(::Orgnr)] ?: UKJENT_VIRKSOMHET
-        val sykmeldtNavn = steg4.personer[steg1.forespoersel.fnr.let(::Fnr)]?.navn ?: UKJENT_NAVN
-        val avsenderNavn = steg4.personer[steg0.avsenderFnr]?.navn ?: UKJENT_NAVN
+        val orgNavn = steg2.orgnrMedNavn[steg1.forespoersel.orgnr.let(::Orgnr)] ?: UKJENT_VIRKSOMHET
+        val sykmeldtNavn = steg3.personer[steg1.forespoersel.fnr.let(::Fnr)]?.navn ?: UKJENT_NAVN
+        val avsenderNavn = steg3.personer[steg0.avsenderFnr]?.navn ?: UKJENT_NAVN
         val aarsakInnsending = if (steg1.forespoersel.erBesvart) AarsakInnsending.Endring else AarsakInnsending.Ny
 
         val inntektsmelding =
@@ -247,22 +201,21 @@ class BerikInntektsmeldingService(
             ).also { loggBehovPublisert(BehovType.LAGRE_IM, it) }
     }
 
-    override fun utfoerSteg5(
+    override fun utfoerSteg4(
         data: Map<Key, JsonElement>,
         steg0: Steg0,
         steg1: Steg1,
         steg2: Steg2,
         steg3: Steg3,
         steg4: Steg4,
-        steg5: Steg5,
     ) {
-        if (!steg5.erDuplikat) {
+        if (!steg4.erDuplikat) {
             val publisert =
                 rapid.publish(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
                     Key.UUID to steg0.transaksjonId.toJson(),
                     Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
-                    Key.INNTEKTSMELDING_DOKUMENT to steg5.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                    Key.INNTEKTSMELDING_DOKUMENT to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
                     Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                 )
 

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
@@ -186,40 +186,6 @@ abstract class ServiceMed4Steg<S0, S1, S2, S3, S4> : ServiceMed3Steg<S0, S1, S2,
     }
 }
 
-abstract class ServiceMed5Steg<S0, S1, S2, S3, S4, S5> : ServiceMed4Steg<S0, S1, S2, S3, S4>() {
-    protected abstract fun lesSteg5(melding: Map<Key, JsonElement>): S5
-
-    protected abstract fun utfoerSteg5(
-        data: Map<Key, JsonElement>,
-        steg0: S0,
-        steg1: S1,
-        steg2: S2,
-        steg3: S3,
-        steg4: S4,
-        steg5: S5,
-    )
-
-    override fun onData(melding: Map<Key, JsonElement>) {
-        runCatching {
-            Septuple(
-                first = lesData(melding),
-                second = lesSteg0(melding),
-                third = lesSteg1(melding),
-                fourth = lesSteg2(melding),
-                fifth = lesSteg3(melding),
-                sixth = lesSteg4(melding),
-                seventh = lesSteg5(melding),
-            )
-        }.onSuccess {
-            medLoggfelt(it.second) {
-                utfoerSteg5(it.first, it.second, it.third, it.fourth, it.fifth, it.sixth, it.seventh)
-            }
-        }.onFailure {
-            super.onData(melding)
-        }
-    }
-}
-
 private class Quadruple<S0, S1, S2, S3>(
     val first: S0,
     val second: S1,
@@ -242,14 +208,4 @@ private class Sextuple<S0, S1, S2, S3, S4, S5>(
     val fourth: S3,
     val fifth: S4,
     val sixth: S5,
-)
-
-private class Septuple<S0, S1, S2, S3, S4, S5, S6>(
-    val first: S0,
-    val second: S1,
-    val third: S2,
-    val fourth: S3,
-    val fifth: S4,
-    val sixth: S5,
-    val seventh: S6,
 )

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -1,7 +1,6 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest
 
 import io.kotest.assertions.throwables.shouldNotThrowAny
-import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -16,7 +15,6 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.domene.ForespoerselType
-import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
@@ -99,24 +97,6 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
                 data[Key.FORESPOERSEL_SVAR]?.fromJson(Forespoersel.serializer()) shouldBe Mock.forespoersel
-            }
-
-        // Tidligere inntektsmelding hentet
-        messages
-            .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.LAGRET_INNTEKTSMELDING, nestedData = true)
-            .filter(Key.EKSTERN_INNTEKTSMELDING, nestedData = true)
-            .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
-            .verifiserForespoerselIdFraSkjema()
-            .also {
-                it shouldContainKey Key.DATA
-
-                val data = it[Key.DATA].shouldNotBeNull().toMap()
-                val tidligereInntektsmeldingResult = ResultJson(success = tidligereInntektsmelding.toJson(Inntektsmelding.serializer()))
-
-                data[Key.LAGRET_INNTEKTSMELDING]?.fromJson(ResultJson.serializer()) shouldBe tidligereInntektsmeldingResult
-                data[Key.EKSTERN_INNTEKTSMELDING]?.fromJson(ResultJson.serializer()) shouldBe ResultJson(success = null)
             }
 
         // Virksomhetsnavn hentet
@@ -242,24 +222,6 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
                 data[Key.FORESPOERSEL_SVAR]?.fromJson(Forespoersel.serializer()) shouldBe Mock.forespoersel
-            }
-
-        // Tidligere inntektsmelding hentet
-        messages
-            .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.LAGRET_INNTEKTSMELDING, nestedData = true)
-            .filter(Key.EKSTERN_INNTEKTSMELDING, nestedData = true)
-            .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
-            .verifiserForespoerselIdFraSkjema()
-            .also {
-                it shouldContainKey Key.DATA
-
-                val data = it[Key.DATA].shouldNotBeNull().toMap()
-                val tidligereInntektsmeldingResult = ResultJson(success = tidligereInntektsmelding.toJson(Inntektsmelding.serializer()))
-
-                data[Key.LAGRET_INNTEKTSMELDING]?.fromJson(ResultJson.serializer()) shouldBe tidligereInntektsmeldingResult
-                data[Key.EKSTERN_INNTEKTSMELDING]?.fromJson(ResultJson.serializer()) shouldBe ResultJson(success = null)
             }
 
         // Virksomhetsnavn hentet


### PR DESCRIPTION
**Bakgrunn**
Etter endringen i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/677 så trenger vi ikke lenger hente lagrede IMer i beriktjenesten. Dette er fordi vi nå bruker `forespoersel.erBesvart` fra Storebror til å avgjøre `aarsakInnsending` istedenfor lagrede IMer.

**Løsning**
Fjern steget i BerikInntektsmeldingService som henter lagrede IMer. Siden dette skjedde i `steg2`, så forskyver rekken av steg seg ett hakk fremover og vi vil ikke lenger ha `steg5`. (`Steg5` blir `steg4`, `steg4` blir `steg3`, `steg3` blir `steg2`. `Steg0` og `steg1` forblir uendret)