### PR TITLE
Integrasjonstest: Bruk nested data som default i meldingsfiltrering

### DIFF
--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
@@ -102,7 +102,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             }
 
         aktiveOrgnrMeldinger
-            .filter(Key.ORG_RETTIGHETER, nestedData = true)
+            .filter(Key.ORG_RETTIGHETER)
             .firstAsMap()
             .also { melding ->
                 val data = melding[Key.DATA].shouldNotBeNull().toMap()
@@ -110,7 +110,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             }
 
         aktiveOrgnrMeldinger
-            .filter(Key.ARBEIDSFORHOLD, nestedData = true)
+            .filter(Key.ARBEIDSFORHOLD)
             .firstAsMap()
             .also { melding ->
                 val data = melding[Key.DATA].shouldNotBeNull().toMap()
@@ -126,7 +126,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             }
 
         aktiveOrgnrMeldinger
-            .filter(Key.VIRKSOMHETER, nestedData = true)
+            .filter(Key.VIRKSOMHETER)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -183,7 +183,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             }
 
         aktiveOrgnrMeldinger
-            .filter(Key.ORG_RETTIGHETER, nestedData = true)
+            .filter(Key.ORG_RETTIGHETER)
             .firstAsMap()
             .also { melding ->
                 val data = melding[Key.DATA].shouldNotBeNull().toMap()
@@ -191,7 +191,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
             }
 
         aktiveOrgnrMeldinger
-            .filter(Key.ARBEIDSFORHOLD, nestedData = true)
+            .filter(Key.ARBEIDSFORHOLD)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -92,7 +92,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Forespørsel hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.FORESPOERSEL_SVAR, nestedData = true)
+            .filter(Key.FORESPOERSEL_SVAR)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -104,7 +104,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Virksomhetsnavn hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.VIRKSOMHETER, nestedData = true)
+            .filter(Key.VIRKSOMHETER)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -116,8 +116,8 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Inntektsmelding lagret
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.INNTEKTSMELDING_DOKUMENT, nestedData = true)
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.INNTEKTSMELDING_DOKUMENT)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -132,7 +132,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Sykmeldt og innsender hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -221,7 +221,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Forespørsel hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.FORESPOERSEL_SVAR, nestedData = true)
+            .filter(Key.FORESPOERSEL_SVAR)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -233,7 +233,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Virksomhetsnavn hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.VIRKSOMHETER, nestedData = true)
+            .filter(Key.VIRKSOMHETER)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()
@@ -245,7 +245,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Personnavn ikke hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .all()
             .size shouldBe 0
 
@@ -269,7 +269,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         // Sykmeldt og innsender hentet
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .firstAsMap()
             .verifiserTransaksjonId(Mock.transaksjonId)
             .verifiserForespoerselIdFraSkjema()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselBesvartIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselBesvartIT.kt
@@ -90,7 +90,7 @@ class ForespoerselBesvartIT : EndToEndTest() {
 
         messages
             .filter(EventName.FORESPOERSEL_BESVART)
-            .filter(Key.SAK_ID, utenDataKey = true)
+            .filter(Key.SAK_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 it shouldNotContainKey Key.BEHOV
@@ -108,7 +108,7 @@ class ForespoerselBesvartIT : EndToEndTest() {
 
         messages
             .filter(EventName.FORESPOERSEL_BESVART)
-            .filter(Key.OPPGAVE_ID, utenDataKey = true)
+            .filter(Key.OPPGAVE_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 it shouldNotContainKey Key.BEHOV
@@ -126,7 +126,7 @@ class ForespoerselBesvartIT : EndToEndTest() {
 
         messages
             .filter(EventName.SAK_FERDIGSTILT)
-            .filter(Key.SAK_ID, utenDataKey = true)
+            .filter(Key.SAK_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 if (forventetTransaksjonId == null) {
@@ -142,7 +142,7 @@ class ForespoerselBesvartIT : EndToEndTest() {
 
         messages
             .filter(EventName.OPPGAVE_FERDIGSTILT)
-            .filter(Key.OPPGAVE_ID, utenDataKey = true)
+            .filter(Key.OPPGAVE_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 if (forventetTransaksjonId == null) {

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -81,8 +81,8 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
-            .filter(Key.INNTEKTSMELDING_DOKUMENT, nestedData = true)
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.INNTEKTSMELDING_DOKUMENT)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 // Ble lagret i databasen
@@ -152,7 +152,7 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.INSENDING_STARTED)
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -189,7 +189,7 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.INSENDING_STARTED)
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -216,7 +216,7 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.FORESPOERSEL_BESVART)
-            .filter(Key.SAK_ID, utenDataKey = true)
+            .filter(Key.SAK_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 Key.FORESPOERSEL_ID.les(UuidSerializer, it) shouldBe Mock.forespoerselId
@@ -225,7 +225,7 @@ class InnsendingIT : EndToEndTest() {
 
         messages
             .filter(EventName.FORESPOERSEL_BESVART)
-            .filter(Key.OPPGAVE_ID, utenDataKey = true)
+            .filter(Key.OPPGAVE_ID, nestedData = false, utenDataKey = true)
             .firstAsMap()
             .also {
                 Key.FORESPOERSEL_ID.les(UuidSerializer, it) shouldBe Mock.forespoerselId

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -91,7 +91,7 @@ class InnsendingServiceIT : EndToEndTest() {
         // Inntektsmelding lagret
         messages
             .filter(EventName.INSENDING_STARTED)
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .verifiserTransaksjonId(transaksjonId)
             .verifiserForespoerselId()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
@@ -57,7 +57,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
             )
 
         messages
-            .filter(Key.INNTEKT, nestedData = true)
+            .filter(Key.INNTEKT)
             .firstAsMap()
             .shouldContainExactly(
                 mapOf(

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -48,8 +48,8 @@ class KvitteringIT : EndToEndTest() {
 
         messages
             .filter(EventName.KVITTERING_REQUESTED)
-            .filter(Key.LAGRET_INNTEKTSMELDING, nestedData = true)
-            .filter(Key.EKSTERN_INNTEKTSMELDING, nestedData = true)
+            .filter(Key.LAGRET_INNTEKTSMELDING)
+            .filter(Key.EKSTERN_INNTEKTSMELDING)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -85,8 +85,8 @@ class KvitteringIT : EndToEndTest() {
 
         messages
             .filter(EventName.KVITTERING_REQUESTED)
-            .filter(Key.LAGRET_INNTEKTSMELDING, nestedData = true)
-            .filter(Key.EKSTERN_INNTEKTSMELDING, nestedData = true)
+            .filter(Key.LAGRET_INNTEKTSMELDING)
+            .filter(Key.EKSTERN_INNTEKTSMELDING)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -115,8 +115,8 @@ class KvitteringIT : EndToEndTest() {
 
         messages
             .filter(EventName.KVITTERING_REQUESTED)
-            .filter(Key.LAGRET_INNTEKTSMELDING, nestedData = true)
-            .filter(Key.EKSTERN_INNTEKTSMELDING, nestedData = true)
+            .filter(Key.LAGRET_INNTEKTSMELDING)
+            .filter(Key.EKSTERN_INNTEKTSMELDING)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -97,7 +97,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Data hentet
         serviceMessages
-            .filter(Key.VIRKSOMHETER, nestedData = true)
+            .filter(Key.VIRKSOMHETER)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -107,7 +107,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Data hentet
         serviceMessages
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .firstAsMap()
             .also { melding ->
                 val data = melding[Key.DATA].shouldNotBeNull().toMap()
@@ -118,7 +118,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Data hentet
         serviceMessages
-            .filter(Key.ARBEIDSFORHOLD, nestedData = true)
+            .filter(Key.ARBEIDSFORHOLD)
             .firstAsMap()
             .also { melding ->
                 val data = melding[Key.DATA].shouldNotBeNull().toMap()
@@ -136,7 +136,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Lagring utført, uten duplikat
         serviceMessages
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -154,7 +154,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Opprettelse av sak utført
         serviceMessages
-            .filter(Key.SAK_ID, nestedData = true)
+            .filter(Key.SAK_ID)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -215,7 +215,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Lagring utført, uten duplikat
         serviceMessages
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -230,7 +230,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Opprettelse av sak _ikke_ utført
         serviceMessages
-            .filter(Key.SAK_ID, nestedData = true)
+            .filter(Key.SAK_ID)
             .all()
             .shouldBeEmpty()
 
@@ -283,7 +283,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Lagring utført, med duplikat
         serviceMessages
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -291,7 +291,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             }
 
         serviceMessages
-            .filter(Key.ER_DUPLIKAT_IM, nestedData = true)
+            .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -306,7 +306,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         // Opprettelse av sak _ikke_ utført
         serviceMessages
-            .filter(Key.SAK_ID, nestedData = true)
+            .filter(Key.SAK_ID)
             .all()
             .shouldBeEmpty()
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/NotifikasjonIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/NotifikasjonIT.kt
@@ -57,7 +57,7 @@ class NotifikasjonIT : EndToEndTest() {
 
         messages
             .filter(EventName.SAK_OPPRETT_REQUESTED)
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -76,7 +76,7 @@ class NotifikasjonIT : EndToEndTest() {
 
         messages
             .filter(EventName.SAK_OPPRETT_REQUESTED)
-            .filter(Key.SAK_ID)
+            .filter(Key.SAK_ID, nestedData = false)
             .firstAsMap()
             .also {
                 val sakId = it[Key.SAK_ID]?.fromJsonToString()
@@ -200,7 +200,7 @@ class NotifikasjonIT : EndToEndTest() {
 
         messages
             .filter(EventName.MANUELL_OPPRETT_SAK_REQUESTED)
-            .filter(Key.PERSONER, nestedData = true)
+            .filter(Key.PERSONER)
             .firstAsMap()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -219,7 +219,7 @@ class NotifikasjonIT : EndToEndTest() {
 
         messages
             .filter(EventName.MANUELL_OPPRETT_SAK_REQUESTED)
-            .filter(Key.SAK_ID)
+            .filter(Key.SAK_ID, nestedData = false)
             .firstAsMap()
             .also {
                 val sakId = it[Key.SAK_ID]?.fromJsonToString()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
@@ -64,7 +64,7 @@ class TilgangskontrollIT : EndToEndTest() {
         val result =
             messages
                 .filter(EventName.TILGANG_FORESPOERSEL_REQUESTED)
-                .filter(Key.TILGANG, nestedData = true)
+                .filter(Key.TILGANG)
                 .firstAsMap()
 
         val tilgang =
@@ -92,7 +92,7 @@ class TilgangskontrollIT : EndToEndTest() {
         val result =
             messages
                 .filter(EventName.TILGANG_FORESPOERSEL_REQUESTED)
-                .filter(Key.TILGANG, nestedData = true)
+                .filter(Key.TILGANG)
                 .firstAsMap()
 
         val tilgang =
@@ -112,7 +112,7 @@ class TilgangskontrollIT : EndToEndTest() {
         val result =
             messages
                 .filter(EventName.TILGANG_ORG_REQUESTED)
-                .filter(Key.TILGANG, nestedData = true)
+                .filter(Key.TILGANG)
                 .firstAsMap()
 
         val tilgang =
@@ -132,7 +132,7 @@ class TilgangskontrollIT : EndToEndTest() {
         val result =
             messages
                 .filter(EventName.TILGANG_ORG_REQUESTED)
-                .filter(Key.TILGANG, nestedData = true)
+                .filter(Key.TILGANG)
                 .firstAsMap()
 
         val tilgang =

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/Messages.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/Messages.kt
@@ -54,7 +54,7 @@ value class Messages(
 
     fun filter(
         dataFelt: Key,
-        nestedData: Boolean = false,
+        nestedData: Boolean = true,
         utenDataKey: Boolean = false,
     ): Messages =
         filter { msg ->

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/MessagesTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/MessagesTest.kt
@@ -50,7 +50,7 @@ class MessagesTest :
         }
 
         test("finner korrekt melding for key") {
-            val funnetMelding = Mock.meldinger.filter(Key.VIRKSOMHET).firstAsMap()
+            val funnetMelding = Mock.meldinger.filter(Key.VIRKSOMHET, nestedData = false).firstAsMap()
 
             funnetMelding.also {
                 it shouldContainKey Key.DATA
@@ -60,7 +60,7 @@ class MessagesTest :
 
         test("finner ikke manglende melding for key") {
             Mock.meldinger
-                .filter(Key.ARBEIDSFORHOLD)
+                .filter(Key.ARBEIDSFORHOLD, nestedData = false)
                 .all()
                 .shouldBeEmpty()
         }


### PR DESCRIPTION
Nested data har blitt normen, så da endrer vi noen defaultverdier i integrasjonstestene.