### PR TITLE
Legg til erstatningskey i melding for forespoersel-ID

### DIFF
--- a/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
+++ b/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.HentArbeidsforholdMelding
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.HentArbeidsforholdRiver
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.tilArbeidsforhold
@@ -57,7 +57,7 @@ class HentArbeidsforholdRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -90,7 +90,7 @@ class HentArbeidsforholdRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockAaregClient.hentArbeidsforhold(innkommendeMelding.fnr.verdi, innkommendeMelding.transaksjonId.toString())

--- a/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiverTest.kt
+++ b/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -19,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.altinn.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -50,7 +50,7 @@ class AltinnRiverTest :
                     .mapNotNull { it.orgnr }
                     .toSet()
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -86,7 +86,7 @@ class AltinnRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockAltinnClient.hentRettighetOrganisasjoner(innkommendeMelding.fnr.verdi)

--- a/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiverTest.kt
+++ b/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiverTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -23,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.altinn.MockTilgang.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -57,7 +57,7 @@ class TilgangRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -91,7 +91,7 @@ class TilgangRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockAltinnClient.harRettighetForOrganisasjon(innkommendeMelding.fnr.verdi, innkommendeMelding.orgnr.verdi)

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -11,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.api.innsending.InnsendingProducer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -30,7 +30,7 @@ class InnsendingProducerTest :
             producer.publish(transaksjonId, skjema, avsenderFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.aktiveorgnr
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -27,7 +27,7 @@ class AktiveOrgnrProducerTest :
             producer.publish(transaksjonId, arbeidsgiverFnr, arbeidstagerFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -27,7 +27,7 @@ class HentForespoerselProducerTest :
             producer.publish(transaksjonId, HentForespoerselRequest(forespoerselId), avsenderFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoerselIdListe
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -25,7 +25,7 @@ class HentForespoerselIdListeProducerTest :
             producer.publish(transaksjonId, HentForespoerslerRequest(vedtaksperiodeIdListe))
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentselvbestemtim
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -25,7 +25,7 @@ class HentSelvbestemtImProducerTest :
             producer.publish(transaksjonId, selvbestemtId)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
@@ -2,12 +2,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.inntekt
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import java.util.UUID
@@ -25,7 +25,7 @@ class InntektProducerTest :
 
             val publisert = testRapid.firstMessage().toMap()
 
-            publisert shouldContainExactly
+            publisert shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.inntektselvbestemt
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -30,7 +30,7 @@ class InntektSelvbestemtProducerTest :
             producer.publish(transaksjonId, InntektSelvbestemtRequest(sykmeldtFnr, orgnr, inntektsdato))
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducerTest.kt
@@ -3,12 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.kvittering
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -24,7 +24,7 @@ class KvitteringProducerTest :
             producer.publish(transaksjonId, forespoerselId)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducerTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducerTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.lagreselvbestemtim
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -11,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -30,7 +30,7 @@ class LagreSelvbestemtImProducerTest :
             producer.publish(transaksjonId, skjema, avsenderFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
                     Key.UUID to transaksjonId.toJson(),

--- a/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiverTest.kt
+++ b/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiverTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -23,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.brospinn.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -49,7 +49,7 @@ class HentEksternImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_MOTTATT.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -124,7 +124,7 @@ class HentEksternImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
                 verifySequence {
                     mockSpinnKlient.hentEksternInntektsmelding(innkommendeMelding.spinnImId)

--- a/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
+++ b/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.brreg.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -56,7 +56,7 @@ class HentVirksomhetNavnRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -87,7 +87,7 @@ class HentVirksomhetNavnRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -118,7 +118,7 @@ class HentVirksomhetNavnRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -151,7 +151,7 @@ class HentVirksomhetNavnRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockBrregClient.hentVirksomheter(innkommendeMelding.orgnr.map { it.verdi })

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -25,6 +24,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.MockHentIm.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -64,7 +64,7 @@ class HentLagretImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -112,7 +112,7 @@ class HentLagretImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             verifySequence {
                 mockImRepo.hentNyesteEksternEllerInternInntektsmelding(innkommendeMelding.forespoerselId)

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -22,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -55,7 +55,7 @@ class HentSelvbestemtImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -81,7 +81,7 @@ class HentSelvbestemtImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 forventetFail
                     .tilMelding()
                     .minus(Key.FORESPOERSEL_ID)
@@ -102,7 +102,7 @@ class HentSelvbestemtImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 forventetFail
                     .tilMelding()
                     .minus(Key.FORESPOERSEL_ID)

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -24,6 +23,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -49,7 +49,7 @@ class LagreEksternImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_LAGRET.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -81,7 +81,7 @@ class LagreEksternImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             verifySequence {
                 mockImRepo.lagreEksternInntektsmelding(innkommendeMelding.forespoerselId, innkommendeMelding.eksternInntektsmelding)

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -28,6 +27,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.august
@@ -69,7 +69,7 @@ class LagreImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -114,7 +114,7 @@ class LagreImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -155,7 +155,7 @@ class LagreImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             verifySequence {
                 mockImRepo.hentNyesteInntektsmelding(any())

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -25,6 +24,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.juli
@@ -76,7 +76,7 @@ class LagreImSkjemaRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -108,7 +108,7 @@ class LagreImSkjemaRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -150,7 +150,7 @@ class LagreImSkjemaRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             verifySequence {
                 mockInntektsmeldingRepo.hentNyesteInntektsmeldingSkjema(any())

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -26,6 +25,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.INNSENDING_ID
@@ -59,7 +59,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -99,7 +99,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -154,7 +154,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
                 verifySequence {
                     mockImRepo.oppdaterJournalpostId(any(), any())
@@ -190,7 +190,7 @@ class LagreJournalpostIdRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
                 verifySequence {
                     mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())

--- a/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiverTest.kt
+++ b/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
@@ -27,6 +26,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.juli
@@ -68,7 +68,7 @@ class LagreSelvbestemtImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -110,7 +110,7 @@ class LagreSelvbestemtImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -149,7 +149,7 @@ class LagreSelvbestemtImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 forventetFail
                     .tilMelding()
                     .minus(Key.FORESPOERSEL_ID)

--- a/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
+++ b/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -24,6 +23,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.distribusjon.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -56,7 +56,7 @@ class DistribusjonRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -104,7 +104,7 @@ class DistribusjonRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -149,7 +149,7 @@ class DistribusjonRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             verifySequence {
                 mockKafkaProducer.send(any())

--- a/feil-behandler/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytterTest.kt
+++ b/feil-behandler/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytterTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.river
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import kotlinx.serialization.builtins.serializer
@@ -16,6 +15,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.prosessor.FeilProsessor
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
@@ -53,7 +53,7 @@ class FeilLytterTest :
             jobber.size shouldBeExactly 1
 
             jobber[0].uuid shouldBe forespoerselMottattFail.transaksjonId
-            jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding.toMap()
+            jobber[0].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail.utloesendeMelding.toMap()
         }
 
         test("ved flere feil på samme transaksjon-ID og event, men ulikt innhold, så lagres to jobber med ulik transaksjon-ID") {
@@ -84,7 +84,7 @@ class FeilLytterTest :
             jobber.size shouldBeExactly 2
 
             jobber[0].uuid shouldBe transaksjonId
-            jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding.toMap()
+            jobber[0].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail.utloesendeMelding.toMap()
 
             jobber[1].uuid shouldNotBe transaksjonId
             jobber[1].data.parseJson().toMap().also {
@@ -114,7 +114,7 @@ class FeilLytterTest :
             jobber.size shouldBeExactly 2
 
             jobber[0].uuid shouldBe transaksjonId
-            jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding.toMap()
+            jobber[0].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail.utloesendeMelding.toMap()
 
             jobber[1].uuid shouldNotBe transaksjonId
             jobber[1].data.parseJson().toMap().also {
@@ -141,10 +141,10 @@ class FeilLytterTest :
             jobber.size shouldBeExactly 2
 
             jobber[0].uuid shouldBe forespoerselMottattFail1.transaksjonId
-            jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail1.utloesendeMelding.toMap()
+            jobber[0].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail1.utloesendeMelding.toMap()
 
             jobber[1].uuid shouldBe forespoerselMottattFail2.transaksjonId
-            jobber[1].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail2.utloesendeMelding.toMap()
+            jobber[1].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail2.utloesendeMelding.toMap()
         }
 
         test("ved flere feil på ulik transaksjon-ID og ulik event, så lagres to jobber (med ulik transaksjon-ID)") {
@@ -165,10 +165,10 @@ class FeilLytterTest :
             jobber.size shouldBeExactly 2
 
             jobber[0].uuid shouldBe forespoerselMottattFail.transaksjonId
-            jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding.toMap()
+            jobber[0].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselMottattFail.utloesendeMelding.toMap()
 
             jobber[1].uuid shouldBe forespoerselBesvartFail.transaksjonId
-            jobber[1].data.parseJson().toMap() shouldContainExactly forespoerselBesvartFail.utloesendeMelding.toMap()
+            jobber[1].data.parseJson().toMap() shouldContainAllExcludingTempKey forespoerselBesvartFail.utloesendeMelding.toMap()
         }
 
         test("setter jobb til STOPPET når maks antall forsøk er overskredet") {

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -52,6 +52,7 @@ enum class Key(
 
     // ulik formattering
     FORESPOERSEL_ID("forespoerselId"),
+    FORESPOERSEL_ID_V2("forespoersel_id"),
     ORGNRUNDERENHET("orgnrUnderenhet"),
     SPINN_INNTEKTSMELDING_ID("spinnInntektsmeldingId"),
     ;

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -8,6 +8,9 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 
@@ -15,7 +18,19 @@ fun MessageContext.publish(vararg messageFields: Pair<Key, JsonElement>): JsonEl
 
 fun MessageContext.publish(messageFields: Map<Key, JsonElement>): JsonElement =
     messageFields
-        .mapKeys { (key, _) -> key.toString() }
+        .let { root ->
+            val data = root[Key.DATA]?.toMap().orEmpty()
+            val newData =
+                data
+                    .plus(Key.FORESPOERSEL_ID_V2 to data[Key.FORESPOERSEL_ID])
+                    .mapValuesNotNull { it }
+                    .ifEmpty { null }
+
+            root
+                .plus(Key.FORESPOERSEL_ID_V2 to root[Key.FORESPOERSEL_ID])
+                .plus(Key.DATA to newData?.toJson())
+                .mapValuesNotNull { it }
+        }.mapKeys { (key, _) -> key.toString() }
         .filterValues { it !is JsonNull }
         .toJson()
         .toString()

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.felles.rapidsrivers
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.spyk
 import io.mockk.verifySequence
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -41,7 +41,7 @@ class RiverUtilsKtTest :
                 verifySequence {
                     testRapid.publish(
                         withArg<String> {
-                            it.parseJson().toMap() shouldContainExactly melding.toMap()
+                            it.parseJson().toMap() shouldContainAllExcludingTempKey melding.toMap()
                         },
                     )
                 }
@@ -60,7 +60,7 @@ class RiverUtilsKtTest :
                 verifySequence {
                     testRapid.publish(
                         withArg<String> {
-                            it.parseJson().toMap() shouldContainExactly melding
+                            it.parseJson().toMap() shouldContainAllExcludingTempKey melding
                         },
                     )
                 }
@@ -79,7 +79,7 @@ class RiverUtilsKtTest :
                 verifySequence {
                     testRapid.publish(
                         withArg<String> {
-                            it.parseJson().toMap() shouldContainExactly mapOf(Key.SELVBESTEMT_ID to selvbestemtId.toJson())
+                            it.parseJson().toMap() shouldContainAllExcludingTempKey mapOf(Key.SELVBESTEMT_ID to selvbestemtId.toJson())
                         },
                     )
                 }

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/FailTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/model/FailTest.kt
@@ -1,7 +1,7 @@
 package no.nav.helsearbeidsgiver.felles.rapidsrivers.model
 
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.maps.shouldContainExactly
+import io.kotest.matchers.nulls.shouldNotBeNull
 import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail.Companion.serializer
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -20,19 +21,19 @@ class FailTest :
             test("har med forventede felter") {
                 val fail = mockFail()
 
-                fail.tilMelding() shouldContainExactly
+                fail.tilMelding() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.FAIL to fail.toJson(serializer()),
                         Key.EVENT_NAME to fail.event.toJson(),
                         Key.UUID to fail.transaksjonId.toJson(),
-                        Key.FORESPOERSEL_ID to fail.forespoerselId?.toJson(),
+                        Key.FORESPOERSEL_ID to fail.forespoerselId.shouldNotBeNull().toJson(),
                     )
             }
 
             test("inkluderer _ikke_ ${Key.FORESPOERSEL_ID} dersom verdi er 'null'") {
                 val failUtenForespoerselId = mockFail().copy(forespoerselId = null)
 
-                failUtenForespoerselId.tilMelding() shouldContainExactly
+                failUtenForespoerselId.tilMelding() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.FAIL to failUtenForespoerselId.toJson(serializer()),
                         Key.EVENT_NAME to failUtenForespoerselId.event.toJson(),

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStoreTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStoreTest.kt
@@ -2,12 +2,12 @@ package no.nav.helsearbeidsgiver.felles.rapidsrivers.redis
 
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.maps.shouldBeEmpty
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.serializer
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.test.mock.redisWithMockRedisClient
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -38,7 +38,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                     mapOf(
                         Key.FNR to "ananas".toJson(),
                         Key.ORGNRUNDERENHET to "kokosnøtt".toJson(),
@@ -67,7 +67,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                     mapOf(
                         Key.ORGNRUNDERENHET to "kokosnøtt".toJson(),
                     )
@@ -94,7 +94,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                     mapOf(
                         Key.FNR to "ananas".toJson(),
                     )
@@ -171,7 +171,7 @@ class RedisStoreTest :
 
             redisStore.skrivMellomlagring(transaksjonId, Key.FNR, "durian".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                 mapOf(
                     Key.FNR to "durian".toJson(),
                 )
@@ -179,7 +179,7 @@ class RedisStoreTest :
             redisStore.skrivMellomlagring(transaksjonId, Key.INNTEKT, "kiwi".toJson())
             redisStore.skrivMellomlagring(transaksjonId, Key.JOURNALPOST_ID, "litchi".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                 mapOf(
                     Key.FNR to "durian".toJson(),
                     Key.INNTEKT to "kiwi".toJson(),
@@ -188,7 +188,7 @@ class RedisStoreTest :
 
             redisStore.skrivMellomlagring(transaksjonId, Key.INNTEKT, "granateple".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey
                 mapOf(
                     Key.FNR to "durian".toJson(),
                     Key.INNTEKT to "granateple".toJson(),
@@ -230,7 +230,7 @@ class RedisStoreTest :
 
             // Har ikke blitt overskrevet
             redisStore.lesFeil(transaksjonId1)?.fromJson(String.serializer()) shouldBe "dragefrukt"
-            redisStore.lesAlleMellomlagrede(transaksjonId1) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
+            redisStore.lesAlleMellomlagrede(transaksjonId1) shouldContainAllExcludingTempKey mapOf(Key.FNR to "durian".toJson())
             redisStore.lesResultat(transaksjonId2)?.fromJson(String.serializer()) shouldBe "rambutan"
         }
 
@@ -265,6 +265,6 @@ class RedisStoreTest :
 
             // Har ikke blitt overskrevet
             redisStore.lesResultat(transaksjonId)?.fromJson(String.serializer()) shouldBe "rabarbra"
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
+            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainAllExcludingTempKey mapOf(Key.FNR to "durian".toJson())
         }
     })

--- a/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/Temp.kt
+++ b/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/Temp.kt
@@ -1,0 +1,11 @@
+package no.nav.helsearbeidsgiver.felles.test
+
+import io.kotest.matchers.maps.shouldContainAll
+import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.toMap
+
+infix fun Map<Key, JsonElement>.shouldContainAllExcludingTempKey(expected: Map<Key, JsonElement>) {
+    this.minus(Key.DATA) shouldContainAll expected.minus(Key.DATA)
+    this[Key.DATA]?.toMap().orEmpty() shouldContainAll expected[Key.DATA]?.toMap().orEmpty()
+}

--- a/forespoersel-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiverTest.kt
+++ b/forespoersel-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.forespoerselbesvart
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainKey
 import io.mockk.clearAllMocks
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -50,7 +50,7 @@ class ForespoerselBesvartRiverTest :
 
             publisert shouldContainKey Key.UUID
 
-            publisert.minus(Key.UUID) shouldContainExactly forventetPublisert.minus(Key.UUID)
+            publisert.minus(Key.UUID) shouldContainAllExcludingTempKey forventetPublisert.minus(Key.UUID)
         }
 
         test("Ved notis om besvart forespørsel publiseres behov om å hente notifikasjon-ID-er _med_ IM-ID fra Spinn") {
@@ -79,6 +79,6 @@ class ForespoerselBesvartRiverTest :
 
             publisert shouldContainKey Key.UUID
 
-            publisert.minus(Key.UUID) shouldContainExactly forventetPublisert.minus(Key.UUID)
+            publisert.minus(Key.UUID) shouldContainAllExcludingTempKey forventetPublisert.minus(Key.UUID)
         }
     })

--- a/forespoersel-forkastet/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiverTest.kt
+++ b/forespoersel-forkastet/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.forespoerselforkastet
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainKey
 import io.mockk.clearAllMocks
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -47,6 +47,6 @@ class ForespoerselForkastetRiverTest :
 
             publisert shouldContainKey Key.UUID
 
-            publisert.minus(Key.UUID) shouldContainExactly forventetPublisert.minus(Key.UUID)
+            publisert.minus(Key.UUID) shouldContainAllExcludingTempKey forventetPublisert.minus(Key.UUID)
         }
     })

--- a/forespoersel-infotrygd/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiverTest.kt
+++ b/forespoersel-infotrygd/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.forespoerselinfotrygd
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainKey
 import io.mockk.clearAllMocks
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -13,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -47,6 +47,6 @@ class ForespoerselKastetTilInfotrygdRiverTest :
 
             publisert shouldContainKey Key.UUID
 
-            publisert.minus(Key.UUID) shouldContainExactly forventetPublisert.minus(Key.UUID)
+            publisert.minus(Key.UUID) shouldContainAllExcludingTempKey forventetPublisert.minus(Key.UUID)
         }
     })

--- a/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.forespoerselmottatt
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.maps.shouldContainKey
 import io.mockk.clearAllMocks
 import kotlinx.serialization.builtins.serializer
@@ -19,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -48,7 +48,7 @@ class ForespoerselMottattRiverTest :
 
             publisert shouldContainKey Key.UUID
 
-            publisert.minus(Key.UUID) shouldContainExactly
+            publisert.minus(Key.UUID) shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(EventName.serializer()),
                     Key.DATA to

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
@@ -5,7 +5,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.helsebro
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.UseSerializers
 import kotlinx.serialization.builtins.MapSerializer
@@ -21,6 +20,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.test.json.lesFail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.helsebro.domene.ForespoerselListeSvar
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -65,7 +65,7 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetSvar
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetSvar
         }
 
         test("Ved feil så publiseres feil på simba-rapid") {

--- a/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
+++ b/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntekt.InntektKlient
 import no.nav.helsearbeidsgiver.inntektsmelding.inntekt.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -100,7 +100,7 @@ class HentInntektRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -133,7 +133,7 @@ class HentInntektRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockInntektClient.hentInntektPerOrgnrOgMaaned(innkommendeMelding.fnr.verdi, januar(2018), mars(2018), any(), any())

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest
 
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -27,6 +26,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.tilArbeidsforhold
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.bjarneBetjent
@@ -260,7 +260,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
                 .shouldNotBeNull()
 
         actualFail.shouldBeEqualToIgnoringFields(expectedFail, Fail::utloesendeMelding)
-        actualFail.utloesendeMelding.toMap() shouldContainExactly expectedFail.utloesendeMelding.toMap()
+        actualFail.utloesendeMelding.toMap() shouldContainAllExcludingTempKey expectedFail.utloesendeMelding.toMap()
     }
 
     private object Mock {

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest
 
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.mockk.coEvery
 import no.nav.helsearbeidsgiver.felles.BehovType
@@ -9,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.april
@@ -42,7 +42,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
         messages
             .filter(BehovType.HENT_INNTEKT)
             .firstAsMap()
-            .shouldContainExactly(
+            .shouldContainAllExcludingTempKey(
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
                     Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
@@ -59,7 +59,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
         messages
             .filter(Key.INNTEKT)
             .firstAsMap()
-            .shouldContainExactly(
+            .shouldContainAllExcludingTempKey(
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
                     Key.UUID to Mock.transaksjonId.toJson(),

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -5,7 +5,6 @@ import io.kotest.matchers.booleans.shouldBeTrue
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.equality.shouldBeEqualToIgnoringFields
-import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
@@ -33,6 +32,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.felles.test.mock.randomDigitString
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.aareg.tilArbeidsforhold
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
@@ -350,7 +350,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
         inntektsmelding: Inntektsmelding,
         compareType: Boolean,
     ) {
-        this shouldContainAll
+        this shouldContainAllExcludingTempKey
             mapOf(
                 Key.UUID to transaksjonId.toJson(),
                 Key.JOURNALPOST_ID to Mock.journalpostId.toJson(),

--- a/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -6,7 +6,6 @@ import io.kotest.datatest.withData
 import io.kotest.matchers.collections.shouldContainExactly
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -29,6 +28,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -73,7 +73,7 @@ class JournalfoerImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -119,7 +119,7 @@ class JournalfoerImRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
                         Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -171,7 +171,7 @@ class JournalfoerImRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail.tilMelding()
 
             coVerifySequence {
                 mockDokArkivKlient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseServiceTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
@@ -23,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.message
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
@@ -54,7 +54,7 @@ class HentDataTilPaaminnelseServiceTest :
             testRapid.sendJson(HentDataTilPaaminnelseServiceMock.steg2())
 
             testRapid.inspektør.size shouldBeExactly 3
-            testRapid.message(2).toMap() shouldContainExactly
+            testRapid.message(2).toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED.toJson(),
                     Key.UUID to HentDataTilPaaminnelseServiceMock.transaksjonId.toJson(),

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveServiceTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveServiceTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
@@ -25,6 +24,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.message
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -57,7 +57,7 @@ class HentDataTilSakOgOppgaveServiceTest :
             testRapid.sendJson(Mock.steg2())
 
             testRapid.inspektør.size shouldBeExactly 3
-            testRapid.message(2).toMap() shouldContainExactly
+            testRapid.message(2).toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED.toJson(),
                     Key.UUID to Mock.transaksjonId.toJson(),

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -24,6 +23,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.NotifikasjonTekst
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
@@ -83,7 +83,7 @@ class EndrePaaminnelseRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
         }
 
         test("kaster ingen exception dersom oppgaven ikke finnes") {

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -24,6 +23,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.NotifikasjonTekst
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -63,7 +63,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
                 testRapid.inspektør.size shouldBeExactly 1
 
-                testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding)
 
                 coVerifySequence {
                     mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
@@ -105,7 +105,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 // Feiler
@@ -154,7 +154,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
@@ -178,7 +178,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
@@ -202,7 +202,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
@@ -223,7 +223,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding", any(), any(), any())
@@ -245,7 +245,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiverTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -20,6 +19,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.NotifikasjonTekst
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.PaaminnelseToggle
 import no.nav.helsearbeidsgiver.utils.json.toJson
@@ -84,7 +84,7 @@ class FjernPaaminnelseRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
         }
 
         test("kaster ingen exception dersom oppgaven ikke finnes") {

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
@@ -4,13 +4,13 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.mockk
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Paaminnelse
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
@@ -26,6 +26,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespoersel
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.NotifikasjonTekst
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.PaaminnelseToggle
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.sakLevetid
@@ -69,7 +70,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, sakId, oppgaveId)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding, sakId, oppgaveId)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(
@@ -129,7 +130,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, sakId, duplikatOppgaveId)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding, sakId, duplikatOppgaveId)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -153,7 +154,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, oppgaveId)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, oppgaveId)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -179,7 +180,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, duplikatOppgaveId)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, duplikatOppgaveId)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -198,7 +199,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -220,7 +221,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
@@ -289,7 +290,7 @@ private fun forventetUtgaaendeMelding(
     innkommendeMelding: OpprettForespoerselSakOgOppgaveMelding,
     sakId: String,
     oppgaveId: String,
-): Map<Key, Any> =
+): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETTET.toJson(),
         Key.UUID to innkommendeMelding.transaksjonId.toJson(),

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -25,6 +24,7 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 
@@ -52,7 +52,7 @@ class OpprettSelvbestemtSakRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -94,7 +94,7 @@ class OpprettSelvbestemtSakRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -122,7 +122,7 @@ class OpprettSelvbestemtSakRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 forventetFail
                     .tilMelding()
                     .minus(Key.FORESPOERSEL_ID)

--- a/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
+++ b/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
@@ -23,6 +22,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
@@ -47,7 +47,7 @@ class UtgaattForespoerselRiverTest :
             testRapid.sendJson(innkommendeMelding.toMap())
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey Mock.forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
@@ -79,7 +79,7 @@ class UtgaattForespoerselRiverTest :
             testRapid.sendJson(innkommendeMelding.toMap())
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey Mock.forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 // Feiler
@@ -123,7 +123,7 @@ class UtgaattForespoerselRiverTest :
             testRapid.sendJson(innkommendeMelding.toMap())
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey Mock.forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 // Feiler
@@ -159,7 +159,7 @@ class UtgaattForespoerselRiverTest :
             testRapid.sendJson(innkommendeMelding.toMap())
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetUtgaaendeMelding(innkommendeMelding)
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey Mock.forventetUtgaaendeMelding(innkommendeMelding)
 
             coVerifySequence {
                 // Feiler ikke
@@ -197,7 +197,7 @@ class UtgaattForespoerselRiverTest :
             testRapid.sendJson(innkommendeMelding.toMap())
 
             testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetFail(innkommendeMelding).tilMelding()
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey Mock.forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
                 // Feiler
@@ -230,7 +230,7 @@ class UtgaattForespoerselRiverTest :
                 testRapid.sendJson(innkommendeFail.tilMelding())
 
                 testRapid.inspektør.size shouldBeExactly 1
-                testRapid.firstMessage().toMap() shouldContainExactly
+                testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                     mapOf(
                         Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_UTGAATT.toJson(),
                         Key.UUID to innkommendeFail.transaksjonId.toJson(),

--- a/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
+++ b/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
@@ -4,7 +4,6 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
-import io.kotest.matchers.maps.shouldContainExactly
 import io.mockk.clearAllMocks
 import io.mockk.coEvery
 import io.mockk.coVerify
@@ -22,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
+import no.nav.helsearbeidsgiver.felles.test.shouldContainAllExcludingTempKey
 import no.nav.helsearbeidsgiver.inntektsmelding.pdl.Mock.toMap
 import no.nav.helsearbeidsgiver.pdl.PdlClient
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
@@ -61,7 +61,7 @@ class HentPersonerRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -100,7 +100,7 @@ class HentPersonerRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -132,7 +132,7 @@ class HentPersonerRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -164,7 +164,7 @@ class HentPersonerRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                     Key.UUID to innkommendeMelding.transaksjonId.toJson(),
@@ -205,7 +205,7 @@ class HentPersonerRiverTest :
 
             testRapid.inspektør.size shouldBeExactly 1
 
-            testRapid.firstMessage().toMap() shouldContainExactly
+            testRapid.firstMessage().toMap() shouldContainAllExcludingTempKey
                 forventetFail
                     .tilMelding()
                     .plus(Key.FORESPOERSEL_ID to forespoerselId.toJson())


### PR DESCRIPTION
Dette er innsats for å strømlinjeforme formatet på meldingsnøklene våre, der vi i gamle dager kjørte en "gjør hva du vil"-policy.

Denne PR-en tar for seg verstingen `FORESPOERSEL_ID`, som har utstrakt bruk. Det legges til en ny key med nytt format i de meldingene der den gamle keyen er tilstede.

Fordi vi har strenge tester (🥳) så tok jeg en snarvei for å ikke måtte manuelt endre en haug med tester. Snarveien besto av en `replace all` på `shouldContainExactly` for å bytte med den mer tilgivelige `shouldContainAllExcludingTempKey`. Disse testendringene skal reverseres i neste PR.