### PR TITLE
Publiser meldinger med Kafka-key i servicer

### DIFF
--- a/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -96,6 +96,7 @@ class AktiveOrgnrService(
         steg0: Steg0,
     ) {
         rapid.publish(
+            key = steg0.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.ARBEIDSGIVERE.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -106,6 +107,7 @@ class AktiveOrgnrService(
         )
 
         rapid.publish(
+            key = steg0.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_ARBEIDSFORHOLD.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -116,6 +118,7 @@ class AktiveOrgnrService(
         )
 
         rapid.publish(
+            key = steg0.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -144,6 +147,7 @@ class AktiveOrgnrService(
                 utfoerSteg2(data, steg0, steg1, Steg2(emptyMap()))
             } else {
                 rapid.publish(
+                    key = steg0.sykmeldtFnr,
                     Key.EVENT_NAME to eventName.toJson(),
                     Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
                     Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -103,6 +103,7 @@ class BerikInntektsmeldingService(
     ) {
         rapid
             .publish(
+                key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -120,6 +121,7 @@ class BerikInntektsmeldingService(
     ) {
         rapid
             .publish(
+                key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -138,6 +140,7 @@ class BerikInntektsmeldingService(
     ) {
         rapid
             .publish(
+                key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -187,6 +190,7 @@ class BerikInntektsmeldingService(
 
         rapid
             .publish(
+                key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.LAGRE_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -214,6 +218,7 @@ class BerikInntektsmeldingService(
         if (!steg4.erDuplikat) {
             val publisert =
                 rapid.publish(
+                    key = steg0.skjema.forespoerselId,
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
                     Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
                     Key.DATA to

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -13,8 +13,6 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
-fun MessageContext.publish(vararg messageFields: Pair<Key, JsonElement>): JsonElement = publish(null, messageFields.toMap())
-
 fun MessageContext.publish(
     key: Fnr,
     vararg messageFields: Pair<Key, JsonElement>,

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
@@ -30,25 +30,6 @@ class RiverUtilsKtTest :
 
         context("publish") {
 
-            test("vararg pairs (uten key)") {
-                val melding =
-                    arrayOf(
-                        Key.FORESPOERSEL_ID to UUID.randomUUID().toJson(),
-                        Key.INNTEKTSMELDING to mockInntektsmeldingV1().toJson(Inntektsmelding.serializer()),
-                        Key.FNR_LISTE to setOf("111", "333", "555").toJson(String.serializer()),
-                    )
-
-                testRapid.publish(*melding)
-
-                verifySequence {
-                    testRapid.publish(
-                        withArg<String> {
-                            it.parseJson().toMap() shouldContainExactly melding.toMap()
-                        },
-                    )
-                }
-            }
-
             test("vararg pairs (fnr-key)") {
                 val key = Fnr.genererGyldig()
                 val melding =

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -63,6 +63,7 @@ class InnsendingService(
     ) {
         rapid
             .publish(
+                key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.LAGRE_IM_SKJEMA.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -84,15 +85,15 @@ class InnsendingService(
 
         if (!steg1.erDuplikat) {
             val publisert =
-                rapid
-                    .publish(
-                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
-                        Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
-                        Key.DATA to
-                            data
-                                .plus(Key.INNSENDING_ID to steg1.innsendingId.toJson(Long.serializer()))
-                                .toJson(),
-                    )
+                rapid.publish(
+                    key = steg0.skjema.forespoerselId,
+                    Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
+                    Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                    Key.DATA to
+                        data
+                            .plus(Key.INNSENDING_ID to steg1.innsendingId.toJson(Long.serializer()))
+                            .toJson(),
+                )
 
             MdcUtils.withLogFields(
                 Log.event(EventName.INNTEKTSMELDING_SKJEMA_LAGRET),

--- a/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
+++ b/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
@@ -70,6 +70,7 @@ class KvitteringService(
     ) {
         val publisert =
             rapid.publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_LAGRET_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
+++ b/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
@@ -66,6 +66,7 @@ class InntektSelvbestemtService(
     ) {
         val publisert =
             rapid.publish(
+                key = steg0.fnr,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
+++ b/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 data class Steg0(
     val transaksjonId: UUID,
     val orgnr: Orgnr,
-    val fnr: Fnr,
+    val sykmeldtFnr: Fnr,
     val inntektsdato: LocalDate,
 )
 
@@ -50,8 +50,8 @@ class InntektSelvbestemtService(
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
             transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
-            fnr = Key.FNR.les(Fnr.serializer(), melding),
             orgnr = Key.ORGNRUNDERENHET.les(Orgnr.serializer(), melding),
+            sykmeldtFnr = Key.FNR.les(Fnr.serializer(), melding),
             inntektsdato = Key.INNTEKTSDATO.les(LocalDateSerializer, melding),
         )
 
@@ -66,7 +66,7 @@ class InntektSelvbestemtService(
     ) {
         val publisert =
             rapid.publish(
-                key = steg0.fnr,
+                key = steg0.sykmeldtFnr,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -75,7 +75,7 @@ class InntektSelvbestemtService(
                         .plus(
                             mapOf(
                                 Key.ORGNRUNDERENHET to steg0.orgnr.toJson(),
-                                Key.FNR to steg0.fnr.toJson(),
+                                Key.FNR to steg0.sykmeldtFnr.toJson(),
                                 Key.INNTEKTSDATO to steg0.inntektsdato.toJson(),
                             ),
                         ).toJson(),

--- a/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -72,6 +72,7 @@ class InntektService(
     ) {
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -96,6 +97,7 @@ class InntektService(
     ) {
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
@@ -55,6 +55,7 @@ class HentDataTilPaaminnelseService(
         }
 
         rapid.publish(
+            key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -71,17 +72,17 @@ class HentDataTilPaaminnelseService(
         steg0: Steg0,
         steg1: Steg1,
     ) {
-        rapid
-            .publish(
-                Key.EVENT_NAME to eventName.toJson(),
-                Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
-                Key.DATA to
-                    data
-                        .plus(
-                            Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(String.serializer()),
-                        ).toJson(),
-            )
+        rapid.publish(
+            key = steg0.forespoerselId,
+            Key.EVENT_NAME to eventName.toJson(),
+            Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
+            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.DATA to
+                data
+                    .plus(
+                        Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(String.serializer()),
+                    ).toJson(),
+        )
     }
 
     override fun utfoerSteg2(
@@ -98,6 +99,7 @@ class HentDataTilPaaminnelseService(
         val orgNavn = steg2.orgnrMedNavn[steg1.forespoersel.orgnr.let(::Orgnr)] ?: ORG_NAVN_DEFAULT
 
         rapid.publish(
+            key = steg0.forespoerselId,
             Key.EVENT_NAME to EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
             Key.DATA to

--- a/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
+++ b/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
@@ -75,6 +75,7 @@ class HentDataTilSakOgOppgaveService(
         }
 
         rapid.publish(
+            key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -91,17 +92,17 @@ class HentDataTilSakOgOppgaveService(
         steg0: Steg0,
         steg1: Steg1,
     ) {
-        rapid
-            .publish(
-                Key.EVENT_NAME to eventName.toJson(),
-                Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
-                Key.DATA to
-                    data
-                        .plus(
-                            Key.FNR_LISTE to setOf(steg0.forespoersel.fnr).toJson(String.serializer()),
-                        ).toJson(),
-            )
+        rapid.publish(
+            key = steg0.forespoerselId,
+            Key.EVENT_NAME to eventName.toJson(),
+            Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
+            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.DATA to
+                data
+                    .plus(
+                        Key.FNR_LISTE to setOf(steg0.forespoersel.fnr).toJson(String.serializer()),
+                    ).toJson(),
+        )
     }
 
     override fun utfoerSteg2(
@@ -119,6 +120,7 @@ class HentDataTilSakOgOppgaveService(
         val sykmeldt = steg2.personer[steg0.forespoersel.fnr.let(::Fnr)] ?: personDefault(steg0.forespoersel.fnr.let(::Fnr))
 
         rapid.publish(
+            key = steg0.forespoerselId,
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
             Key.DATA to

--- a/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
+++ b/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
@@ -57,6 +57,7 @@ class HentSelvbestemtImService(
     ) {
         val publisert =
             rapid.publish(
+                key = steg0.selvbestemtId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_SELVBESTEMT_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -128,6 +128,7 @@ class LagreSelvbestemtImService(
         kontrollerSkjema(steg0.skjema)
 
         rapid.publish(
+            key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -140,6 +141,7 @@ class LagreSelvbestemtImService(
         )
 
         rapid.publish(
+            key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -156,6 +158,7 @@ class LagreSelvbestemtImService(
         )
 
         rapid.publish(
+            key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_ARBEIDSFORHOLD.toJson(),
             Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -198,6 +201,7 @@ class LagreSelvbestemtImService(
             if (erAktivtArbeidsforhold) {
                 rapid
                     .publish(
+                        key = inntektsmelding.type.id,
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.LAGRE_SELVBESTEMT_IM.toJson(),
                         Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -234,6 +238,7 @@ class LagreSelvbestemtImService(
             AarsakInnsending.Ny -> {
                 rapid
                     .publish(
+                        key = steg2.inntektsmelding.type.id,
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.OPPRETT_SELVBESTEMT_SAK.toJson(),
                         Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -270,6 +275,7 @@ class LagreSelvbestemtImService(
             if (!steg2.erDuplikat) {
                 val publisert =
                     rapid.publish(
+                        key = steg2.inntektsmelding.type.id,
                         Key.EVENT_NAME to EventName.SELVBESTEMT_IM_LAGRET.toJson(),
                         Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
                         Key.DATA to

--- a/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
+++ b/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
@@ -75,6 +75,7 @@ class TilgangForespoerselService(
     ) {
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -99,6 +100,7 @@ class TilgangForespoerselService(
     ) {
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
+++ b/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
@@ -62,6 +62,7 @@ class TilgangOrgService(
     ) {
         rapid
             .publish(
+                key = steg0.fnr,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
@@ -109,6 +109,7 @@ class HentForespoerselService(
     ) {
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -128,6 +129,7 @@ class HentForespoerselService(
 
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -140,6 +142,7 @@ class HentForespoerselService(
 
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
@@ -156,6 +159,7 @@ class HentForespoerselService(
 
         rapid
             .publish(
+                key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),

--- a/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
+++ b/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
@@ -60,6 +60,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
     ) {
         rapid
             .publish(
+                key = UUID.randomUUID(),
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(),
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),


### PR DESCRIPTION
Dette er nødvendig for å sikre oss at meldingene på Kafka blir lest i samme rekkefølge som de blir skrevet.