### PR TITLE
Legg til erstatningskey i melding for kontekst-ID (kalt 'uuid')

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -32,6 +32,7 @@ enum class Key(
     INNTEKT("inntekt"),
     INNTEKTSDATO("inntektsdato"),
     INNTEKTSMELDING("inntektsmelding"),
+    KONTEKST_ID("kontekst_id"),
     LAGRET_INNTEKTSMELDING("lagret_inntektsmelding"),
     OPPGAVE_ID("oppgave_id"),
     ORGNR_UNDERENHETER("orgnr_underenheter"),

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -8,8 +8,7 @@ import io.micrometer.prometheusmetrics.PrometheusMeterRegistry
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.Key
-import no.nav.helsearbeidsgiver.felles.json.toJson
-import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 
@@ -17,7 +16,11 @@ fun MessageContext.publish(vararg messageFields: Pair<Key, JsonElement>): JsonEl
 
 fun MessageContext.publish(messageFields: Map<Key, JsonElement>): JsonElement =
     messageFields
-        .mapKeys { (key, _) -> key.toString() }
+        .let { root ->
+            root
+                .plus(Key.KONTEKST_ID to root[Key.UUID])
+                .mapValuesNotNull { it }
+        }.mapKeys { (key, _) -> key.toString() }
         .filterValues { it !is JsonNull }
         .toJson()
         .toString()


### PR DESCRIPTION
Ønsker å bytte `Key.UUID` med den mer meningsbærende `Key.KONTEKST_ID`. Valgte "kontekst-ID" siden verdien identifiserer konteksten meldingene befinner seg i, i forhold til de andre meldingene og for hvilken bruker man utfører handlingen (som meldingen beskriver) for.