### PR TITLE
Sett ikke funnet forespørsel til utgått

### DIFF
--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -284,7 +284,7 @@ abstract class EndToEndTest : ContainerTest() {
 
     fun mockForespoerselSvarFraHelsebro(
         forespoerselId: UUID,
-        forespoerselSvar: ForespoerselFraBro,
+        forespoerselSvar: ForespoerselFraBro?,
     ) {
         var boomerang: JsonElement? = null
 
@@ -308,6 +308,12 @@ abstract class EndToEndTest : ContainerTest() {
                     ForespoerselSvar(
                         forespoerselId = forespoerselId,
                         resultat = forespoerselSvar,
+                        feil =
+                            if (forespoerselSvar == null) {
+                                ForespoerselSvar.Feil.FORESPOERSEL_IKKE_FUNNET
+                            } else {
+                                null
+                            },
                         boomerang = boomerang.shouldNotBeNull(),
                     ).toJson(ForespoerselSvar.serializer()),
             )

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
@@ -2,16 +2,20 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
+import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.mockk
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveFinnesIkkeException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
+import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -20,6 +24,8 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river.Mock.toMap
+import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -30,7 +36,7 @@ class UtgaattForespoerselRiverTest :
 
         UtgaattForespoerselRiver(Mock.LINK_URL, mockAgNotifikasjonKlient).connect(testRapid)
 
-        beforeEach {
+        beforeTest {
             testRapid.reset()
             clearAllMocks()
         }
@@ -208,6 +214,109 @@ class UtgaattForespoerselRiverTest :
                 )
             }
         }
+
+        context("Ved mislykket henting av forkastet (ikke funnet) forespørsel") {
+
+            test("med korrekt fail så settes oppgaven til utgått og sak til ferdig") {
+                val innkommendeFail = Mock.forespoerselIkkeFunnetFail()
+                val forespoerselId =
+                    innkommendeFail.utloesendeMelding
+                        .toMap()[Key.DATA]
+                        .shouldNotBeNull()
+                        .toMap()[Key.FORESPOERSEL_ID]
+                        .shouldNotBeNull()
+                        .fromJson(UuidSerializer)
+
+                testRapid.sendJson(innkommendeFail.tilMelding())
+
+                testRapid.inspektør.size shouldBeExactly 1
+                testRapid.firstMessage().toMap() shouldContainExactly
+                    mapOf(
+                        Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_UTGAATT.toJson(),
+                        Key.UUID to innkommendeFail.transaksjonId.toJson(),
+                        Key.FORESPOERSEL_ID to forespoerselId.toJson(),
+                    )
+
+                coVerifySequence {
+                    mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
+                        merkelapp = "Inntektsmelding sykepenger",
+                        eksternId = forespoerselId.toString(),
+                        nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
+                    )
+                    mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
+                        grupperingsid = forespoerselId.toString(),
+                        merkelapp = "Inntektsmelding sykepenger",
+                        status = SaksStatus.FERDIG,
+                        tidspunkt = null,
+                        statusTekst = "Avbrutt av Nav",
+                        nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
+                    )
+                }
+            }
+
+            test("med feil behovtype så ignoreres meldingen") {
+                val innkommendeFail =
+                    Mock.forespoerselIkkeFunnetFail().let {
+                        it.copy(
+                            utloesendeMelding =
+                                it.utloesendeMelding
+                                    .toMap()
+                                    .plus(Key.BEHOV to BehovType.HENT_INNTEKT.toJson())
+                                    .toJson(),
+                        )
+                    }
+
+                testRapid.sendJson(innkommendeFail.tilMelding())
+
+                testRapid.inspektør.size shouldBeExactly 0
+
+                coVerify(exactly = 0) {
+                    mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(any(), any(), any())
+                    mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), any(), any(), any(), any(), any())
+                }
+            }
+
+            test("med feil feilmelding så ignoreres meldingen") {
+                val innkommendeFail =
+                    Mock.forespoerselIkkeFunnetFail().copy(
+                        feilmelding = "Klarte ikke hente forespørsel. Ukjent feil.",
+                    )
+
+                testRapid.sendJson(innkommendeFail.tilMelding())
+
+                testRapid.inspektør.size shouldBeExactly 0
+
+                coVerify(exactly = 0) {
+                    mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(any(), any(), any())
+                    mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), any(), any(), any(), any(), any())
+                }
+            }
+        }
+
+        context("ignorerer melding") {
+            withData(
+                mapOf(
+                    "melding med uønsket event" to Pair(Key.EVENT_NAME, EventName.FORESPOERSEL_BESVART.toJson()),
+                    "melding med uønsket behov" to Pair(Key.BEHOV, BehovType.HENT_INNTEKT.toJson()),
+                    "melding med data som flagg" to Pair(Key.DATA, "".toJson()),
+                    "melding med fail" to Pair(Key.FAIL, Mock.forventetFail(Mock.innkommendeMelding()).toJson(Fail.serializer())),
+                ),
+            ) { uoensketKeyMedVerdi ->
+                testRapid.sendJson(
+                    Mock
+                        .innkommendeMelding()
+                        .toMap()
+                        .plus(uoensketKeyMedVerdi),
+                )
+
+                testRapid.inspektør.size shouldBeExactly 0
+
+                coVerify(exactly = 0) {
+                    mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(any(), any(), any())
+                    mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), any(), any(), any(), any(), any())
+                }
+            }
+        }
     })
 
 private object Mock {
@@ -242,4 +351,27 @@ private object Mock {
             forespoerselId = innkommendeMelding.forespoerselId,
             utloesendeMelding = innkommendeMelding.toMap().toJson(),
         )
+
+    fun forespoerselIkkeFunnetFail(): Fail {
+        val eventName = EventName.TRENGER_REQUESTED
+        val transaksjonId = UUID.randomUUID()
+        val forespoerselId = UUID.randomUUID()
+
+        return Fail(
+            feilmelding = "Klarte ikke hente forespørsel. Feilet med kode 'FORESPOERSEL_IKKE_FUNNET'.",
+            event = eventName,
+            transaksjonId = transaksjonId,
+            forespoerselId = forespoerselId,
+            utloesendeMelding =
+                mapOf(
+                    Key.EVENT_NAME to eventName.toJson(),
+                    Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
+                    Key.UUID to transaksjonId.toJson(),
+                    Key.DATA to
+                        mapOf(
+                            Key.FORESPOERSEL_ID to forespoerselId.toJson(),
+                        ).toJson(),
+                ).toJson(),
+        )
+    }
 }


### PR DESCRIPTION
Alle forespølser som blir forkastet vil i dag få sak og oppgave satt til utgått, men gamle forkastede forespørsler vil ikke det. Denne endringen gjør at gamle forkastede forespørsler får sak og oppgave satt til utgått dersom noen forsøker å hente dem. Slik vil man forhåpentligvis hjelpe noen arbeidsgivere å forstå at forespørselen de prøver å finne ikke lenger trenger en IM.