### PR TITLE
Gjør InnsendingService stateless

### DIFF
--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/App.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/App.kt
@@ -6,7 +6,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateful
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -26,7 +25,7 @@ fun main() {
 fun RapidsConnection.createInnsending(redisConnection: RedisConnection): RapidsConnection =
     also {
         logger.info("Starter ${InnsendingService::class.simpleName}...")
-        ServiceRiverStateful(
+        ServiceRiverStateless(
             InnsendingService(
                 rapid = this,
                 redisStore = RedisStore(redisConnection, RedisPrefix.Innsending),

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -14,7 +14,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.Service
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed1Steg
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -39,9 +38,8 @@ data class Steg1(
 
 class InnsendingService(
     private val rapid: RapidsConnection,
-    override val redisStore: RedisStore,
-) : ServiceMed1Steg<Steg0, Steg1>(),
-    Service.MedRedis {
+    private val redisStore: RedisStore,
+) : ServiceMed1Steg<Steg0, Steg1>() {
     override val logger = logger()
     override val sikkerLogger = sikkerLogger()
 

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -67,11 +67,7 @@ class InnsendingService(
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.LAGRE_IM_SKJEMA.toJson(),
                 Key.UUID to steg0.transaksjonId.toJson(),
-                Key.DATA to
-                    mapOf(
-                        Key.ARBEIDSGIVER_FNR to steg0.avsenderFnr.toJson(),
-                        Key.SKJEMA_INNTEKTSMELDING to steg0.skjema.toJson(SkjemaInntektsmelding.serializer()),
-                    ).toJson(),
+                Key.DATA to data.toJson(),
             ).also { loggBehovPublisert(BehovType.LAGRE_IM_SKJEMA, it) }
     }
 
@@ -94,11 +90,9 @@ class InnsendingService(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
                         Key.UUID to steg0.transaksjonId.toJson(),
                         Key.DATA to
-                            mapOf(
-                                Key.ARBEIDSGIVER_FNR to steg0.avsenderFnr.toJson(),
-                                Key.SKJEMA_INNTEKTSMELDING to steg0.skjema.toJson(SkjemaInntektsmelding.serializer()),
-                                Key.INNSENDING_ID to steg1.innsendingId.toJson(Long.serializer()),
-                            ).toJson(),
+                            data
+                                .plus(Key.INNSENDING_ID to steg1.innsendingId.toJson(Long.serializer()))
+                                .toJson(),
                     )
 
             MdcUtils.withLogFields(

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -69,6 +69,7 @@ class InnsendingService(
                 Key.UUID to steg0.transaksjonId.toJson(),
                 Key.DATA to
                     mapOf(
+                        Key.ARBEIDSGIVER_FNR to steg0.avsenderFnr.toJson(),
                         Key.SKJEMA_INNTEKTSMELDING to steg0.skjema.toJson(SkjemaInntektsmelding.serializer()),
                     ).toJson(),
             ).also { loggBehovPublisert(BehovType.LAGRE_IM_SKJEMA, it) }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -74,7 +74,6 @@ class InnsendingIT : EndToEndTest() {
             Key.UUID to UUID.randomUUID().toJson(),
             Key.DATA to
                 mapOf(
-                    Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson(),
                     Key.ARBEIDSGIVER_FNR to Mock.forespoersel.fnr.toJson(),
                     Key.SKJEMA_INNTEKTSMELDING to Mock.skjema.toJson(SkjemaInntektsmelding.serializer()),
                 ).toJson(),


### PR DESCRIPTION
Siden `InnsendingService` legger dataen den trenger videre på data-nøkkelen i meldingene og ikke har noen parallelle operasjoner, så trenger den ikke lenger hjelp fra Redis til å huske hva som foregår.