### PR TITLE
Klargjør bytte av feltnøkkel

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -194,7 +194,9 @@ class BerikInntektsmeldingService(
                         .plus(
                             mapOf(
                                 Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
+                                // TODO Fjern Key.INNTEKTSMELDING etter overgangsperiode
                                 Key.INNTEKTSMELDING to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
+                                Key.INNTEKTSMELDING_DOKUMENT to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
                                 Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                             ),
                         ).toJson(),


### PR DESCRIPTION
Jeg ønsker å bytte `Key.INNTEKTSMELDING` med `Key.INNTEKTSMELDING_DOKUMENT`, for å kunne bruke førstnevnte til `InntektsmeldingV1` i et senere steg. De fleste andre steder har det samme forholdet mellom gammel og ny nøkkel og IM-klasse.