### PR TITLE
Bytt feltnøkkel for inntektsmelding

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -90,7 +90,7 @@ class BerikInntektsmeldingService(
 
     override fun lesSteg4(melding: Map<Key, JsonElement>): Steg4 =
         Steg4(
-            inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), melding),
+            inntektsmelding = Key.INNTEKTSMELDING_DOKUMENT.les(Inntektsmelding.serializer(), melding),
             erDuplikat = Key.ER_DUPLIKAT_IM.les(Boolean.serializer(), melding),
         )
 
@@ -194,8 +194,6 @@ class BerikInntektsmeldingService(
                         .plus(
                             mapOf(
                                 Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
-                                // TODO Fjern Key.INNTEKTSMELDING etter overgangsperiode
-                                Key.INNTEKTSMELDING to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
                                 Key.INNTEKTSMELDING_DOKUMENT to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
                                 Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                             ),

--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/UtledBestemmendeFravaersdag.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/UtledBestemmendeFravaersdag.kt
@@ -10,7 +10,7 @@ import java.time.LocalDate
  * - Vi ber om AGP. Da kan AGP inneholde info som Spleis ikke vet om, f. eks. egenmeldinger.
  * - Vi ber kun om refusjon. Da kan Spleis sitt forslag inneholde feil`*` dersom sykmeldt har mer enn én arbeidsgiver.
  *
- * `*` Det er ikke feil, men forslagene fra Spleis er egentlig inntektsdatoer, ikke BF-er.
+ * `*` Det er ikke feil, men forslagene fra Spleis er egentlig inntektsdatoer per arbeidsgiver, ikke BF-er.
  * For én arbeidsgiver så er disse datoene like, men det er de nødvendigvis ikke ved mer enn én arbeidsgiver.
 */
 fun utledBestemmendeFravaersdag(

--- a/berik-inntektsmelding-service/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
+++ b/berik-inntektsmelding-service/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
@@ -102,11 +102,7 @@ class BerikInntektsmeldingServiceTest :
                 it.lesBehov() shouldBe BehovType.LAGRE_IM
 
                 val data = it.lesData()
-                Key.INNTEKTSMELDING.lesOrNull(
-                    Inntektsmelding
-                        .serializer(),
-                    data,
-                ) shouldNotBe null
+                Key.INNTEKTSMELDING_DOKUMENT.lesOrNull(Inntektsmelding.serializer(), data) shouldNotBe null
                 Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data) shouldBe Mock.skjema.forespoerselId
                 Key.INNSENDING_ID.lesOrNull(Long.serializer(), data) shouldBe Mock.innsendingId
             }
@@ -214,11 +210,7 @@ private object Mock {
     val steg4data =
         mapOf(
             Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
-            Key.INNTEKTSMELDING to
-                inntektsmelding.toJson(
-                    Inntektsmelding
-                        .serializer(),
-                ),
+            Key.INNTEKTSMELDING_DOKUMENT to inntektsmelding.toJson(Inntektsmelding.serializer()),
         )
 
     fun steg0(transaksjonId: UUID): Map<Key, JsonElement> =

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -49,7 +49,7 @@ class LagreImRiver(
                 transaksjonId = Key.UUID.les(UuidSerializer, json),
                 data = data,
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
-                inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
+                inntektsmelding = Key.INNTEKTSMELDING_DOKUMENT.les(Inntektsmelding.serializer(), data),
                 innsendingId = Key.INNSENDING_ID.les(Long.serializer(), data),
             )
         }

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
@@ -74,7 +74,7 @@ class LagreImRiverTest :
                         Key.DATA to
                             mapOf(
                                 Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
-                                Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                                Key.INNTEKTSMELDING_DOKUMENT to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                                 Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
                                 Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                             ).toJson(),
@@ -114,7 +114,7 @@ class LagreImRiverTest :
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
-                            Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                            Key.INNTEKTSMELDING_DOKUMENT to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                             Key.ER_DUPLIKAT_IM to true.toJson(Boolean.serializer()),
                             Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                         ).toJson(),
@@ -195,7 +195,7 @@ private fun innkommendeMelding(
         data =
             mapOf(
                 Key.FORESPOERSEL_ID to forespoerselId.toJson(),
-                Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
+                Key.INNTEKTSMELDING_DOKUMENT to inntektsmelding.toJson(Inntektsmelding.serializer()),
                 Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
             ),
         forespoerselId = forespoerselId,

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -114,7 +114,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Inntektsmelding lagret
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.INNTEKTSMELDING, nestedData = true)
+            .filter(Key.INNTEKTSMELDING_DOKUMENT, nestedData = true)
             .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
@@ -122,7 +122,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
 
-                data[Key.INNTEKTSMELDING].shouldNotBeNull().fromJson(Inntektsmelding.serializer())
+                data[Key.INNTEKTSMELDING_DOKUMENT].shouldNotBeNull().fromJson(Inntektsmelding.serializer())
 
                 data[Key.ER_DUPLIKAT_IM]?.fromJson(Boolean.serializer()) shouldBe false
             }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -81,13 +81,13 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.INNTEKTSMELDING, nestedData = true)
+            .filter(Key.INNTEKTSMELDING_DOKUMENT, nestedData = true)
             .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
             .firstAsMap()
             .also {
                 // Ble lagret i databasen
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
-                data[Key.INNTEKTSMELDING].shouldNotBeNull()
+                data[Key.INNTEKTSMELDING_DOKUMENT].shouldNotBeNull()
                 data[Key.ER_DUPLIKAT_IM].shouldNotBeNull().fromJson(Boolean.serializer()).shouldBeFalse()
             }
 


### PR DESCRIPTION
Bytter feltnøkkel for å senere kunne bruke `Key.INNTEKTSMELDING` til å sende `InntektsmeldingV1`.