### PR TITLE
Bruk ny IM-klasse under lagring av journalpost-ID

### DIFF
--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -72,8 +72,8 @@ class LagreJournalpostIdRiver(
                 } else {
                     "Klarte ikke journalføre pga. manglende innsending-ID for forespørsel '${inntektsmelding.type.id}' og journalpost-ID '$journalpostId'."
                         .also {
-                            logger.info(it)
-                            sikkerLogger.info(it)
+                            logger.error(it)
+                            sikkerLogger.error(it)
                         }
                 }
             }

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.db.river
 
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -16,21 +17,19 @@ import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
-import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
 
 data class LagreJournalpostIdMelding(
     val eventName: EventName,
     val behovType: BehovType,
     val transaksjonId: UUID,
-    // TODO erstatt med v1.Inntektsmelding når mulig
-    val inntektsmeldingType: InntektsmeldingV1.Type,
+    val inntektsmelding: Inntektsmelding,
     val journalpostId: String,
+    val innsendingId: Long?,
 )
 
 class LagreJournalpostIdRiver(
@@ -44,75 +43,52 @@ class LagreJournalpostIdRiver(
         if (setOf(Key.DATA, Key.FAIL).any(json::containsKey)) {
             null
         } else {
-            val forespoerselId = Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, json)
-            val selvbestemtId = Key.SELVBESTEMT_ID.lesOrNull(UuidSerializer, json)
-            val inntektsmeldingType =
-                if (forespoerselId != null) {
-                    InntektsmeldingV1.Type.Forespurt(
-                        id = forespoerselId,
-                    )
-                } else if (selvbestemtId != null) {
-                    InntektsmeldingV1.Type.Selvbestemt(
-                        id = selvbestemtId,
-                    )
-                } else {
-                    null
-                }
-
-            if (inntektsmeldingType != null) {
-                LagreJournalpostIdMelding(
-                    eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
-                    behovType = Key.BEHOV.krev(BehovType.LAGRE_JOURNALPOST_ID, BehovType.serializer(), json),
-                    transaksjonId = Key.UUID.les(UuidSerializer, json),
-                    inntektsmeldingType = inntektsmeldingType,
-                    journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
-                )
-            } else {
-                if (Key.BEHOV.lesOrNull(BehovType.serializer(), json) == BehovType.LAGRE_JOURNALPOST_ID) {
-                    "Klarte ikke lagre journalpost-ID. Melding mangler inntektsmeldingstype-ID.".also {
-                        logger.error(it)
-                        sikkerLogger.error("$it\n${json.toPretty()}")
-                    }
-                }
-
-                null
-            }
+            LagreJournalpostIdMelding(
+                eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
+                behovType = Key.BEHOV.krev(BehovType.LAGRE_JOURNALPOST_ID, BehovType.serializer(), json),
+                transaksjonId = Key.UUID.les(UuidSerializer, json),
+                inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
+                journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
+                innsendingId = Key.INNSENDING_ID.lesOrNull(Long.serializer(), json),
+            )
         }
 
     override fun LagreJournalpostIdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok melding.")
         sikkerLogger.info("Mottok melding:\n${json.toPretty()}")
 
-        when (inntektsmeldingType) {
-            is InntektsmeldingV1.Type.Forespurt -> {
-                val innsendingId = Key.INNSENDING_ID.les(Long.serializer(), json)
+        when (inntektsmelding.type) {
+            is Inntektsmelding.Type.Forespurt -> {
+                if (innsendingId != null) {
+                    imRepo.oppdaterJournalpostId(innsendingId, journalpostId)
 
-                imRepo.oppdaterJournalpostId(innsendingId, journalpostId)
-
-                if (imRepo.hentNyesteBerikedeInnsendingId(inntektsmeldingType.id) != innsendingId) {
-                    return null.also {
+                    if (imRepo.hentNyesteBerikedeInnsendingId(inntektsmelding.type.id) != innsendingId) {
                         "Inntektsmelding journalført, men ikke distribuert pga. nyere innsending.".also {
                             logger.info(it)
                             sikkerLogger.info(it)
                         }
+                        return null
                     }
+                } else {
+                    "Klarte ikke journalføre pga. manglende innsending-ID for forespørsel '${inntektsmelding.type.id}' og journalpost-ID '$journalpostId'."
+                        .also {
+                            logger.info(it)
+                            sikkerLogger.info(it)
+                        }
                 }
             }
 
-            is InntektsmeldingV1.Type.Selvbestemt -> {
-                selvbestemtImRepo.oppdaterJournalpostId(inntektsmeldingType.id, journalpostId)
+            is Inntektsmelding.Type.Selvbestemt -> {
+                selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
             }
         }
 
         return mapOf(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
             Key.UUID to transaksjonId.toJson(),
-            Key.JOURNALPOST_ID to journalpostId.toJson(),
-            Key.INNTEKTSMELDING to json[Key.INNTEKTSMELDING],
+            Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.BESTEMMENDE_FRAVAERSDAG to json[Key.BESTEMMENDE_FRAVAERSDAG],
-            Key.INNTEKTSMELDING_DOKUMENT to json[Key.INNTEKTSMELDING_DOKUMENT],
-            Key.FORESPOERSEL_ID to json[Key.FORESPOERSEL_ID],
-            Key.SELVBESTEMT_ID to json[Key.SELVBESTEMT_ID],
+            Key.JOURNALPOST_ID to journalpostId.toJson(),
         ).mapValuesNotNull { it }
             .also {
                 logger.info("Publiserer event '${EventName.INNTEKTSMELDING_JOURNALFOERT}' med journalpost-ID '$journalpostId'.")
@@ -129,17 +105,14 @@ class LagreJournalpostIdRiver(
                 feilmelding = "Klarte ikke lagre journalpost-ID '$journalpostId'.",
                 event = eventName,
                 transaksjonId = transaksjonId,
-                forespoerselId = json[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer),
+                forespoerselId = null,
                 utloesendeMelding = json.toJson(),
             )
 
-        logger.error(fail.feilmelding)
+        logger.error(fail.feilmelding, error) // TODO temp error
         sikkerLogger.error(fail.feilmelding, error)
 
-        return fail
-            .tilMelding()
-            .plus(Key.SELVBESTEMT_ID to json[Key.SELVBESTEMT_ID])
-            .mapValuesNotNull { it }
+        return fail.tilMelding()
     }
 
     override fun LagreJournalpostIdMelding.loggfelt(): Map<String, String> =
@@ -148,5 +121,9 @@ class LagreJournalpostIdRiver(
             Log.event(eventName),
             Log.behov(behovType),
             Log.transaksjonId(transaksjonId),
+            when (inntektsmelding.type) {
+                is Inntektsmelding.Type.Forespurt -> Log.forespoerselId(inntektsmelding.type.id)
+                is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)
+            },
         )
 }

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -109,7 +109,7 @@ class LagreJournalpostIdRiver(
                 utloesendeMelding = json.toJson(),
             )
 
-        logger.error(fail.feilmelding, error) // TODO temp error
+        logger.error(fail.feilmelding)
         sikkerLogger.error(fail.feilmelding, error)
 
         return fail.tilMelding()

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepoTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepoTest.kt
@@ -147,7 +147,7 @@ class SelvbestemtImRepoTest :
 
         context(SelvbestemtImRepo::oppdaterJournalpostId.name) {
 
-            test("journalpost-ID oppdateres for angitt selvbestemt ID") {
+            test("journalpost-ID oppdateres for angitt inntektsmelding-ID (_ulik_ selvbestemt ID)") {
                 val selvbestemtId = UUID.randomUUID()
                 val journalpostId = randomDigitString(12)
                 val inntektsmelding =
@@ -160,7 +160,7 @@ class SelvbestemtImRepoTest :
 
                 selvbestemtImRepo.lagreIm(inntektsmelding)
                 selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
-                selvbestemtImRepo.oppdaterJournalpostId(selvbestemtId, journalpostId)
+                selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
 
                 val alleRader = lesAlleRader(db)
 
@@ -173,14 +173,16 @@ class SelvbestemtImRepoTest :
                 }
 
                 alleRader.last().let {
+                    it[SelvbestemtInntektsmeldingEntitet.inntektsmeldingId] shouldNotBe inntektsmelding.id
                     it[SelvbestemtInntektsmeldingEntitet.selvbestemtId] shouldNotBe selvbestemtId
-                    it[SelvbestemtInntektsmeldingEntitet.journalpostId] shouldNotBe journalpostId
+                    it[SelvbestemtInntektsmeldingEntitet.journalpostId].shouldBeNull()
                 }
             }
 
-            test("kun nyeste inntektsmelding oppdateres med journalpost-ID") {
+            test("journalpost-ID oppdateres for angitt inntektsmelding-ID (_lik_ selvbestemt ID)") {
                 val selvbestemtId = UUID.randomUUID()
-                val journalpostId = randomDigitString(5)
+                val journalpostId1 = randomDigitString(5)
+                val journalpostId2 = randomDigitString(6)
                 val originalInntektsmelding =
                     mockInntektsmeldingV1().copy(
                         type =
@@ -195,7 +197,8 @@ class SelvbestemtImRepoTest :
 
                 selvbestemtImRepo.lagreIm(originalInntektsmelding)
                 selvbestemtImRepo.lagreIm(endretInntektsmelding)
-                selvbestemtImRepo.oppdaterJournalpostId(selvbestemtId, journalpostId)
+                selvbestemtImRepo.oppdaterJournalpostId(originalInntektsmelding.id, journalpostId1)
+                selvbestemtImRepo.oppdaterJournalpostId(endretInntektsmelding.id, journalpostId2)
 
                 val alleRader = lesAlleRader(db)
 
@@ -204,13 +207,13 @@ class SelvbestemtImRepoTest :
                 alleRader.first().let {
                     it[SelvbestemtInntektsmeldingEntitet.inntektsmeldingId] shouldBe originalInntektsmelding.id
                     it[SelvbestemtInntektsmeldingEntitet.selvbestemtId] shouldBe selvbestemtId
-                    it[SelvbestemtInntektsmeldingEntitet.journalpostId].shouldBeNull()
+                    it[SelvbestemtInntektsmeldingEntitet.journalpostId] shouldBe journalpostId1
                 }
 
                 alleRader.last().let {
                     it[SelvbestemtInntektsmeldingEntitet.inntektsmeldingId] shouldBe endretInntektsmelding.id
                     it[SelvbestemtInntektsmeldingEntitet.selvbestemtId] shouldBe selvbestemtId
-                    it[SelvbestemtInntektsmeldingEntitet.journalpostId] shouldBe journalpostId
+                    it[SelvbestemtInntektsmeldingEntitet.journalpostId] shouldBe journalpostId2
                 }
             }
 
@@ -232,7 +235,7 @@ class SelvbestemtImRepoTest :
 
                 selvbestemtImRepo.lagreIm(originalInntektsmelding)
                 selvbestemtImRepo.lagreIm(endretInntektsmelding)
-                selvbestemtImRepo.oppdaterJournalpostId(selvbestemtId, gammelJournalpostId)
+                selvbestemtImRepo.oppdaterJournalpostId(endretInntektsmelding.id, gammelJournalpostId)
 
                 val alleRaderEtterSetup = lesAlleRader(db)
 
@@ -251,7 +254,7 @@ class SelvbestemtImRepoTest :
                 }
 
                 // Denne skal ha ingen effekt
-                selvbestemtImRepo.oppdaterJournalpostId(selvbestemtId, nyJournalpostId)
+                selvbestemtImRepo.oppdaterJournalpostId(endretInntektsmelding.id, nyJournalpostId)
 
                 val alleRaderEtterOppdatering = lesAlleRader(db)
 
@@ -278,10 +281,10 @@ class SelvbestemtImRepoTest :
                 selvbestemtImRepo.lagreIm(inntektsmelding1)
                 selvbestemtImRepo.lagreIm(inntektsmelding2)
 
-                selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding1.type.id, journalpostId)
+                selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding1.id, journalpostId)
 
                 shouldThrowExactly<ExposedSQLException> {
-                    selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding2.type.id, journalpostId)
+                    selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding2.id, journalpostId)
                 }
             }
 

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/TestData.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/TestData.kt
@@ -3,14 +3,13 @@ package no.nav.helsearbeidsgiver.inntektsmelding.db
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.BegrunnelseIngenEllerRedusertUtbetalingKode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.FullLoennIArbeidsgiverPerioden
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Refusjon
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.UUID
 
-val INNTEKTSMELDING_DOKUMENT =
+val INNTEKTSMELDING_DOKUMENT_GAMMELT_INNTEKTFORMAT =
     Inntektsmelding(
         orgnrUnderenhet = "",
         identitetsnummer = "",
@@ -22,13 +21,7 @@ val INNTEKTSMELDING_DOKUMENT =
         fraværsperioder = emptyList(),
         arbeidsgiverperioder = emptyList(),
         beregnetInntekt = 502.0,
-        inntekt =
-            Inntekt(
-                bekreftet = true,
-                beregnetInntekt = 502.0,
-                endringÅrsak = null,
-                manueltKorrigert = false,
-            ),
+        inntekt = null,
         refusjon =
             Refusjon(
                 true,
@@ -47,8 +40,3 @@ val INNTEKTSMELDING_DOKUMENT =
         innsenderNavn = "Fido",
         vedtaksperiodeId = UUID.randomUUID(),
     )
-
-val INNTEKTSMELDING_DOKUMENT_GAMMELT_INNTEKTFORMAT = INNTEKTSMELDING_DOKUMENT.copy(inntekt = null)
-
-val INNTEKTSMELDING_DOKUMENT_MED_TOM_FORESPURT_DATA = INNTEKTSMELDING_DOKUMENT.copy(forespurtData = emptyList())
-val INNTEKTSMELDING_DOKUMENT_MED_FORESPURT_DATA = INNTEKTSMELDING_DOKUMENT.copy(forespurtData = listOf("inntekt", "refusjon"))

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -15,7 +15,7 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -26,7 +26,6 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
-import no.nav.helsearbeidsgiver.inntektsmelding.db.INNTEKTSMELDING_DOKUMENT
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.INNSENDING_ID
@@ -35,7 +34,6 @@ import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import java.util.UUID
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
 
 class LagreJournalpostIdRiverTest :
     FunSpec({
@@ -56,12 +54,7 @@ class LagreJournalpostIdRiverTest :
                 every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
                 every { mockImRepo.hentNyesteBerikedeInnsendingId(any()) } returns INNSENDING_ID
 
-                val innkommendeMelding =
-                    Mock.innkommendeMelding(
-                        InntektsmeldingV1.Type.Forespurt(
-                            id = UUID.randomUUID(),
-                        ),
-                    )
+                val innkommendeMelding = Mock.innkommendeMelding()
 
                 testRapid.sendJson(innkommendeMelding.toMap())
 
@@ -71,16 +64,14 @@ class LagreJournalpostIdRiverTest :
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
-                        Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
-                        Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(InntektsmeldingV1.serializer()),
+                        Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(LocalDateSerializer),
-                        Key.INNTEKTSMELDING_DOKUMENT to INNTEKTSMELDING_DOKUMENT.toJson(Inntektsmelding.serializer()),
-                        Key.FORESPOERSEL_ID to innkommendeMelding.inntektsmeldingType.id.toJson(),
+                        Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     )
 
                 verifySequence {
                     mockImRepo.oppdaterJournalpostId(INNSENDING_ID, innkommendeMelding.journalpostId)
-                    mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmeldingType.id)
+                    mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmelding.type.id)
                 }
                 verify(exactly = 0) {
                     mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -92,12 +83,20 @@ class LagreJournalpostIdRiverTest :
 
                 val innkommendeMelding =
                     Mock.innkommendeMelding(
-                        InntektsmeldingV1.Type.Selvbestemt(
-                            id = UUID.randomUUID(),
+                        mockInntektsmeldingV1().copy(
+                            type =
+                                Inntektsmelding.Type.Selvbestemt(
+                                    id = UUID.randomUUID(),
+                                ),
                         ),
                     )
 
-                testRapid.sendJson(innkommendeMelding.toMap())
+                testRapid.sendJson(
+                    innkommendeMelding
+                        .toMap()
+                        .minus(Key.BESTEMMENDE_FRAVAERSDAG)
+                        .minus(Key.INNSENDING_ID),
+                )
 
                 testRapid.inspektør.size shouldBeExactly 1
 
@@ -105,15 +104,12 @@ class LagreJournalpostIdRiverTest :
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
-                        Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(InntektsmeldingV1.serializer()),
-                        Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(LocalDateSerializer),
-                        Key.INNTEKTSMELDING_DOKUMENT to INNTEKTSMELDING_DOKUMENT.toJson(Inntektsmelding.serializer()),
-                        Key.SELVBESTEMT_ID to innkommendeMelding.inntektsmeldingType.id.toJson(),
                     )
 
                 verifySequence {
-                    mockSelvbestemtImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmeldingType.id, innkommendeMelding.journalpostId)
+                    mockSelvbestemtImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmelding.id, innkommendeMelding.journalpostId)
                 }
                 verify(exactly = 0) {
                     mockImRepo.oppdaterJournalpostId(any(), any())
@@ -125,12 +121,7 @@ class LagreJournalpostIdRiverTest :
             every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
             every { mockImRepo.hentNyesteBerikedeInnsendingId(any()) } returns INNSENDING_ID + 1L
 
-            val innkommendeMelding =
-                Mock.innkommendeMelding(
-                    InntektsmeldingV1.Type.Forespurt(
-                        id = UUID.randomUUID(),
-                    ),
-                )
+            val innkommendeMelding = Mock.innkommendeMelding()
 
             testRapid.sendJson(innkommendeMelding.toMap())
 
@@ -138,7 +129,7 @@ class LagreJournalpostIdRiverTest :
 
             verifySequence {
                 mockImRepo.oppdaterJournalpostId(INNSENDING_ID, innkommendeMelding.journalpostId)
-                mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmeldingType.id)
+                mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmelding.type.id)
             }
             verify(exactly = 0) {
                 mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -149,19 +140,14 @@ class LagreJournalpostIdRiverTest :
             test("forespurt IM") {
                 every { mockImRepo.oppdaterJournalpostId(any(), any()) } throws Exception()
 
-                val innkommendeMelding =
-                    Mock.innkommendeMelding(
-                        InntektsmeldingV1.Type.Forespurt(
-                            id = UUID.randomUUID(),
-                        ),
-                    )
+                val innkommendeMelding = Mock.innkommendeMelding()
 
                 val forventetFail =
                     Fail(
                         feilmelding = "Klarte ikke lagre journalpost-ID '${innkommendeMelding.journalpostId}'.",
                         event = innkommendeMelding.eventName,
                         transaksjonId = innkommendeMelding.transaksjonId,
-                        forespoerselId = innkommendeMelding.inntektsmeldingType.id,
+                        forespoerselId = null,
                         utloesendeMelding = innkommendeMelding.toMap().toJson(),
                     )
 
@@ -169,10 +155,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
-                    forventetFail
-                        .tilMelding()
-                        .plus(Key.FORESPOERSEL_ID to innkommendeMelding.inntektsmeldingType.id.toJson())
+                testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
 
                 verifySequence {
                     mockImRepo.oppdaterJournalpostId(any(), any())
@@ -187,8 +170,11 @@ class LagreJournalpostIdRiverTest :
 
                 val innkommendeMelding =
                     Mock.innkommendeMelding(
-                        InntektsmeldingV1.Type.Selvbestemt(
-                            id = UUID.randomUUID(),
+                        mockInntektsmeldingV1().copy(
+                            type =
+                                Inntektsmelding.Type.Selvbestemt(
+                                    id = UUID.randomUUID(),
+                                ),
                         ),
                     )
 
@@ -205,11 +191,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
-                    forventetFail
-                        .tilMelding()
-                        .minus(Key.FORESPOERSEL_ID)
-                        .plus(Key.SELVBESTEMT_ID to innkommendeMelding.inntektsmeldingType.id.toJson())
+                testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
 
                 verifySequence {
                     mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -230,31 +212,9 @@ class LagreJournalpostIdRiverTest :
             ) { uoensketKeyMedVerdi ->
                 testRapid.sendJson(
                     Mock
-                        .innkommendeMelding(
-                            InntektsmeldingV1.Type.Forespurt(
-                                id = UUID.randomUUID(),
-                            ),
-                        ).toMap()
+                        .innkommendeMelding()
+                        .toMap()
                         .plus(uoensketKeyMedVerdi),
-                )
-
-                testRapid.inspektør.size shouldBeExactly 0
-
-                verify(exactly = 0) {
-                    mockImRepo.oppdaterJournalpostId(any(), any())
-                    mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
-                }
-            }
-
-            test("melding mangler både forespoerselId og selvbestemtId") {
-                testRapid.sendJson(
-                    Mock
-                        .innkommendeMelding(
-                            InntektsmeldingV1.Type.Selvbestemt(
-                                id = UUID.randomUUID(),
-                            ),
-                        ).toMap()
-                        .minus(Key.SELVBESTEMT_ID),
                 )
 
                 testRapid.inspektør.size shouldBeExactly 0
@@ -270,47 +230,28 @@ class LagreJournalpostIdRiverTest :
 private object Mock {
     const val INNSENDING_ID = 1L
 
-    val inntektsmelding = mockInntektsmeldingV1()
     val bestemmendeFravaersdag = 20.oktober
 
-    fun innkommendeMelding(inntektsmeldingType: InntektsmeldingV1.Type): LagreJournalpostIdMelding =
+    fun innkommendeMelding(inntektsmelding: Inntektsmelding = mockInntektsmeldingV1()): LagreJournalpostIdMelding =
         LagreJournalpostIdMelding(
             eventName = EventName.INNTEKTSMELDING_MOTTATT,
             behovType = BehovType.LAGRE_JOURNALPOST_ID,
             transaksjonId = UUID.randomUUID(),
-            inntektsmeldingType = inntektsmeldingType,
+            inntektsmelding = inntektsmelding,
             journalpostId = randomDigitString(10),
+            innsendingId = INNSENDING_ID,
         )
 
     fun LagreJournalpostIdMelding.toMap(): Map<Key, JsonElement> =
-        when (inntektsmeldingType) {
-            is InntektsmeldingV1.Type.Forespurt -> {
-                mapOf(
-                    Key.EVENT_NAME to eventName.toJson(),
-                    Key.BEHOV to behovType.toJson(),
-                    Key.UUID to transaksjonId.toJson(),
-                    Key.JOURNALPOST_ID to journalpostId.toJson(),
-                    Key.INNTEKTSMELDING to inntektsmelding.toJson(InntektsmeldingV1.serializer()),
-                    Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(LocalDateSerializer),
-                    Key.INNTEKTSMELDING_DOKUMENT to INNTEKTSMELDING_DOKUMENT.toJson(Inntektsmelding.serializer()),
-                    Key.FORESPOERSEL_ID to inntektsmeldingType.id.toJson(),
-                    Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
-                )
-            }
-
-            is InntektsmeldingV1.Type.Selvbestemt -> {
-                mapOf(
-                    Key.EVENT_NAME to eventName.toJson(),
-                    Key.BEHOV to behovType.toJson(),
-                    Key.UUID to transaksjonId.toJson(),
-                    Key.JOURNALPOST_ID to journalpostId.toJson(),
-                    Key.INNTEKTSMELDING to inntektsmelding.toJson(InntektsmeldingV1.serializer()),
-                    Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(LocalDateSerializer),
-                    Key.INNTEKTSMELDING_DOKUMENT to INNTEKTSMELDING_DOKUMENT.toJson(Inntektsmelding.serializer()),
-                    Key.SELVBESTEMT_ID to inntektsmeldingType.id.toJson(),
-                )
-            }
-        }
+        mapOf(
+            Key.EVENT_NAME to eventName.toJson(),
+            Key.BEHOV to behovType.toJson(),
+            Key.UUID to transaksjonId.toJson(),
+            Key.JOURNALPOST_ID to journalpostId.toJson(),
+            Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
+            Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(LocalDateSerializer),
+            Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
+        )
 
     val fail =
         Fail(

--- a/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
+++ b/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
@@ -13,7 +13,7 @@ import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convert
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -33,7 +33,6 @@ import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
 import java.util.UUID
 import java.util.concurrent.CompletableFuture
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
 
 class DistribusjonRiverTest :
     FunSpec({
@@ -74,7 +73,7 @@ class DistribusjonRiverTest :
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
-                        Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(InntektsmeldingV1.serializer()),
+                        Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.BESTEMMENDE_FRAVAERSDAG to innkommendeMelding.bestemmendeFravaersdag?.toJson(),
                     ).mapValuesNotNull { it }
 
@@ -109,7 +108,7 @@ class DistribusjonRiverTest :
                 val selvbestemtInntektsmelding =
                     mockInntektsmeldingV1().copy(
                         type =
-                            InntektsmeldingV1.Type.Selvbestemt(
+                            Inntektsmelding.Type.Selvbestemt(
                                 id = UUID.randomUUID(),
                             ),
                     )
@@ -120,7 +119,7 @@ class DistribusjonRiverTest :
                     innkommendeMelding
                         .toMap()
                         .minus(Key.BESTEMMENDE_FRAVAERSDAG)
-                        .plus(Key.INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(InntektsmeldingV1.serializer()))
+                        .plus(Key.INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(Inntektsmelding.serializer()))
                         .plus(Key.BEHOV to innkommendeBehov?.toJson())
                         .mapValuesNotNull { it },
                 )
@@ -132,7 +131,7 @@ class DistribusjonRiverTest :
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
-                        Key.INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(InntektsmeldingV1.serializer()),
+                        Key.INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(Inntektsmelding.serializer()),
                     )
 
                 val forventetRecord =
@@ -233,7 +232,7 @@ private object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.UUID to transaksjonId.toJson(),
-            Key.INNTEKTSMELDING to inntektsmelding.toJson(InntektsmeldingV1.serializer()),
+            Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag?.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
         ).mapValuesNotNull { it }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -105,7 +105,6 @@ class InnsendingIT : EndToEndTest() {
             .firstAsMap()
             .also {
                 // Journalført i dokarkiv
-                it[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer) shouldBe Mock.forespoerselId
                 it[Key.JOURNALPOST_ID]?.fromJsonToString() shouldBe Mock.JOURNALPOST_ID
             }
 
@@ -113,7 +112,7 @@ class InnsendingIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .firstAsMap()
             .also {
-                it shouldContainKey Key.INNTEKTSMELDING_DOKUMENT
+                it shouldContainKey Key.INNTEKTSMELDING
                 it[Key.JOURNALPOST_ID]?.fromJsonToString() shouldBe Mock.JOURNALPOST_ID
             }
 


### PR DESCRIPTION
Vi ønsker å bruke ny IM-klasse overalt. Nå er det lagring av journalpost-ID sin tur.