### PR TITLE
Bruk ny event for journalpost ID lagret

### DIFF
--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
@@ -32,8 +32,7 @@ class LagreEksternImRiver(
     private val sikkerLogger = sikkerLogger()
 
     override fun les(json: Map<Key, JsonElement>): LagreEksternImMelding? =
-        // TODO ignorer behov etter overgangsfase
-        if (Key.FAIL in json) {
+        if (setOf(Key.BEHOV, Key.FAIL).any(json::containsKey)) {
             null
         } else {
             val data = json[Key.DATA]?.toMap().orEmpty()

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -84,14 +84,14 @@ class LagreJournalpostIdRiver(
         }
 
         return mapOf(
-            Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
+            Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
             Key.UUID to transaksjonId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.BESTEMMENDE_FRAVAERSDAG to json[Key.BESTEMMENDE_FRAVAERSDAG],
             Key.JOURNALPOST_ID to journalpostId.toJson(),
         ).mapValuesNotNull { it }
             .also {
-                logger.info("Publiserer event '${EventName.INNTEKTSMELDING_JOURNALFOERT}' med journalpost-ID '$journalpostId'.")
+                logger.info("Publiserer event '${EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET}' med journalpost-ID '$journalpostId'.")
                 sikkerLogger.info("Publiserer event:\n${it.toPretty()}")
             }
     }

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
@@ -14,6 +14,7 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
+import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
@@ -90,7 +91,7 @@ class LagreEksternImRiverTest :
         context("ignorerer melding") {
             withData(
                 mapOf(
-//                    "melding med uønsket behov" to Pair(Key.BEHOV, BehovType.HENT_VIRKSOMHET_NAVN.toJson()),
+                    "melding med uønsket behov" to Pair(Key.BEHOV, BehovType.HENT_VIRKSOMHET_NAVN.toJson()),
                     "melding med data som flagg" to Pair(Key.DATA, "".toJson()),
                     "melding med fail" to Pair(Key.FAIL, mockFail.toJson(Fail.serializer())),
                 ),

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -61,7 +61,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
-                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
+                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(),
@@ -101,7 +101,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
-                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
+                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),

--- a/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
+++ b/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
@@ -213,7 +213,7 @@ private object Mock {
     val fail =
         Fail(
             feilmelding = "I'm afraid I can't let you do that.",
-            event = EventName.INNTEKTSMELDING_JOURNALFOERT,
+            event = EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET,
             transaksjonId = UUID.randomUUID(),
             forespoerselId = UUID.randomUUID(),
             utloesendeMelding = JsonNull,
@@ -221,7 +221,7 @@ private object Mock {
 
     fun innkommendeMelding(): Melding =
         Melding(
-            eventName = EventName.INNTEKTSMELDING_JOURNALFOERT,
+            eventName = EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET,
             transaksjonId = UUID.randomUUID(),
             inntektsmelding = mockInntektsmeldingV1(),
             bestemmendeFravaersdag = bestemmendeFravaersdag,

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -101,7 +101,7 @@ class InnsendingIT : EndToEndTest() {
             }
 
         messages
-            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
+            .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .firstAsMap()
             .also {
                 it shouldContainKey Key.INNTEKTSMELDING
@@ -153,6 +153,8 @@ class InnsendingIT : EndToEndTest() {
 
         messages.filter(EventName.INNTEKTSMELDING_JOURNALFOERT).all() shouldHaveSize 0
 
+        messages.filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET).all() shouldHaveSize 0
+
         messages.filter(EventName.INNTEKTSMELDING_DISTRIBUERT).all() shouldHaveSize 0
     }
 
@@ -185,6 +187,8 @@ class InnsendingIT : EndToEndTest() {
         messages.filter(EventName.INNTEKTSMELDING_MOTTATT).all() shouldHaveSize 0
 
         messages.filter(EventName.INNTEKTSMELDING_JOURNALFOERT).all() shouldHaveSize 0
+
+        messages.filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET).all() shouldHaveSize 0
 
         messages.filter(EventName.INNTEKTSMELDING_DISTRIBUERT).all() shouldHaveSize 0
     }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -177,7 +177,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)
 
         messages
-            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
+            .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .firstAsMap()
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)
 
@@ -250,7 +250,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
 
         messages
-            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
+            .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .firstAsMap()
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
 
@@ -324,7 +324,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldBeEmpty()
 
         messages
-            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
+            .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .all()
             .shouldBeEmpty()
 


### PR DESCRIPTION
Bytter til en event som er mer presis. Neste ledd i kjeden (distribusjon) forventer allerede den nye eventen.