### PR TITLE
Skriv feil til Redis per key

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStore.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStore.kt
@@ -1,17 +1,20 @@
 package no.nav.helsearbeidsgiver.felles.rapidsrivers.redis
 
+import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.utils.collection.mapKeysNotNull
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
+import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
+import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
 private const val KEY_PART_SEPARATOR = "#"
-private const val KEY_FEIL_POSTFIX = "Feilmelding"
+private const val KEY_FEIL_POSTFIX = "feil"
 
 class RedisStore(
 // class RedisStore<Success : Any, Failure : Any>(
@@ -23,16 +26,65 @@ class RedisStore(
     private val logger = logger()
     private val sikkerLogger = sikkerLogger()
 
+    fun lesResultat(transaksjonId: UUID): JsonElement? = resultatKey(transaksjonId).les()
+
     fun lesAlleMellomlagrede(transaksjonId: UUID): Map<Key, JsonElement> {
         val prefix = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator(withPostfix = true)
 
-        val keys = Key.entries.map { mellomlagringKey(transaksjonId, it) }
+        return Key.entries
+            .map { mellomlagringKey(transaksjonId, it) }
+            .lesAlle { removePrefix(prefix) }
+    }
 
-        return redis
-            .getAll(keys)
+    fun lesAlleFeil(transaksjonId: UUID): Map<Key, String> {
+        val prefix = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator(withPostfix = true)
+        val postfix = KEY_PART_SEPARATOR + KEY_FEIL_POSTFIX
+
+        return Key.entries
+            .map { feilKey(transaksjonId, it) }
+            .lesAlle {
+                removePrefix(prefix)
+                    .removeSuffix(postfix)
+            }.mapValues { it.value.fromJson(String.serializer()) }
+    }
+
+    fun skrivResultat(
+        transaksjonId: UUID,
+        value: JsonElement,
+    ) {
+        resultatKey(transaksjonId).skriv(value)
+    }
+
+    fun skrivMellomlagring(
+        transaksjonId: UUID,
+        key: Key,
+        value: JsonElement,
+    ) {
+        mellomlagringKey(transaksjonId, key).skriv(value)
+    }
+
+    fun skrivFeil(
+        transaksjonId: UUID,
+        key: Key,
+        value: String,
+    ) {
+        feilKey(transaksjonId, key).skriv(value.toJson())
+    }
+
+    private fun String.les(): JsonElement? =
+        redis
+            .get(this)
+            ?.parseJson()
+            .also { value ->
+                sikkerLogger.debug("Leser fra redis:\n$this -> ${value?.toPretty()}")
+            }
+
+    private fun List<String>.lesAlle(redisKeyToJsonKey: String.() -> String): Map<Key, JsonElement> =
+        redis
+            .getAll(this)
             .mapKeysNotNull { key ->
                 key
-                    .removePrefix(prefix)
+                    .redisKeyToJsonKey()
                     .runCatching(Key::fromString)
                     .getOrElse { error ->
                         "Feil med nøkkel '$key' i Redis.".also {
@@ -52,56 +104,31 @@ class RedisStore(
                         null
                     }
             }
-    }
-
-    fun lesResultat(transaksjonId: UUID): JsonElement? = resultatKey(transaksjonId).les()
-
-    fun lesFeil(transaksjonId: UUID): JsonElement? = feilKey(transaksjonId).les()
-
-    fun skrivMellomlagring(
-        transaksjonId: UUID,
-        key: Key,
-        value: JsonElement,
-    ) {
-        mellomlagringKey(transaksjonId, key).skriv(value)
-    }
-
-    fun skrivResultat(
-        transaksjonId: UUID,
-        value: JsonElement,
-    ) {
-        resultatKey(transaksjonId).skriv(value)
-    }
-
-    // TODO Skriv feil for hver key separat
-    fun skrivFeil(
-        transaksjonId: UUID,
-        value: JsonElement,
-    ) {
-        feilKey(transaksjonId).skriv(value)
-    }
-
-    private fun String.les(): JsonElement? =
-        redis
-            .get(this)
-            ?.parseJson()
-            .also { value ->
-                sikkerLogger.debug("Leser fra redis:\n$this -> ${value?.toPretty()}")
-            }
 
     private fun String.skriv(value: JsonElement) {
         sikkerLogger.debug("Skriver til redis:\n$this -> ${value.toPretty()}")
         redis.set(this, value.toString())
     }
 
+    private fun resultatKey(transaksjonId: UUID): String = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator()
+
     private fun mellomlagringKey(
         transaksjonId: UUID,
         key: Key,
-    ): String = listOf(keyPrefix.name, transaksjonId.toString(), key.toString()).joinKeySeparator()
+    ): String =
+        listOf(
+            resultatKey(transaksjonId),
+            key.toString(),
+        ).joinKeySeparator()
 
-    private fun resultatKey(transaksjonId: UUID): String = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator()
-
-    private fun feilKey(transaksjonId: UUID): String = listOf(keyPrefix.name, transaksjonId.toString(), KEY_FEIL_POSTFIX).joinKeySeparator()
+    private fun feilKey(
+        transaksjonId: UUID,
+        key: Key,
+    ): String =
+        listOf(
+            mellomlagringKey(transaksjonId, key),
+            KEY_FEIL_POSTFIX,
+        ).joinKeySeparator()
 }
 
 private fun List<String>.joinKeySeparator(withPostfix: Boolean = false): String =


### PR DESCRIPTION
Denne endringen gjør at skriving og lesing av feil under henting av verdier ligner mer på skriving og lesing av suksessfullt hentede verdier. Da blir flyten under feil lettere å følge.