### PR TITLE
Send ny IM-klasse til journalføringsapp

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.json.les
+import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -20,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed4Steg
 import no.nav.helsearbeidsgiver.felles.utils.Log
+import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
@@ -29,6 +31,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
 
 private const val UKJENT_NAVN = "Ukjent navn"
 private const val UKJENT_VIRKSOMHET = "Ukjent virksomhet"
@@ -53,6 +56,8 @@ data class Steg3(
 )
 
 data class Steg4(
+    // TODO fjern nullable etter overgangsperiode
+    val inntektsmeldingV1: InntektsmeldingV1?,
     val inntektsmelding: Inntektsmelding,
     val erDuplikat: Boolean,
 )
@@ -90,6 +95,7 @@ class BerikInntektsmeldingService(
 
     override fun lesSteg4(melding: Map<Key, JsonElement>): Steg4 =
         Steg4(
+            inntektsmeldingV1 = Key.INNTEKTSMELDING.lesOrNull(InntektsmeldingV1.serializer(), melding),
             inntektsmelding = Key.INNTEKTSMELDING_DOKUMENT.les(Inntektsmelding.serializer(), melding),
             erDuplikat = Key.ER_DUPLIKAT_IM.les(Boolean.serializer(), melding),
         )
@@ -194,6 +200,7 @@ class BerikInntektsmeldingService(
                         .plus(
                             mapOf(
                                 Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
+                                Key.INNTEKTSMELDING to inntektsmelding.toJson(InntektsmeldingV1.serializer()),
                                 Key.INNTEKTSMELDING_DOKUMENT to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
                                 Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                             ),
@@ -212,11 +219,14 @@ class BerikInntektsmeldingService(
         if (!steg4.erDuplikat) {
             val publisert =
                 rapid.publish(
-                    Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
-                    Key.UUID to steg0.transaksjonId.toJson(),
-                    Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
-                    Key.INNTEKTSMELDING_DOKUMENT to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                    Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
+                    mapOf(
+                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
+                        Key.UUID to steg0.transaksjonId.toJson(),
+                        Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
+                        Key.INNTEKTSMELDING to steg4.inntektsmeldingV1?.toJson(InntektsmeldingV1.serializer()),
+                        Key.INNTEKTSMELDING_DOKUMENT to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                        Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
+                    ).mapValuesNotNull { it },
                 )
 
             MdcUtils.withLogFields(

--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed4Steg
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
@@ -30,6 +31,7 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.time.LocalDate
 import java.util.UUID
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
 
@@ -58,6 +60,8 @@ data class Steg3(
 data class Steg4(
     // TODO fjern nullable etter overgangsperiode
     val inntektsmeldingV1: InntektsmeldingV1?,
+    // TODO fjern nullable etter overgangsperiode
+    val bestemmendeFravaersdag: LocalDate?,
     val inntektsmelding: Inntektsmelding,
     val erDuplikat: Boolean,
 )
@@ -96,6 +100,7 @@ class BerikInntektsmeldingService(
     override fun lesSteg4(melding: Map<Key, JsonElement>): Steg4 =
         Steg4(
             inntektsmeldingV1 = Key.INNTEKTSMELDING.lesOrNull(InntektsmeldingV1.serializer(), melding),
+            bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, melding),
             inntektsmelding = Key.INNTEKTSMELDING_DOKUMENT.les(Inntektsmelding.serializer(), melding),
             erDuplikat = Key.ER_DUPLIKAT_IM.les(Boolean.serializer(), melding),
         )
@@ -201,6 +206,8 @@ class BerikInntektsmeldingService(
                             mapOf(
                                 Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
                                 Key.INNTEKTSMELDING to inntektsmelding.toJson(InntektsmeldingV1.serializer()),
+                                // TODO vurder å flytte denne inn i InntektsmeldingV1 (ikke sikker om det er en god idé, så avventer til v1 er brukt overalt)
+                                Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(),
                                 Key.INNTEKTSMELDING_DOKUMENT to inntektsmeldingGammeltFormat.toJson(Inntektsmelding.serializer()),
                                 Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                             ),
@@ -224,6 +231,7 @@ class BerikInntektsmeldingService(
                         Key.UUID to steg0.transaksjonId.toJson(),
                         Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
                         Key.INNTEKTSMELDING to steg4.inntektsmeldingV1?.toJson(InntektsmeldingV1.serializer()),
+                        Key.BESTEMMENDE_FRAVAERSDAG to steg4.bestemmendeFravaersdag?.toJson(),
                         Key.INNTEKTSMELDING_DOKUMENT to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                     ).mapValuesNotNull { it },

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -46,6 +46,7 @@ enum class Key(
     FNR("fnr"),
     FNR_LISTE("fnr_liste"),
     PERSONER("personer"),
+    BESTEMMENDE_FRAVAERSDAG("bestemmende_fravaersdag"),
     INNTEKTSDATO("inntektsdato"),
     TILGANG("tilgang"),
     SPINN_INNTEKTSMELDING_ID("spinnInntektsmeldingId"),

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -58,7 +58,12 @@ class JournalfoerImRiver(
                     JournalfoerImMelding(
                         eventName = eventName,
                         transaksjonId = transaksjonId,
-                        inntektsmeldingJson = Key.INNTEKTSMELDING_DOKUMENT.les(JsonElement.serializer(), json),
+                        inntektsmeldingJson =
+                            Key.INNTEKTSMELDING
+                                .lesOrNull(InntektsmeldingV1.serializer(), json)
+                                ?.convert()
+                                ?.toJson(Inntektsmelding.serializer())
+                                ?: Key.INNTEKTSMELDING_DOKUMENT.les(JsonElement.serializer(), json),
                     )
 
                 EventName.SELVBESTEMT_IM_LAGRET ->

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -372,6 +372,8 @@ private object Mock {
             eventName = eventName,
             transaksjonId = UUID.randomUUID(),
             inntektsmeldingJson = inntektsmeldingJson,
+            // TODO legg til verdi når InntektsmeldingV1 er tatt i bruk
+            bestemmendeFravaersdag = null,
         )
 
     fun JournalfoerImMelding.toMap(imKey: Key = Key.INNTEKTSMELDING_DOKUMENT): Map<Key, JsonElement> =


### PR DESCRIPTION
Vi ønsker å bruke ny IM-klasse. Her sender vi gammel og ny klasse til journalføringsappen, så prøver den å bruke ny klasse, men faller tilbake til gammel dersom den nye mangler. Dette gjør vi i en kort overgangsperiode, for å forhindre in-flight problemer.