### PR TITLE
videresend  hele forespørselen i forespoerselMottatt eventet

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -39,6 +39,7 @@ enum class Key(
     ORG_RETTIGHETER("org_rettigheter"),
     FORESPOERSEL_SVAR("forespoersel-svar"),
     FORESPOERSEL_MAP("forespoersel_map"),
+    FORESPOERSEL("forespoersel"),
     INNTEKT("inntekt"),
     FNR("fnr"),
     FNR_LISTE("fnr_liste"),

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -1,12 +1,12 @@
 @file:UseSerializers(UuidSerializer::class, LocalDateSerializer::class)
 
-package no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene
+package no.nav.helsearbeidsgiver.felles.domene
+
+
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
-import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
-import no.nav.helsearbeidsgiver.felles.domene.ForespurtData
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -14,8 +14,9 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.LocalDate
 import java.util.UUID
 
+
 @Serializable
-data class Forespoersel(
+data class ForespoerselFraBro(
     val orgnr: Orgnr,
     val fnr: Fnr,
     /** Ikke bruk ved henting av én forespørsel (Storebror lekker feil id). */

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -2,8 +2,6 @@
 
 package no.nav.helsearbeidsgiver.felles.domene
 
-
-
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
@@ -13,7 +11,6 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.LocalDate
 import java.util.UUID
-
 
 @Serializable
 data class ForespoerselFraBro(

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/pritopic/Pri.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/pritopic/Pri.kt
@@ -28,6 +28,7 @@ object Pri {
         SPINN_INNTEKTSMELDING_ID("spinnInntektsmeldingId"),
         VEDTAKSPERIODE_ID_LISTE("vedtaksperiode_id_liste"),
         SKAL_HA_PAAMINNELSE("skal_ha_paaminnelse"),
+        FORESPOERSEL("forespoersel"),
         ;
 
         override fun toString(): String = str

--- a/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -29,7 +29,7 @@ data class Melding(
     val orgnr: Orgnr,
     val fnr: Fnr,
     val skalHaPaaminnelse: Boolean,
-    val forespoerselFraBro: ForespoerselFraBro
+    val forespoerselFraBro: ForespoerselFraBro,
 )
 
 /** Tar imot notifikasjon om at det er kommet en forespørsel om arbeidsgiveropplysninger. */

--- a/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -5,6 +5,8 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -27,6 +29,7 @@ data class Melding(
     val orgnr: Orgnr,
     val fnr: Fnr,
     val skalHaPaaminnelse: Boolean,
+    val forespoerselFraBro: ForespoerselFraBro
 )
 
 /** Tar imot notifikasjon om at det er kommet en forespørsel om arbeidsgiveropplysninger. */
@@ -42,6 +45,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
             orgnr = Pri.Key.ORGNR.les(Orgnr.serializer(), json),
             fnr = Pri.Key.FNR.les(Fnr.serializer(), json),
             skalHaPaaminnelse = Pri.Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), json),
+            forespoerselFraBro = Pri.Key.FORESPOERSEL.les(ForespoerselFraBro.serializer(), json),
         )
 
     override fun Melding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
@@ -57,6 +61,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
                     Key.ORGNRUNDERENHET to orgnr.toJson(),
                     Key.FNR to fnr.toJson(),
                     Key.SKAL_HA_PAAMINNELSE to skalHaPaaminnelse.toJson(Boolean.serializer()),
+                    Key.FORESPOERSEL to forespoerselFraBro.toForespoersel().toJson(Forespoersel.serializer()),
                 ).toJson(),
         )
     }

--- a/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -8,14 +8,19 @@ import io.kotest.matchers.maps.shouldContainKey
 import io.mockk.clearAllMocks
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
+import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -52,6 +57,7 @@ class ForespoerselMottattRiverTest :
                             Key.ORGNRUNDERENHET to innkommendeMelding.orgnr.toJson(),
                             Key.FNR to innkommendeMelding.fnr.toJson(),
                             Key.SKAL_HA_PAAMINNELSE to innkommendeMelding.skalHaPaaminnelse.toJson(Boolean.serializer()),
+                            Key.FORESPOERSEL to innkommendeMelding.forespoerselFraBro.toForespoersel().toJson(Forespoersel.serializer()),
                         ).toJson(),
                 )
         }
@@ -65,6 +71,7 @@ private fun mockInnkommendeMelding(): Melding =
         orgnr = Orgnr.genererGyldig(),
         fnr = Fnr.genererGyldig(),
         skalHaPaaminnelse = true,
+        forespoerselFraBro = Mock.forespoerselFraBro,
     )
 
 private fun Melding.toMap(): Map<Pri.Key, JsonElement> =
@@ -74,4 +81,21 @@ private fun Melding.toMap(): Map<Pri.Key, JsonElement> =
         Pri.Key.ORGNR to orgnr.toJson(),
         Pri.Key.FNR to fnr.toJson(),
         Pri.Key.SKAL_HA_PAAMINNELSE to skalHaPaaminnelse.toJson(Boolean.serializer()),
+        Pri.Key.FORESPOERSEL to forespoerselFraBro.toJson(ForespoerselFraBro.serializer()),
     )
+
+object Mock {
+    val orgnr = Orgnr.genererGyldig()
+    val forespoerselFraBro =
+        ForespoerselFraBro(
+            orgnr = orgnr,
+            fnr = Fnr.genererGyldig(),
+            vedtaksperiodeId = UUID.randomUUID(),
+            forespoerselId = UUID.randomUUID(),
+            sykmeldingsperioder = listOf(2.januar til 16.januar),
+            egenmeldingsperioder = listOf(1.januar til 1.januar),
+            bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
+            forespurtData = mockForespurtData(),
+            erBesvart = false,
+        )
+}

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselListeSvar.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselListeSvar.kt
@@ -5,12 +5,13 @@ package no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 
 @Serializable
 data class ForespoerselListeSvar(
-    val resultat: List<Forespoersel>,
+    val resultat: List<ForespoerselFraBro>,
     val boomerang: JsonElement,
     val feil: Feil? = null,
 ) {

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselSvar.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselSvar.kt
@@ -5,13 +5,14 @@ package no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.util.UUID
 
 @Serializable
 data class ForespoerselSvar(
     val forespoerselId: UUID,
-    val resultat: Forespoersel? = null,
+    val resultat: ForespoerselFraBro? = null,
     val feil: Feil? = null,
     val boomerang: JsonElement,
 ) {

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -7,7 +7,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtDataMedFastsattInntekt
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselListeSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselSvar
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -32,7 +32,7 @@ fun mockForespoerselListeSvarMedSuksess(): ForespoerselListeSvar {
     return ForespoerselListeSvar(
         resultat =
             listOf(
-                Forespoersel(
+                ForespoerselFraBro(
                     orgnr = orgnr,
                     fnr = Fnr.genererGyldig(),
                     vedtaksperiodeId = UUID.randomUUID(),
@@ -73,9 +73,9 @@ fun mockForespoerselListeSvarMedFeil(): ForespoerselListeSvar =
         feil = ForespoerselListeSvar.Feil.FORESPOERSEL_FOR_VEDTAKSPERIODE_ID_LISTE_FEILET,
     )
 
-fun mockForespoerselSvarSuksess(forespoerselId: UUID): Forespoersel {
+fun mockForespoerselSvarSuksess(forespoerselId: UUID): ForespoerselFraBro {
     val orgnr = Orgnr.genererGyldig()
-    return Forespoersel(
+    return ForespoerselFraBro(
         orgnr = orgnr,
         fnr = Fnr.genererGyldig(),
         forespoerselId = forespoerselId,
@@ -88,9 +88,9 @@ fun mockForespoerselSvarSuksess(forespoerselId: UUID): Forespoersel {
     )
 }
 
-fun mockForespoerselSvarSuksessMedFastsattInntekt(forespoerselId: UUID): Forespoersel {
+fun mockForespoerselSvarSuksessMedFastsattInntekt(forespoerselId: UUID): ForespoerselFraBro {
     val orgnr = Orgnr.genererGyldig()
-    return Forespoersel(
+    return ForespoerselFraBro(
         orgnr = orgnr,
         fnr = Fnr.genererGyldig(),
         forespoerselId = forespoerselId,

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -4,10 +4,10 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtDataMedFastsattInntekt
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselListeSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselSvar
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -41,7 +41,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel as ForespoerselBro
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro as ForespoerselBro
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BerikInntektsmeldingServiceIT : EndToEndTest() {

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -13,6 +13,7 @@ import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
@@ -41,7 +42,6 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding as InntektsmeldingV1
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro as ForespoerselBro
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class BerikInntektsmeldingServiceIT : EndToEndTest() {
@@ -346,7 +346,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             )
 
         val forespoerselSvar =
-            ForespoerselBro(
+            ForespoerselFraBro(
                 orgnr = Orgnr(forespoersel.orgnr),
                 fnr = Fnr(forespoersel.fnr),
                 forespoerselId = forespoerselId,

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
@@ -7,6 +7,7 @@ import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
@@ -14,6 +15,7 @@ import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
+import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -44,6 +46,18 @@ class ForespoerselMottattIT : EndToEndTest() {
             Pri.Key.ORGNR to Mock.orgnr.toJson(),
             Pri.Key.FNR to Mock.fnr.toJson(),
             Pri.Key.SKAL_HA_PAAMINNELSE to Mock.skalHaPaaminnelse.toJson(Boolean.serializer()),
+            Pri.Key.FORESPOERSEL to
+                ForespoerselFraBro(
+                    orgnr = Mock.orgnr,
+                    fnr = Mock.fnr,
+                    forespoerselId = Mock.forespoerselId,
+                    vedtaksperiodeId = UUID.randomUUID(),
+                    sykmeldingsperioder = emptyList(),
+                    egenmeldingsperioder = emptyList(),
+                    bestemmendeFravaersdager = emptyMap(),
+                    forespurtData = mockForespurtData(),
+                    erBesvart = false,
+                ).toJson(ForespoerselFraBro.serializer()),
         )
 
         val messagesFilteredForespoerselMottatt = messages.filter(EventName.FORESPOERSEL_MOTTATT)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -16,6 +16,7 @@ import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
@@ -37,7 +38,6 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro as ForespoerselBro
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InnsendingIT : EndToEndTest() {
@@ -244,7 +244,7 @@ class InnsendingIT : EndToEndTest() {
             )
 
         val forespoerselSvar =
-            ForespoerselBro(
+            ForespoerselFraBro(
                 orgnr = Orgnr(forespoersel.orgnr),
                 fnr = Fnr(forespoersel.fnr),
                 forespoerselId = forespoerselId,

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -37,7 +37,7 @@ import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestInstance
 import java.util.UUID
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel as ForespoerselBro
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro as ForespoerselBro
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class InnsendingIT : EndToEndTest() {

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -19,7 +20,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -19,7 +19,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -158,7 +158,7 @@ class InnsendingServiceIT : EndToEndTest() {
         val vedtaksperiodeId: UUID = UUID.randomUUID()
 
         val forespoerselSvar =
-            Forespoersel(
+            ForespoerselFraBro(
                 orgnr = orgnr,
                 fnr = Fnr.genererGyldig(),
                 forespoerselId = skjema.forespoerselId,

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
@@ -1,8 +1,8 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.mock
 
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
-import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
+import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
@@ -2,16 +2,16 @@ package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.mock
 
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
 
-fun mockForespoerselSvarSuksess(): Forespoersel {
+fun mockForespoerselSvarSuksess(): ForespoerselFraBro {
     val orgnr = Orgnr.genererGyldig()
-    return Forespoersel(
+    return ForespoerselFraBro(
         orgnr = orgnr,
         fnr = Fnr.genererGyldig(),
         forespoerselId = UUID.randomUUID(),
@@ -31,10 +31,10 @@ fun mockForespoerselSvarSuksess(): Forespoersel {
 fun mockForespoerselListeSvarResultat(
     vedtaksperiodeId1: UUID,
     vedtaksperiodeId2: UUID,
-): List<Forespoersel> {
+): List<ForespoerselFraBro> {
     val orgnr = Orgnr.genererGyldig()
     val forespoersel =
-        Forespoersel(
+        ForespoerselFraBro(
             orgnr = orgnr,
             fnr = Fnr.genererGyldig(),
             forespoerselId = UUID.randomUUID(),

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.brreg.Virksomhet
 import no.nav.helsearbeidsgiver.dokarkiv.DokArkivClient
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.db.exposed.Database
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
@@ -49,7 +50,6 @@ import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselinfotrygd.createFore
 import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselmarkerbesvart.createMarkerForespoerselBesvart
 import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselmottatt.createForespoerselMottattRiver
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.createHelsebroRivers
-import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselListeSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.innsending.createInnsending

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -49,7 +49,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselinfotrygd.createFore
 import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselmarkerbesvart.createMarkerForespoerselBesvart
 import no.nav.helsearbeidsgiver.inntektsmelding.forespoerselmottatt.createForespoerselMottattRiver
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.createHelsebroRivers
-import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.Forespoersel
+import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselListeSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselSvar
 import no.nav.helsearbeidsgiver.inntektsmelding.innsending.createInnsending
@@ -317,7 +317,7 @@ abstract class EndToEndTest : ContainerTest() {
 
     fun mockForespoerselSvarFraHelsebro(
         forespoerselId: UUID,
-        forespoerselSvar: Forespoersel,
+        forespoerselSvar: ForespoerselFraBro,
     ) {
         var boomerang: JsonElement? = null
 
@@ -351,7 +351,7 @@ abstract class EndToEndTest : ContainerTest() {
         }
     }
 
-    fun mockForespoerselSvarFraHelsebro(forespoerselListeSvar: List<Forespoersel>) {
+    fun mockForespoerselSvarFraHelsebro(forespoerselListeSvar: List<ForespoerselFraBro>) {
         var boomerang: JsonElement? = null
 
         every {


### PR DESCRIPTION
For å kunne ta med sykepemeldingsperioder i varselet til arbeidsgiver trenger i å videresende hele forespørselen i forespørsel mottatt eventet. Dette kan også brukes i lps-apiet.