### PR TITLE
Skru på påminnelse etter 28 dager for alle

### DIFF
--- a/config/notifikasjon/dev-gcp.yml
+++ b/config/notifikasjon/dev-gcp.yml
@@ -12,6 +12,6 @@ env:
   - name: LINK_URL
     value: "https://arbeidsgiver.intern.dev.nav.no"
   - name: OPPGAVEPAAMINNELSER_AKTIVERT
-    value: "false"
+    value: "true"
   - name: TID_MELLOM_OPPGAVEOPPRETTELSE_OG_PAAMINNELSE
     value: "PT10M"

--- a/config/notifikasjon/prod-gcp.yml
+++ b/config/notifikasjon/prod-gcp.yml
@@ -12,6 +12,6 @@ env:
   - name: LINK_URL
     value: "https://arbeidsgiver.nav.no"
   - name: OPPGAVEPAAMINNELSER_AKTIVERT
-    value: "false"
+    value: "true"
   - name: TID_MELLOM_OPPGAVEOPPRETTELSE_OG_PAAMINNELSE
     value: "P28D"


### PR DESCRIPTION
**Bakgrunn**
Eksperimentet vårt for å teste effekten av påminnelser viser en klar økning av innsendte inntektsmeldinger for gruppen vi sendte påminnelser til sammenliknet med kontrollgruppen. Vi ønsker derfor å skru på påminnelser til alle.

**Løsning**
Skru på påminnelser på oppgaver i prod (28 dager etter oppgaveopprettelse) og dev (10 minutter etter oppgaveopprettelse).