### PR TITLE
Bruk egen event for fullført journalføring

### DIFF
--- a/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -52,18 +53,13 @@ class DistribusjonRiver(
         ) {
             null
         } else {
-            val eventName = Key.EVENT_NAME.les(EventName.serializer(), json)
-            if (eventName !in setOf(EventName.INNTEKTSMELDING_JOURNALFOERT, EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)) {
-                null
-            } else {
-                Melding(
-                    eventName = eventName,
-                    transaksjonId = Key.UUID.les(UuidSerializer, json),
-                    inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
-                    bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, json),
-                    journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
-                )
-            }
+            Melding(
+                eventName = Key.EVENT_NAME.krev(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET, EventName.serializer(), json),
+                transaksjonId = Key.UUID.les(UuidSerializer, json),
+                inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
+                bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, json),
+                journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
+            )
         }
     }
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -92,11 +92,11 @@ class InnsendingIT : EndToEndTest() {
             }
 
         messages
-            .filter(EventName.INNTEKTSMELDING_MOTTATT)
+            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .filter(BehovType.LAGRE_JOURNALPOST_ID)
             .firstAsMap()
             .also {
-                // Journalført i dokarkiv
+                it shouldContainKey Key.INNTEKTSMELDING
                 it[Key.JOURNALPOST_ID]?.fromJson(String.serializer()) shouldBe Mock.JOURNALPOST_ID
             }
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -244,7 +244,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldBeEqualToInntektsmelding(Mock.inntektsmelding, compareType = true)
 
         messages
-            .filter(EventName.SELVBESTEMT_IM_LAGRET)
+            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .filter(BehovType.LAGRE_JOURNALPOST_ID)
             .firstAsMap()
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
@@ -318,7 +318,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldBeEmpty()
 
         messages
-            .filter(EventName.SELVBESTEMT_IM_LAGRET)
+            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .filter(BehovType.LAGRE_JOURNALPOST_ID)
             .all()
             .shouldBeEmpty()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -171,7 +171,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
             .shouldBeEqualToInntektsmelding(nyInntektsmelding)
 
         messages
-            .filter(EventName.SELVBESTEMT_IM_LAGRET)
+            .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .filter(BehovType.LAGRE_JOURNALPOST_ID)
             .firstAsMap()
             .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -82,7 +82,7 @@ class JournalfoerImRiver(
         val journalpostId = opprettOgFerdigstillJournalpost(transaksjonId, inntektsmelding, bestemmendeFravaersdag)
 
         return mapOf(
-            Key.EVENT_NAME to eventName.toJson(),
+            Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
             Key.BEHOV to BehovType.LAGRE_JOURNALPOST_ID.toJson(),
             Key.UUID to transaksjonId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -75,7 +75,7 @@ class JournalfoerImRiverTest :
 
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
-                        Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
+                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.BEHOV to BehovType.LAGRE_JOURNALPOST_ID.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
@@ -122,7 +122,7 @@ class JournalfoerImRiverTest :
 
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
-                        Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
+                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.BEHOV to BehovType.LAGRE_JOURNALPOST_ID.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
@@ -174,7 +174,7 @@ class JournalfoerImRiverTest :
 
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
-                    Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
+                    Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                     Key.BEHOV to BehovType.LAGRE_JOURNALPOST_ID.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
                     Key.JOURNALPOST_ID to journalpostId.toJson(),


### PR DESCRIPTION
Journalføring får en egen (resirkulert) event for å komme oss bort fra behov i den asykrone flyten.