### PR TITLE
Erstatt key i melding for forespoersel-ID

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -26,6 +26,7 @@ enum class Key(
     FNR("fnr"),
     FNR_LISTE("fnr_liste"),
     FORESPOERSEL("forespoersel"),
+    FORESPOERSEL_ID("forespoersel_id"),
     FORESPOERSEL_MAP("forespoersel_map"),
     INNSENDING_ID("innsending_id"),
     INNTEKT("inntekt"),
@@ -51,8 +52,6 @@ enum class Key(
     JOURNALPOST_ID("journalpost_id"),
 
     // ulik formattering
-    FORESPOERSEL_ID("forespoerselId"),
-    FORESPOERSEL_ID_V2("forespoersel_id"),
     ORGNRUNDERENHET("orgnrUnderenhet"),
     SPINN_INNTEKTSMELDING_ID("spinnInntektsmeldingId"),
     ;

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -10,7 +10,6 @@ import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
-import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 
@@ -18,19 +17,7 @@ fun MessageContext.publish(vararg messageFields: Pair<Key, JsonElement>): JsonEl
 
 fun MessageContext.publish(messageFields: Map<Key, JsonElement>): JsonElement =
     messageFields
-        .let { root ->
-            val data = root[Key.DATA]?.toMap().orEmpty()
-            val newData =
-                data
-                    .plus(Key.FORESPOERSEL_ID_V2 to data[Key.FORESPOERSEL_ID])
-                    .mapValuesNotNull { it }
-                    .ifEmpty { null }
-
-            root
-                .plus(Key.FORESPOERSEL_ID_V2 to root[Key.FORESPOERSEL_ID])
-                .plus(Key.DATA to newData?.toJson())
-                .mapValuesNotNull { it }
-        }.mapKeys { (key, _) -> key.toString() }
+        .mapKeys { (key, _) -> key.toString() }
         .filterValues { it !is JsonNull }
         .toJson()
         .toString()


### PR DESCRIPTION
Dette er innsats for å strømlinjeforme formatet på meldingsnøklene våre, der vi i gamle dager kjørte en "gjør hva du vil"-policy.

Skal benytte anledningen til å endre `Key.UUID` også, i egen PR. Lar derfor testene som ble endret i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/772 forbli inntil videre.