### PR TITLE
Tillat podene mer tid på startup ved deploy

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
@@ -10,6 +10,9 @@ import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 
 fun Application.helsesjekkerRouting() {
     routing {
+        get("started") {
+            call.respondText("I started")
+        }
         get("isalive") {
             call.respondText("I'm alive")
         }

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/HelsesjekkerRouting.kt
@@ -10,9 +10,6 @@ import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 
 fun Application.helsesjekkerRouting() {
     routing {
-        get("started") {
-            call.respondText("I started")
-        }
         get("isalive") {
             call.respondText("I'm alive")
         }

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -27,12 +27,15 @@ spec:
     scalingStrategy:
       cpu:
         thresholdPercentage: 75
+  startup:
+    path: /started
+    initialDelay: 10
+    periodSeconds: 5
+    failureThreshold: 22
   liveness:
-    path: isalive
-    initialDelay: 10
+    path: /isalive
   readiness:
-    path: isready
-    initialDelay: 10
+    path: /isready
   secureLogs:
     enabled: true
   observability:

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -28,7 +28,7 @@ spec:
       cpu:
         thresholdPercentage: 75
   startup:
-    path: /started
+    path: /isalive
     initialDelay: 10
     periodSeconds: 5
     failureThreshold: 22


### PR DESCRIPTION
Dette er et forsøk på å fikse prodsettingsproblemene våre. Nå skal podene få 2 minutter (10 + 5 * 22 sek) på å starte. Denne grensen er basert på gjetning, så den kan alltids justeres. Det er uansett bare en maksgrense. Startup proben sier seg ferdig så snart den får svar.

https://doc.nav.cloud.nais.io/workloads/application/reference/application-spec/#startup