### PR TITLE
Fjern unødvendig meldingsfelt fra river som lagrer skjema

### DIFF
--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -110,14 +110,11 @@ class InntektsmeldingRepository(
             }
         }
 
-    fun lagreInntektsmeldingSkjema(
-        forespoerselId: UUID,
-        inntektsmeldingSkjema: SkjemaInntektsmelding,
-    ): Long =
+    fun lagreInntektsmeldingSkjema(inntektsmeldingSkjema: SkjemaInntektsmelding): Long =
         requestLatency.recordTime(InntektsmeldingRepository::lagreInntektsmeldingSkjema) {
             transaction(db) {
                 InntektsmeldingEntitet.insert {
-                    it[this.forespoerselId] = forespoerselId.toString()
+                    it[this.forespoerselId] = inntektsmeldingSkjema.forespoerselId.toString()
                     it[skjema] = inntektsmeldingSkjema
                     it[innsendt] = LocalDateTime.now()
                 } get InntektsmeldingEntitet.id

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -28,7 +28,6 @@ data class LagreImSkjemaMelding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val forespoerselId: UUID,
     val inntektsmeldingSkjema: SkjemaInntektsmelding,
 )
 
@@ -48,13 +47,12 @@ class LagreImSkjemaRiver(
                 behovType = Key.BEHOV.krev(BehovType.LAGRE_IM_SKJEMA, BehovType.serializer(), json),
                 transaksjonId = Key.UUID.les(UuidSerializer, json),
                 data = data,
-                forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 inntektsmeldingSkjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), data),
             )
         }
 
     override fun LagreImSkjemaMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
-        val sisteImSkjema = repository.hentNyesteInntektsmeldingSkjema(forespoerselId)
+        val sisteImSkjema = repository.hentNyesteInntektsmeldingSkjema(inntektsmeldingSkjema.forespoerselId)
 
         val erDuplikat = sisteImSkjema?.erDuplikatAv(inntektsmeldingSkjema) ?: false
 
@@ -63,7 +61,7 @@ class LagreImSkjemaRiver(
                 sikkerLogger.warn("Fant duplikat av inntektsmeldingskjema.")
                 INNSENDING_ID_VED_DUPLIKAT
             } else {
-                repository.lagreInntektsmeldingSkjema(forespoerselId, inntektsmeldingSkjema).also {
+                repository.lagreInntektsmeldingSkjema(inntektsmeldingSkjema).also {
                     sikkerLogger.info("Lagret inntektsmeldingskjema.")
                 }
             }
@@ -90,7 +88,7 @@ class LagreImSkjemaRiver(
                 feilmelding = "Klarte ikke lagre inntektsmeldingskjema i database.",
                 event = eventName,
                 transaksjonId = transaksjonId,
-                forespoerselId = forespoerselId,
+                forespoerselId = inntektsmeldingSkjema.forespoerselId,
                 utloesendeMelding = json.toJson(),
             )
 
@@ -106,6 +104,6 @@ class LagreImSkjemaRiver(
             Log.event(eventName),
             Log.behov(behovType),
             Log.transaksjonId(transaksjonId),
-            Log.forespoerselId(forespoerselId),
+            Log.forespoerselId(inntektsmeldingSkjema.forespoerselId),
         )
 }

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/RepositoryTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/RepositoryTest.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.felles.db.exposed.test.FunSpecWithDb
 import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingGammeltFormat
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
+import no.nav.helsearbeidsgiver.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.ForespoerselEntitet
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import org.jetbrains.exposed.sql.Database
@@ -82,22 +83,21 @@ class RepositoryTest :
                 ForespoerselEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
-            val forespoerselId = UUID.randomUUID()
             val skjema = mockSkjemaInntektsmelding()
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
 
-            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId, skjema)
+            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId, beriketDokument)
 
             transaction {
                 val inntektsmeldinger =
                     InntektsmeldingEntitet
                         .selectAll()
                         .where {
-                            (InntektsmeldingEntitet.forespoerselId eq forespoerselId.toString())
+                            (InntektsmeldingEntitet.forespoerselId eq skjema.forespoerselId.toString())
                         }.toList()
 
                 inntektsmeldinger.size shouldBe 1
@@ -108,9 +108,9 @@ class RepositoryTest :
                 inntektsmeldinger.first().getOrNull(InntektsmeldingEntitet.dokument) shouldBe beriketDokument
             }
 
-            inntektsmeldingRepo.hentNyesteInntektsmelding(forespoerselId) shouldBe beriketDokument
+            inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId) shouldBe beriketDokument
 
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(forespoerselId) shouldBe innsendingId
+            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId
         }
 
         test("skal lagre hvert innsendte skjema med ny innsendingId, men hente nyeste berikede inntektsmelding") {
@@ -121,24 +121,23 @@ class RepositoryTest :
                 ForespoerselEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
-            val forespoerselId = UUID.randomUUID()
-
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
-
             val skjema = mockSkjemaInntektsmelding()
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId, skjema)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId, skjema)
-            val innsendingId3 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId, skjema)
+
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
+
+            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
+            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
+            val innsendingId3 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
             innsendingId1 shouldNotBeEqual innsendingId2
 
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
 
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId2, beriketDokument)
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(forespoerselId) shouldBe innsendingId2
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId2, beriketDokument)
+            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId2
 
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId1, beriketDokument)
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(forespoerselId) shouldBe innsendingId2
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId1, beriketDokument)
+            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId2
         }
 
         test("skal returnere im med gammelt inntekt-format ok") {
@@ -149,21 +148,20 @@ class RepositoryTest :
                 ForespoerselEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
-            val forespoerselId = UUID.randomUUID()
+            val skjema = mockSkjemaInntektsmelding()
             val dok1 = INNTEKTSMELDING_DOKUMENT_GAMMELT_INNTEKTFORMAT
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
 
-            val innsendingId =
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = mockSkjemaInntektsmelding())
+            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId, dok1)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId, dok1)
 
             transaction {
                 InntektsmeldingEntitet
                     .selectAll()
                     .where {
-                        (InntektsmeldingEntitet.forespoerselId eq forespoerselId.toString()) and
+                        (InntektsmeldingEntitet.forespoerselId eq skjema.forespoerselId.toString()) and
                             (InntektsmeldingEntitet.dokument eq dok1)
                     }.single()
             }
@@ -174,20 +172,18 @@ class RepositoryTest :
                 InntektsmeldingEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
-            val forespoerselId = UUID.randomUUID()
+            val skjema = mockSkjemaInntektsmelding()
+            val journalpost1 = randomDigitString(7)
 
-            val journalpost1 = "jp-1"
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
-
-            val innsendingId =
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = mockSkjemaInntektsmelding())
+            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId, beriketDokument)
 
             inntektsmeldingRepo.oppdaterJournalpostId(innsendingId, journalpost1)
 
-            val record = testRepo.hentRecordFraInntektsmelding(forespoerselId)
+            val record = testRepo.hentRecordFraInntektsmelding(skjema.forespoerselId)
 
             record.shouldNotBeNull()
 
@@ -196,18 +192,17 @@ class RepositoryTest :
         }
 
         test("skal oppdatere im med journalpostId") {
-            val forespoerselId = UUID.randomUUID()
+            val skjema = mockSkjemaInntektsmelding()
             val journalpostId = "jp-mollefonken-kjele"
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
 
-            val skjema = mockSkjemaInntektsmelding()
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = skjema)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = skjema)
+            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
+            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId1, beriketDokument)
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId2, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId1, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId2, beriketDokument)
 
             // Skal kun oppdatere den andre av de to inntektsmeldingene
             inntektsmeldingRepo.oppdaterJournalpostId(innsendingId2, journalpostId)
@@ -234,18 +229,18 @@ class RepositoryTest :
         }
 
         test("skal oppdatere inntektsmelding med journalpostId selv om den allerede har dette") {
-            val forespoerselId = UUID.randomUUID()
+            val skjema = mockSkjemaInntektsmelding()
             val gammelJournalpostId = "jp-traust-gevir"
             val nyJournalpostId = "jp-gallant-badehette"
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
-            val skjema = mockSkjemaInntektsmelding()
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = skjema)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = skjema)
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
+
+            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
+            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId1, beriketDokument)
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId2, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId1, beriketDokument)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId2, beriketDokument)
 
             inntektsmeldingRepo.oppdaterJournalpostId(innsendingId2, gammelJournalpostId)
 
@@ -294,16 +289,15 @@ class RepositoryTest :
         }
 
         test("skal _ikke_ oppdatere journalpostId for ekstern inntektsmelding") {
-            val forespoerselId = UUID.randomUUID()
+            val skjema = mockSkjemaInntektsmelding()
             val journalpostId = "jp-slem-fryser"
 
-            foresporselRepo.lagreForespoersel(forespoerselId.toString(), orgnr)
-            val skjema = mockSkjemaInntektsmelding()
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(forespoerselId = forespoerselId, inntektsmeldingSkjema = skjema)
+            foresporselRepo.lagreForespoersel(skjema.forespoerselId.toString(), orgnr)
+            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema)
 
             val beriketDokument = mockInntektsmeldingGammeltFormat().copy(tidspunkt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(forespoerselId, innsendingId1, beriketDokument)
-            inntektsmeldingRepo.lagreEksternInntektsmelding(forespoerselId, mockEksternInntektsmelding())
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId1, beriketDokument)
+            inntektsmeldingRepo.lagreEksternInntektsmelding(skjema.forespoerselId, mockEksternInntektsmelding())
 
             inntektsmeldingRepo.oppdaterJournalpostId(innsendingId1, journalpostId)
 

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -28,7 +28,6 @@ import java.util.UUID
 
 data class Steg0(
     val transaksjonId: UUID,
-    val forespoerselId: UUID,
     val avsenderFnr: Fnr,
     val skjema: SkjemaInntektsmelding,
 )
@@ -51,7 +50,6 @@ class InnsendingService(
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
             transaksjonId = Key.UUID.les(UuidSerializer, melding),
-            forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
             avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), melding),
             skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), melding),
         )
@@ -73,7 +71,8 @@ class InnsendingService(
                 Key.UUID to steg0.transaksjonId.toJson(),
                 Key.DATA to
                     mapOf(
-                        Key.FORESPOERSEL_ID to steg0.forespoerselId.toJson(),
+                        // TODO slett etter overgangsperiode
+                        Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
                         Key.SKJEMA_INNTEKTSMELDING to steg0.skjema.toJson(SkjemaInntektsmelding.serializer()),
                     ).toJson(),
             ).also { loggBehovPublisert(BehovType.LAGRE_IM_SKJEMA, it) }
@@ -119,7 +118,7 @@ class InnsendingService(
             Log.klasse(this@InnsendingService),
             Log.event(eventName),
             Log.transaksjonId(transaksjonId),
-            Log.forespoerselId(forespoerselId),
+            Log.forespoerselId(skjema.forespoerselId),
         )
 
     private fun loggBehovPublisert(

--- a/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/InnsendingServiceTest.kt
+++ b/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/InnsendingServiceTest.kt
@@ -91,7 +91,7 @@ class InnsendingServiceTest :
                 val data = it[Key.DATA]?.toMap().orEmpty()
                 Key.ARBEIDSGIVER_FNR.lesOrNull(Fnr.serializer(), data) shouldBe Mock.avsender.fnr
                 Key.SKJEMA_INNTEKTSMELDING.lesOrNull(SkjemaInntektsmelding.serializer(), data) shouldBe nyttSkjema
-                Key.INNSENDING_ID.lesOrNull(Long.serializer(), data) shouldBe Mock.innsendingId
+                Key.INNSENDING_ID.lesOrNull(Long.serializer(), data) shouldBe Mock.INNSENDING_ID
             }
 
             verify {
@@ -181,6 +181,8 @@ class InnsendingServiceTest :
     })
 
 private object Mock {
+    const val INNSENDING_ID = 1L
+
     val avsender =
         Fnr.genererGyldig().let {
             Person(
@@ -192,15 +194,12 @@ private object Mock {
 
     val skjema = mockSkjemaInntektsmelding()
 
-    val innsendingId = 1L
-
     fun steg0(transaksjonId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
             Key.UUID to transaksjonId.toJson(),
             Key.DATA to
                 mapOf(
-                    Key.FORESPOERSEL_ID to skjema.forespoerselId.toJson(),
                     Key.ARBEIDSGIVER_FNR to avsender.fnr.toJson(),
                     Key.SKJEMA_INNTEKTSMELDING to skjema.toJson(SkjemaInntektsmelding.serializer()),
                 ).toJson(),
@@ -213,7 +212,7 @@ private object Mock {
             Key.DATA to
                 mapOf(
                     Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
-                    Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
+                    Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
                 ).toJson(),
         )
 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -60,7 +60,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         forespoerselRepository.oppdaterSakId(Mock.forespoerselId.toString(), Mock.SAK_ID)
         forespoerselRepository.oppdaterOppgaveId(Mock.forespoerselId.toString(), Mock.OPPGAVE_ID)
 
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.forespoerselId, Mock.skjema)
+        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema)
         imRepository.oppdaterMedBeriketDokument(Mock.forespoerselId, innsendingId, tidligereInntektsmelding)
 
         coEvery {
@@ -183,7 +183,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         forespoerselRepository.lagreForespoersel(Mock.forespoerselId.toString(), Mock.orgnr.toString())
         forespoerselRepository.oppdaterSakId(Mock.forespoerselId.toString(), Mock.SAK_ID)
         forespoerselRepository.oppdaterOppgaveId(Mock.forespoerselId.toString(), Mock.OPPGAVE_ID)
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.forespoerselId, Mock.skjema)
+        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema)
         imRepository.oppdaterMedBeriketDokument(Mock.forespoerselId, innsendingId, tidligereInntektsmelding)
 
         coEvery {

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -139,7 +139,7 @@ class InnsendingIT : EndToEndTest() {
         forespoerselRepository.oppdaterSakId(Mock.forespoerselId.toString(), Mock.SAK_ID)
         forespoerselRepository.oppdaterOppgaveId(Mock.forespoerselId.toString(), Mock.OPPGAVE_ID)
 
-        imRepository.lagreInntektsmeldingSkjema(Mock.forespoerselId, Mock.skjema)
+        imRepository.lagreInntektsmeldingSkjema(Mock.skjema)
 
         publish(
             Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
@@ -176,7 +176,7 @@ class InnsendingIT : EndToEndTest() {
         forespoerselRepository.oppdaterSakId(Mock.forespoerselId.toString(), Mock.SAK_ID)
         forespoerselRepository.oppdaterOppgaveId(Mock.forespoerselId.toString(), Mock.OPPGAVE_ID)
 
-        imRepository.lagreInntektsmeldingSkjema(Mock.forespoerselId, Mock.skjema)
+        imRepository.lagreInntektsmeldingSkjema(Mock.skjema)
 
         publish(
             Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -43,14 +43,14 @@ class InnsendingServiceIT : EndToEndTest() {
         val transaksjonId: UUID = UUID.randomUUID()
         val tidligereInntektsmelding = mockInntektsmelding()
 
-        forespoerselRepository.lagreForespoersel(Mock.forespoerselId.toString(), Mock.orgnr.verdi)
-        forespoerselRepository.oppdaterSakId(Mock.forespoerselId.toString(), Mock.SAK_ID)
-        forespoerselRepository.oppdaterOppgaveId(Mock.forespoerselId.toString(), Mock.OPPGAVE_ID)
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.forespoerselId, Mock.skjema)
-        imRepository.oppdaterMedBeriketDokument(Mock.forespoerselId, innsendingId, tidligereInntektsmelding)
+        forespoerselRepository.lagreForespoersel(Mock.skjema.forespoerselId.toString(), Mock.orgnr.verdi)
+        forespoerselRepository.oppdaterSakId(Mock.skjema.forespoerselId.toString(), Mock.SAK_ID)
+        forespoerselRepository.oppdaterOppgaveId(Mock.skjema.forespoerselId.toString(), Mock.OPPGAVE_ID)
+        val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema)
+        imRepository.oppdaterMedBeriketDokument(Mock.skjema.forespoerselId, innsendingId, tidligereInntektsmelding)
 
         mockForespoerselSvarFraHelsebro(
-            forespoerselId = Mock.forespoerselId,
+            forespoerselId = Mock.skjema.forespoerselId,
             forespoerselSvar = Mock.forespoerselSvar,
         )
 
@@ -82,7 +82,7 @@ class InnsendingServiceIT : EndToEndTest() {
             Key.UUID to transaksjonId.toJson(),
             Key.DATA to
                 mapOf(
-                    Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson(),
+                    Key.FORESPOERSEL_ID to Mock.skjema.forespoerselId.toJson(),
                     Key.ARBEIDSGIVER_FNR to Mock.fnrAg.toJson(),
                     Key.SKJEMA_INNTEKTSMELDING to nyInnsending.toJson(SkjemaInntektsmelding.serializer()),
                 ).toJson(),
@@ -152,14 +152,14 @@ class InnsendingServiceIT : EndToEndTest() {
         also {
             val data = it[Key.DATA]?.toMap().orEmpty()
             val forespoerselId = Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data)
-            forespoerselId shouldBe Mock.forespoerselId
+            forespoerselId shouldBe Mock.skjema.forespoerselId
         }
 
     private fun Map<Key, JsonElement>.verifiserForespoerselIdFraSkjema(): Map<Key, JsonElement> =
         also {
             val data = it[Key.DATA]?.toMap().orEmpty()
             val skjema = Key.SKJEMA_INNTEKTSMELDING.lesOrNull(SkjemaInntektsmelding.serializer(), data)
-            skjema?.forespoerselId shouldBe Mock.forespoerselId
+            skjema?.forespoerselId shouldBe Mock.skjema.forespoerselId
         }
 
     private object Mock {
@@ -170,7 +170,6 @@ class InnsendingServiceIT : EndToEndTest() {
 
         val orgnr = Orgnr.genererGyldig()
         val fnrAg = Fnr.genererGyldig()
-        val forespoerselId: UUID = skjema.forespoerselId
         val vedtaksperiodeId: UUID = UUID.randomUUID()
 
         val forespoerselSvar =

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -31,18 +31,18 @@ class KvitteringIT : EndToEndTest() {
     @Test
     fun `skal hente data til kvittering`() {
         val transaksjonId = UUID.randomUUID()
-        val forespoerselId = UUID.randomUUID()
+        val skjema = mockSkjemaInntektsmelding()
 
-        forespoerselRepository.lagreForespoersel(forespoerselId.toString(), Mock.orgnr)
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(forespoerselId, mockSkjemaInntektsmelding())
-        imRepository.oppdaterMedBeriketDokument(forespoerselId, innsendingId, mockInntektsmeldingGammeltFormat())
+        forespoerselRepository.lagreForespoersel(skjema.forespoerselId.toString(), Mock.orgnr)
+        val innsendingId = imRepository.lagreInntektsmeldingSkjema(skjema)
+        imRepository.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId, mockInntektsmeldingGammeltFormat())
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
             Key.UUID to transaksjonId.toJson(),
             Key.DATA to
                 mapOf(
-                    Key.FORESPOERSEL_ID to forespoerselId.toJson(),
+                    Key.FORESPOERSEL_ID to skjema.forespoerselId.toJson(),
                 ).toJson(),
         )
 


### PR DESCRIPTION
Forespørsel-ID ligger i skjema, så det er ikke nødvending å sende som eget felt.