### PR TITLE
Fjern unødvendig CPU-begrensning

### DIFF
--- a/config/nais.yml
+++ b/config/nais.yml
@@ -32,7 +32,6 @@ spec:
     initialDelay: 5
   resources:
     limits:
-      cpu: 2000m
       memory: 512Mi
     requests:
       cpu: 50m


### PR DESCRIPTION
Man trenger ikke denne, ref. femte paragraf i https://doc.nav.cloud.nais.io/workloads/explanations/good-practices/?h=limits#set-reasonable-resource-requests-and-limits.