### PR TITLE
Flytt alle metrikkdefinisjoner til egen fil

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
@@ -21,13 +21,13 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.inntektsmelding.api.aktiveorgnr.aktiveOrgnrRoute
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.Tilgangskontroll
-import no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel.hentForespoerselRoute
-import no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoerselIdListe.hentForespoerselIdListeRoute
+import no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel.hentForespoersel
+import no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoerselIdListe.hentForespoerselIdListe
 import no.nav.helsearbeidsgiver.inntektsmelding.api.hentselvbestemtim.hentSelvbestemtImRoute
-import no.nav.helsearbeidsgiver.inntektsmelding.api.innsending.innsendingRoute
+import no.nav.helsearbeidsgiver.inntektsmelding.api.innsending.innsending
 import no.nav.helsearbeidsgiver.inntektsmelding.api.inntekt.inntektRoute
 import no.nav.helsearbeidsgiver.inntektsmelding.api.inntektselvbestemt.inntektSelvbestemtRoute
-import no.nav.helsearbeidsgiver.inntektsmelding.api.kvittering.kvitteringRoute
+import no.nav.helsearbeidsgiver.inntektsmelding.api.kvittering.kvittering
 import no.nav.helsearbeidsgiver.inntektsmelding.api.lagreselvbestemtim.lagreSelvbestemtImRoute
 import no.nav.helsearbeidsgiver.inntektsmelding.api.tilgang.TilgangProducer
 import no.nav.helsearbeidsgiver.inntektsmelding.api.tilgangorgnr.tilgangOrgnrRoute
@@ -116,12 +116,12 @@ fun Application.apiModule(
 
         authenticate {
             route(Routes.PREFIX) {
-                hentForespoerselRoute(rapid, tilgangskontroll, redisConnection)
-                hentForespoerselIdListeRoute(rapid, tilgangskontroll, redisConnection)
+                hentForespoersel(rapid, tilgangskontroll, redisConnection)
+                hentForespoerselIdListe(rapid, tilgangskontroll, redisConnection)
                 inntektRoute(rapid, tilgangskontroll, redisConnection)
                 inntektSelvbestemtRoute(rapid, tilgangskontroll, redisConnection)
-                innsendingRoute(rapid, tilgangskontroll, redisConnection)
-                kvitteringRoute(rapid, tilgangskontroll, redisConnection)
+                innsending(rapid, tilgangskontroll, redisConnection)
+                kvittering(rapid, tilgangskontroll, redisConnection)
                 lagreSelvbestemtImRoute(rapid, tilgangskontroll, redisConnection)
                 hentSelvbestemtImRoute(rapid, tilgangskontroll, redisConnection)
                 aktiveOrgnrRoute(rapid, redisConnection)

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
@@ -1,14 +1,12 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api
 
-import io.ktor.http.ContentType
 import io.ktor.server.application.Application
 import io.ktor.server.application.call
 import io.ktor.server.response.respondText
 import io.ktor.server.response.respondTextWriter
 import io.ktor.server.routing.get
 import io.ktor.server.routing.routing
-import io.prometheus.client.CollectorRegistry
-import io.prometheus.client.exporter.common.TextFormat
+import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 
 fun Application.helsesjekkerRouting() {
     routing {
@@ -25,8 +23,8 @@ fun Application.helsesjekkerRouting() {
                     ?.toSet()
                     .orEmpty()
 
-            call.respondTextWriter(ContentType.parse(TextFormat.CONTENT_TYPE_004)) {
-                TextFormat.write004(this, CollectorRegistry.defaultRegistry.filteredMetricFamilySamples(names))
+            call.respondTextWriter(Metrics.Expose.contentType004) {
+                Metrics.Expose.filteredMetricsWrite004(this, names)
             }
         }
     }

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
@@ -13,7 +13,6 @@ import io.ktor.serialization.kotlinx.json.json
 import io.ktor.server.testing.ApplicationTestBuilder
 import io.ktor.server.testing.testApplication
 import io.mockk.mockk
-import io.prometheus.client.CollectorRegistry
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.KSerializer
 import no.nav.helsearbeidsgiver.felles.domene.Tilgang
@@ -22,7 +21,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.inntektsmelding.api.apiModule
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import org.junit.jupiter.api.AfterEach
 
 val harTilgangResultat = TilgangResultat(Tilgang.HAR_TILGANG).toJson(TilgangResultat.serializer()).toString()
 val ikkeTilgangResultat = TilgangResultat(Tilgang.IKKE_TILGANG).toJson(TilgangResultat.serializer()).toString()
@@ -40,11 +38,6 @@ abstract class ApiTest : MockAuthToken() {
 
             testClient.block()
         }
-
-    @AfterEach
-    fun cleanupPrometheus() {
-        CollectorRegistry.defaultRegistry.clear()
-    }
 }
 
 class TestClient(

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -1,9 +1,9 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.db
 
-import io.prometheus.client.Summary
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
+import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 import no.nav.helsearbeidsgiver.felles.metrics.recordTime
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -26,16 +26,8 @@ class InntektsmeldingRepository(
     private val logger = logger()
     private val sikkerLogger = sikkerLogger()
 
-    private val requestLatency =
-        Summary
-            .build()
-            .name("simba_db_inntektsmelding_repo_latency_seconds")
-            .help("database inntektsmeldingRepo latency in seconds")
-            .labelNames("method")
-            .register()
-
     fun hentNyesteInntektsmelding(forespoerselId: UUID): Inntektsmelding? =
-        requestLatency.recordTime(InntektsmeldingRepository::hentNyesteInntektsmelding) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::hentNyesteInntektsmelding) {
             transaction(db) {
                 hentNyesteImQuery(forespoerselId)
                     .firstOrNull()
@@ -44,7 +36,7 @@ class InntektsmeldingRepository(
         }
 
     fun hentNyesteEksternEllerInternInntektsmelding(forespoerselId: UUID): Pair<Inntektsmelding?, EksternInntektsmelding?> =
-        requestLatency.recordTime(InntektsmeldingRepository::hentNyesteEksternEllerInternInntektsmelding) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::hentNyesteEksternEllerInternInntektsmelding) {
             transaction(db) {
                 InntektsmeldingEntitet
                     .select(InntektsmeldingEntitet.dokument, InntektsmeldingEntitet.eksternInntektsmelding)
@@ -64,7 +56,7 @@ class InntektsmeldingRepository(
         innsendingId: Long,
         journalpostId: String,
     ) {
-        requestLatency.recordTime(InntektsmeldingRepository::oppdaterJournalpostId) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::oppdaterJournalpostId) {
             val antallOppdatert =
                 transaction(db) {
                     InntektsmeldingEntitet.update(
@@ -102,7 +94,7 @@ class InntektsmeldingRepository(
     }
 
     fun hentNyesteBerikedeInnsendingId(forespoerselId: UUID): Long? =
-        requestLatency.recordTime(InntektsmeldingRepository::hentNyesteBerikedeInnsendingId) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::hentNyesteBerikedeInnsendingId) {
             transaction(db) {
                 hentNyesteImQuery(forespoerselId)
                     .firstOrNull()
@@ -111,7 +103,7 @@ class InntektsmeldingRepository(
         }
 
     fun lagreInntektsmeldingSkjema(inntektsmeldingSkjema: SkjemaInntektsmelding): Long =
-        requestLatency.recordTime(InntektsmeldingRepository::lagreInntektsmeldingSkjema) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::lagreInntektsmeldingSkjema) {
             transaction(db) {
                 InntektsmeldingEntitet.insert {
                     it[this.forespoerselId] = inntektsmeldingSkjema.forespoerselId.toString()
@@ -122,7 +114,7 @@ class InntektsmeldingRepository(
         }
 
     fun hentNyesteInntektsmeldingSkjema(forespoerselId: UUID): SkjemaInntektsmelding? =
-        requestLatency.recordTime(InntektsmeldingRepository::hentNyesteInntektsmeldingSkjema) {
+        Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::hentNyesteInntektsmeldingSkjema) {
             transaction(db) {
                 hentNyesteImSkjemaQuery(forespoerselId)
                     .firstOrNull()
@@ -136,7 +128,7 @@ class InntektsmeldingRepository(
         inntektsmeldingDokument: Inntektsmelding,
     ) {
         val antallOppdatert =
-            requestLatency.recordTime(InntektsmeldingRepository::oppdaterMedBeriketDokument) {
+            Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::oppdaterMedBeriketDokument) {
                 transaction(db) {
                     InntektsmeldingEntitet.update(
                         where = {

--- a/felles/build.gradle.kts
+++ b/felles/build.gradle.kts
@@ -2,6 +2,7 @@ val kotestVersion: String by project
 val lettuceVersion: String by project
 val mockkVersion: String by project
 val rapidsAndRiversVersion: String by project
+val prometheusVersion: String by project
 val slf4jVersion: String by project
 val utilsVersion: String by project
 
@@ -14,6 +15,7 @@ dependencies {
     api("org.slf4j:slf4j-api:$slf4jVersion")
 
     implementation("io.lettuce:lettuce-core:$lettuceVersion")
+    implementation("io.prometheus:simpleclient:$prometheusVersion")
 
     testFixturesApi("com.github.navikt:rapids-and-rivers:$rapidsAndRiversVersion")
     testFixturesApi("io.lettuce:lettuce-core:$lettuceVersion")

--- a/felles/gradle.properties
+++ b/felles/gradle.properties
@@ -1,2 +1,3 @@
 # Dependency versions
+prometheusVersion=0.16.0
 slf4jVersion=2.0.12

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -5,7 +5,6 @@ import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
-import io.prometheus.client.CollectorRegistry
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
@@ -263,8 +262,6 @@ abstract class EndToEndTest : ContainerTest() {
 
     @AfterAll
     fun afterAllEndToEnd() {
-        // Prometheus-metrikker spenner bein på testene uten denne
-        CollectorRegistry.defaultRegistry.clear()
         redisConnection.close()
         inntektsmeldingDatabase.dataSource.close()
         notifikasjonDatabase.dataSource.close()

--- a/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
+++ b/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
@@ -9,7 +9,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.mockk
-import io.prometheus.client.CollectorRegistry
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helse.rapids_rivers.testsupport.TestRapid
@@ -45,7 +44,6 @@ class HentPersonerRiverTest :
         beforeTest {
             testRapid.reset()
             clearAllMocks()
-            CollectorRegistry.defaultRegistry.clear()
         }
 
         test("finner én person") {


### PR DESCRIPTION
Flytter alle metrikkdefinisjoner i egen fil for å få bedre oversikt.

Fjerner også `CollectorRegistry.defaultRegistry.clear()` fra et par tester, inkludert integrasjonstestene. Uten denne skal visstnok testene erfart problemer før, men de viser ingen tegn til det nå. Teorien er at noe har endret seg i RR-biblioteket.