### PR TITLE
Send data som nested objekt ved mottatt IM

### DIFF
--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -216,9 +216,13 @@ class BerikInntektsmeldingService(
                 rapid.publish(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
                     Key.UUID to steg0.transaksjonId.toJson(),
-                    Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
-                    Key.INNTEKTSMELDING to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                    Key.BESTEMMENDE_FRAVAERSDAG to steg4.bestemmendeFravaersdag.toJson(),
+                    Key.DATA to
+                        mapOf(
+                            Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
+                            Key.INNTEKTSMELDING to steg4.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                            Key.BESTEMMENDE_FRAVAERSDAG to steg4.bestemmendeFravaersdag.toJson(),
+                            Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
+                        ).toJson(),
                     Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                 )
 

--- a/berik-inntektsmelding-service/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
+++ b/berik-inntektsmelding-service/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
@@ -20,7 +20,6 @@ import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
-import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.felles.test.json.lesBehov
@@ -116,10 +115,12 @@ class BerikInntektsmeldingServiceTest :
             testRapid.inspektør.size shouldBeExactly 5
             testRapid.message(4).also {
                 it.lesEventName() shouldBe EventName.INNTEKTSMELDING_MOTTATT
-                Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, it.toMap()) shouldBe Mock.skjema.forespoerselId
-                Key.INNTEKTSMELDING.lesOrNull(InntektsmeldingV1.serializer(), it.toMap()) shouldNotBe null
-                Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, it.toMap()) shouldNotBe null
-                Key.INNSENDING_ID.lesOrNull(Long.serializer(), it.toMap()) shouldBe Mock.INNSENDING_ID
+
+                val data = it.lesData()
+                Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data) shouldBe Mock.skjema.forespoerselId
+                Key.INNTEKTSMELDING.lesOrNull(InntektsmeldingV1.serializer(), data) shouldNotBe null
+                Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, data) shouldNotBe null
+                Key.INNSENDING_ID.lesOrNull(Long.serializer(), data) shouldBe Mock.INNSENDING_ID
             }
         }
 

--- a/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
+++ b/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
@@ -41,8 +41,7 @@ class LagreEksternImRiver(
                 eventName = Key.EVENT_NAME.krev(EventName.EKSTERN_INNTEKTSMELDING_MOTTATT, EventName.serializer(), json),
                 transaksjonId = Key.UUID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
-                eksternInntektsmelding =
-                    Key.EKSTERN_INNTEKTSMELDING.les(EksternInntektsmelding.serializer(), data),
+                eksternInntektsmelding = Key.EKSTERN_INNTEKTSMELDING.les(EksternInntektsmelding.serializer(), data),
             )
         }
 

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
@@ -98,9 +98,7 @@ class KvitteringService(
         val resultJson =
             ResultJson(
                 success =
-                    InnsendtInntektsmelding(steg1.inntektsmeldingDokument, steg1.eksternInntektsmelding).toJson(
-                        InnsendtInntektsmelding.serializer(),
-                    ),
+                    InnsendtInntektsmelding(steg1.inntektsmeldingDokument, steg1.eksternInntektsmelding).toJson(InnsendtInntektsmelding.serializer()),
             ).toJson(ResultJson.serializer())
 
         redisStore.skrivResultat(steg0.transaksjonId, resultJson)

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -148,15 +148,17 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
 
-                    it[Key.FORESPOERSEL_ID]
+                    val data = it[Key.DATA].shouldNotBeNull().toMap()
+
+                    data[Key.FORESPOERSEL_ID]
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
 
-                    it[Key.INNTEKTSMELDING]
+                    data[Key.INNTEKTSMELDING]
                         .shouldNotBeNull()
                         .fromJson(InntektsmeldingV1.serializer())
 
-                    it[Key.BESTEMMENDE_FRAVAERSDAG]
+                    data[Key.BESTEMMENDE_FRAVAERSDAG]
                         .shouldNotBeNull()
                         .fromJson(LocalDateSerializer)
                 }
@@ -282,15 +284,17 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
 
-                    it[Key.FORESPOERSEL_ID]
+                    val data = it[Key.DATA].shouldNotBeNull().toMap()
+
+                    data[Key.FORESPOERSEL_ID]
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
 
-                    it[Key.INNTEKTSMELDING]
+                    data[Key.INNTEKTSMELDING]
                         .shouldNotBeNull()
                         .fromJson(InntektsmeldingV1.serializer())
 
-                    it[Key.BESTEMMENDE_FRAVAERSDAG]
+                    data[Key.BESTEMMENDE_FRAVAERSDAG]
                         .shouldNotBeNull()
                         .fromJson(LocalDateSerializer)
                 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -86,8 +86,8 @@ class InnsendingIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_MOTTATT)
             .firstAsMap()
             .also {
-                // EVENT: Mottatt inntektsmelding
-                it[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer) shouldBe Mock.forespoerselId
+                val data = it[Key.DATA].shouldNotBeNull().toMap()
+                data[Key.FORESPOERSEL_ID]?.fromJson(UuidSerializer) shouldBe Mock.forespoerselId
             }
 
         messages

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -165,7 +165,9 @@ class LagreSelvbestemtIT : EndToEndTest() {
         // Service ferdig
         messages
             .filter(EventName.SELVBESTEMT_IM_LAGRET)
-            .firstAsMap()[Key.SELVBESTEMT_INNTEKTSMELDING]
+            .firstAsMap()[Key.DATA]
+            .shouldNotBeNull()
+            .toMap()[Key.SELVBESTEMT_INNTEKTSMELDING]
             .shouldNotBeNull()
             .fromJson(Inntektsmelding.serializer())
             .shouldBeEqualToInntektsmelding(nyInntektsmelding)
@@ -237,7 +239,9 @@ class LagreSelvbestemtIT : EndToEndTest() {
         // Service ferdig
         messages
             .filter(EventName.SELVBESTEMT_IM_LAGRET)
-            .firstAsMap()[Key.SELVBESTEMT_INNTEKTSMELDING]
+            .firstAsMap()[Key.DATA]
+            .shouldNotBeNull()
+            .toMap()[Key.SELVBESTEMT_INNTEKTSMELDING]
             .shouldNotBeNull()
             .fromJson(Inntektsmelding.serializer())
             .shouldBeEqualToInntektsmelding(Mock.inntektsmelding, compareType = true)

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -88,7 +88,7 @@ class JournalfoerImRiver(
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag?.toJson(),
-            Key.INNSENDING_ID to (json[Key.INNSENDING_ID] ?: json[Key.DATA]?.toMap().orEmpty()[Key.FORESPOERSEL_ID]),
+            Key.INNSENDING_ID to (json[Key.INNSENDING_ID] ?: json[Key.DATA]?.toMap().orEmpty()[Key.INNSENDING_ID]),
         ).mapValuesNotNull { it }
             .also {
                 logger.info("Publiserte melding med event '${EventName.INNTEKTSMELDING_JOURNALFOERT}' og journalpost-ID '$journalpostId'.")

--- a/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -88,7 +88,7 @@ class JournalfoerImRiver(
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag?.toJson(),
-            Key.INNSENDING_ID to json[Key.INNSENDING_ID],
+            Key.INNSENDING_ID to (json[Key.INNSENDING_ID] ?: json[Key.DATA]?.toMap().orEmpty()[Key.FORESPOERSEL_ID]),
         ).mapValuesNotNull { it }
             .also {
                 logger.info("Publiserte melding med event '${EventName.INNTEKTSMELDING_JOURNALFOERT}' og journalpost-ID '$journalpostId'.")

--- a/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -272,7 +272,10 @@ class LagreSelvbestemtImService(
                     rapid.publish(
                         Key.EVENT_NAME to EventName.SELVBESTEMT_IM_LAGRET.toJson(),
                         Key.UUID to steg0.transaksjonId.toJson(),
-                        Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                        Key.DATA to
+                            mapOf(
+                                Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                            ).toJson(),
                     )
 
                 MdcUtils.withLogFields(

--- a/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -35,7 +35,6 @@ import no.nav.helsearbeidsgiver.felles.domene.Arbeidsgiver
 import no.nav.helsearbeidsgiver.felles.domene.PeriodeNullable
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
-import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -129,7 +128,8 @@ class LagreSelvbestemtImServiceTest :
             testRapid.message(5).toMap().also {
                 Key.EVENT_NAME.lesOrNull(EventName.serializer(), it) shouldBe EventName.SELVBESTEMT_IM_LAGRET
                 Key.UUID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
-                Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), it).shouldBeEqualToIgnoringFields(nyInntektsmelding, Inntektsmelding::id)
+
+                it.lesInntektsmelding().shouldBeEqualToIgnoringFields(nyInntektsmelding, Inntektsmelding::id)
             }
 
             verify {
@@ -177,7 +177,8 @@ class LagreSelvbestemtImServiceTest :
             testRapid.message(4).toMap().also {
                 Key.EVENT_NAME.lesOrNull(EventName.serializer(), it) shouldBe EventName.SELVBESTEMT_IM_LAGRET
                 Key.UUID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
-                Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), it).shouldBeEqualToIgnoringFields(endretInntektsmelding, Inntektsmelding::id)
+
+                it.lesInntektsmelding().shouldBeEqualToIgnoringFields(endretInntektsmelding, Inntektsmelding::id)
             }
 
             verify {
@@ -308,9 +309,8 @@ class LagreSelvbestemtImServiceTest :
             testRapid.message(4).toMap().also {
                 Key.EVENT_NAME.lesOrNull(EventName.serializer(), it) shouldBe EventName.SELVBESTEMT_IM_LAGRET
                 Key.UUID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
-                Key.SELVBESTEMT_INNTEKTSMELDING
-                    .les(Inntektsmelding.serializer(), it)
-                    .shouldBeEqualToIgnoringFields(inntektsmeldingMedDefaults, Inntektsmelding::id)
+
+                it.lesInntektsmelding().shouldBeEqualToIgnoringFields(inntektsmeldingMedDefaults, Inntektsmelding::id)
             }
 
             verify {


### PR DESCRIPTION
Et forsøk på å være mer konsekvent i å sende datafelter under Key.DATA.