### PR TITLE
Støtt d-nummer i saktittel

### DIFF
--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -158,6 +158,6 @@ private fun Fnr.lesFoedselsdato(): String {
     return if (foersteSiffer < 4) {
         verdi.take(6)
     } else {
-        (foersteSiffer - 4).toString() + verdi.take(5)
+        (foersteSiffer - 4).toString() + verdi.substring(1, 6)
     }
 }

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -5,6 +5,7 @@ import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjo
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
 import kotlin.time.Duration.Companion.days
@@ -39,10 +40,7 @@ object NotifikasjonTekst {
         selvbestemtId: UUID,
     ): String = "$linkUrl/im-dialog/kvittering/agi/$selvbestemtId"
 
-    fun sakTittel(sykmeldt: Person): String {
-        val foedselsdato = sykmeldt.fnr.verdi.take(6)
-        return "Inntektsmelding for ${sykmeldt.navn}: f. $foedselsdato"
-    }
+    fun sakTittel(sykmeldt: Person): String = "Inntektsmelding for ${sykmeldt.navn}: f. ${sykmeldt.fnr.lesFoedselsdato()}"
 
     fun oppgaveInnhold(
         orgnr: Orgnr,
@@ -153,3 +151,13 @@ fun ArbeidsgiverNotifikasjonKlient.opprettOppgave(
             tidspunkt = null,
         )
     }
+
+// Støtter d-nummer
+private fun Fnr.lesFoedselsdato(): String {
+    val foersteSiffer = verdi.first().digitToInt()
+    return if (foersteSiffer < 4) {
+        verdi.take(6)
+    } else {
+        (foersteSiffer - 4).toString() + verdi.take(5)
+    }
+}

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtilsTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtilsTest.kt
@@ -1,0 +1,24 @@
+package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.felles.domene.Person
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+
+class ArbeidsgiverNotifikasjonKlientUtilsTest :
+    FunSpec({
+
+        context(NotifikasjonTekst::sakTittel.name) {
+            test("fnr gir forventet saktittel") {
+                val person = Person(Fnr("31030267462"), "James Bånn")
+
+                NotifikasjonTekst.sakTittel(person) shouldBe "Inntektsmelding for James Bånn: f. 310302"
+            }
+
+            test("dnr gir forventet saktittel") {
+                val person = Person(Fnr("63047505900"), "Pierce Brosjan")
+
+                NotifikasjonTekst.sakTittel(person) shouldBe "Inntektsmelding for Pierce Brosjan: f. 230475"
+            }
+        }
+    })


### PR DESCRIPTION
Fødselsdatoen må endres for d-nummer, som bruker +4 på første siffer i fødselsdatostrengen: https://www.skatteetaten.no/person/folkeregister/identitetsnummer/d-nummer/