### PR TITLE
Fjern overflødig strengverdi i enum for json-nøkler

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducer.kt
@@ -27,8 +27,8 @@ class HentForespoerselProducer(
         rapid
             .publish(
                 key = request.uuid,
-                Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(EventName.serializer()),
-                Key.KONTEKST_ID to transaksjonId.toString().toJson(),
+                Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
+                Key.KONTEKST_ID to transaksjonId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to request.uuid.toJson(),

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerslerProducer.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerslerProducer.kt
@@ -26,8 +26,8 @@ class HentForespoerslerProducer(
         rapid
             .publish(
                 key = UUID.randomUUID(),
-                Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(EventName.serializer()),
-                Key.KONTEKST_ID to transaksjonId.toString().toJson(),
+                Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
+                Key.KONTEKST_ID to transaksjonId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.VEDTAKSPERIODE_ID_LISTE to request.vedtaksperiodeIdListe.toJson(UuidSerializer),

--- a/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -49,7 +49,7 @@ class FeilLytter(
         River(rapidsConnection)
             .apply {
                 validate { msg ->
-                    msg.demandKey(Key.FAIL.str)
+                    msg.demandKey(Key.FAIL.toString())
                 }
             }.register(this)
     }

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -3,58 +3,59 @@ package no.nav.helsearbeidsgiver.felles
 import kotlinx.serialization.Serializable
 import no.nav.helsearbeidsgiver.utils.json.serializer.AsStringSerializer
 
-interface IKey {
-    val str: String
-}
+interface IKey
 
 @Serializable(KeySerializer::class)
-enum class Key(
-    override val str: String,
-) : IKey {
+enum class Key : IKey {
     // Predefinerte fra rapids-and-rivers-biblioteket
-    EVENT_NAME("@event_name"),
-    BEHOV("@behov"),
+    EVENT_NAME,
+    BEHOV,
 
     // Egendefinerte
-    ARBEIDSFORHOLD("arbeidsforhold"),
-    ARBEIDSGIVER_FNR("arbeidsgiver_fnr"),
-    BESTEMMENDE_FRAVAERSDAG("bestemmende_fravaersdag"),
-    DATA("data"),
-    EKSTERN_INNTEKTSMELDING("ekstern_inntektsmelding"),
-    ER_DUPLIKAT_IM("er_duplikat_im"),
-    FAIL("fail"),
-    FNR("fnr"),
-    FNR_LISTE("fnr_liste"),
-    FORESPOERSEL("forespoersel"),
-    FORESPOERSEL_ID("forespoersel_id"),
-    FORESPOERSEL_MAP("forespoersel_map"),
-    FORESPOERSEL_SVAR("forespoersel_svar"),
-    INNSENDING_ID("innsending_id"),
-    INNTEKT("inntekt"),
-    INNTEKTSDATO("inntektsdato"),
-    INNTEKTSMELDING("inntektsmelding"),
-    JOURNALPOST_ID("journalpost_id"),
-    KONTEKST_ID("kontekst_id"),
-    LAGRET_INNTEKTSMELDING("lagret_inntektsmelding"),
-    OPPGAVE_ID("oppgave_id"),
-    ORGNR_UNDERENHETER("orgnr_underenheter"),
-    ORG_RETTIGHETER("org_rettigheter"),
-    PERSONER("personer"),
-    SAK_ID("sak_id"),
-    SELVBESTEMT_ID("selvbestemt_id"),
-    SELVBESTEMT_INNTEKTSMELDING("selvbestemt_inntektsmelding"),
-    SKAL_HA_PAAMINNELSE("skal_ha_paaminnelse"),
-    SKJEMA_INNTEKTSMELDING("skjema_inntektsmelding"),
-    SPINN_INNTEKTSMELDING_ID("spinn_inntektsmelding_id"),
-    SYKMELDT("sykmeldt"),
-    TILGANG("tilgang"),
-    VEDTAKSPERIODE_ID_LISTE("vedtaksperiode_id_liste"),
-    VIRKSOMHET("virksomhet"),
-    VIRKSOMHETER("virksomheter"),
-    ORGNR_UNDERENHET("orgnr_underenhet"),
+    ARBEIDSFORHOLD,
+    ARBEIDSGIVER_FNR,
+    BESTEMMENDE_FRAVAERSDAG,
+    DATA,
+    EKSTERN_INNTEKTSMELDING,
+    ER_DUPLIKAT_IM,
+    FAIL,
+    FNR,
+    FNR_LISTE,
+    FORESPOERSEL,
+    FORESPOERSEL_ID,
+    FORESPOERSEL_MAP,
+    FORESPOERSEL_SVAR,
+    INNSENDING_ID,
+    INNTEKT,
+    INNTEKTSDATO,
+    INNTEKTSMELDING,
+    JOURNALPOST_ID,
+    KONTEKST_ID,
+    LAGRET_INNTEKTSMELDING,
+    OPPGAVE_ID,
+    ORGNR_UNDERENHET,
+    ORGNR_UNDERENHETER,
+    ORG_RETTIGHETER,
+    PERSONER,
+    SAK_ID,
+    SELVBESTEMT_ID,
+    SELVBESTEMT_INNTEKTSMELDING,
+    SKAL_HA_PAAMINNELSE,
+    SKJEMA_INNTEKTSMELDING,
+    SPINN_INNTEKTSMELDING_ID,
+    SYKMELDT,
+    TILGANG,
+    VEDTAKSPERIODE_ID_LISTE,
+    VIRKSOMHET,
+    VIRKSOMHETER,
     ;
 
-    override fun toString(): String = str
+    override fun toString(): String =
+        when (this) {
+            EVENT_NAME -> "@event_name"
+            BEHOV -> "@behov"
+            else -> name.lowercase()
+        }
 
     companion object {
         internal fun fromString(key: String): Key =

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/pritopic/Pri.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/pritopic/Pri.kt
@@ -12,33 +12,38 @@ object Pri {
     const val TOPIC = "helsearbeidsgiver.pri"
 
     @Serializable(KeySerializer::class)
-    enum class Key(
-        override val str: String,
-    ) : IKey {
+    enum class Key : IKey {
         // Predefinerte fra rapids-and-rivers-biblioteket
-        BEHOV("@behov"),
-        LØSNING("@løsning"),
+        BEHOV,
+        LOESNING,
 
         // Egendefinerte
-        NOTIS("notis"),
-        BOOMERANG("boomerang"),
-        ORGNR("orgnr"),
-        FNR("fnr"),
-        FORESPOERSEL_ID("forespoerselId"),
-        SPINN_INNTEKTSMELDING_ID("spinnInntektsmeldingId"),
-        VEDTAKSPERIODE_ID_LISTE("vedtaksperiode_id_liste"),
-        SKAL_HA_PAAMINNELSE("skal_ha_paaminnelse"),
-        FORESPOERSEL("forespoersel"),
+        BOOMERANG,
+        FNR,
+        FORESPOERSEL,
+        FORESPOERSEL_ID,
+        NOTIS,
+        ORGNR,
+        SKAL_HA_PAAMINNELSE,
+        SPINN_INNTEKTSMELDING_ID,
+        VEDTAKSPERIODE_ID_LISTE,
         ;
 
-        override fun toString(): String = str
+        override fun toString(): String =
+            when (this) {
+                BEHOV -> "@behov"
+                LOESNING -> "@løsning"
+                FORESPOERSEL_ID -> "forespoerselId"
+                SPINN_INNTEKTSMELDING_ID -> "spinnInntektsmeldingId"
+                else -> name.lowercase()
+            }
 
         companion object {
-            internal fun fromJson(json: String): Key =
+            internal fun fromJson(key: String): Key =
                 Key.entries.firstOrNull {
-                    json == it.str
+                    key == it.toString()
                 }
-                    ?: throw IllegalArgumentException("Fant ingen Pri.Key med verdi som matchet '$json'.")
+                    ?: throw IllegalArgumentException("Fant ingen Pri.Key med verdi som matchet '$key'.")
         }
     }
 

--- a/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
+++ b/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
@@ -32,7 +32,7 @@ class KotlinxUtilsKtTest :
                 val json =
                     JsonObject(
                         expectedMap
-                            .mapKeys { it.key.str }
+                            .mapKeys { it.key.toString() }
                             .mapValues { it.value.toJson() },
                     )
 
@@ -51,7 +51,7 @@ class KotlinxUtilsKtTest :
                 val json =
                     JsonObject(
                         expectedMap
-                            .mapKeys { it.key.str }
+                            .mapKeys { it.key.toString() }
                             .plus(
                                 "ikke en key" to "skal ikke være med",
                             ).mapValues { it.value.toJson() },

--- a/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -47,7 +47,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
         sikkerLogger.info("Mottok melding på pri-topic:\n${json.toPretty()}")
 
         return mapOf(
-            Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(EventName.serializer()),
+            Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(),
             Key.KONTEKST_ID to transaksjonId.toJson(),
             Key.DATA to
                 mapOf(

--- a/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -50,7 +50,7 @@ class ForespoerselMottattRiverTest :
 
             publisert.minus(Key.KONTEKST_ID) shouldContainExactly
                 mapOf(
-                    Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(EventName.serializer()),
+                    Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
@@ -33,7 +33,7 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
     private val sikkerLogger = sikkerLogger()
 
     override fun les(json: Map<Pri.Key, JsonElement>): ForespoerselSvarMelding {
-        val forespoerselSvar = Pri.Key.LØSNING.les(ForespoerselSvar.serializer(), json)
+        val forespoerselSvar = Pri.Key.LOESNING.les(ForespoerselSvar.serializer(), json)
         val boomerang = forespoerselSvar.boomerang.toMap()
 
         return ForespoerselSvarMelding(

--- a/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
+++ b/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
@@ -34,7 +34,7 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
     private val sikkerLogger = sikkerLogger()
 
     override fun les(json: Map<Pri.Key, JsonElement>): VedtaksperiodeIdForespoerselSvarMelding {
-        val forespoerselSvar = Pri.Key.LØSNING.les(ForespoerselListeSvar.serializer(), json)
+        val forespoerselSvar = Pri.Key.LOESNING.les(ForespoerselListeSvar.serializer(), json)
         val boomerang = forespoerselSvar.boomerang.toMap()
 
         return VedtaksperiodeIdForespoerselSvarMelding(

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiverTest.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiverTest.kt
@@ -43,7 +43,7 @@ class ForespoerselSvarRiverTest :
         ) { expectedIncoming ->
             testRapid.sendJson(
                 Pri.Key.BEHOV to Pri.BehovType.TRENGER_FORESPØRSEL.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to expectedIncoming.toJson(ForespoerselSvar.serializer()),
+                Pri.Key.LOESNING to expectedIncoming.toJson(ForespoerselSvar.serializer()),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
@@ -56,7 +56,7 @@ class ForespoerselSvarRiverTest :
 
             testRapid.sendJson(
                 Pri.Key.BEHOV to Pri.BehovType.TRENGER_FORESPØRSEL.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to expectedIncoming.toJson(ForespoerselSvar.serializer()),
+                Pri.Key.LOESNING to expectedIncoming.toJson(ForespoerselSvar.serializer()),
             )
 
             testRapid.inspektør.size shouldBeExactly 1

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -109,6 +109,6 @@ fun mockForespoerselSvarSuksessMedFastsattInntekt(forespoerselId: UUID): Forespo
 
 private fun mockBoomerang(): JsonElement =
     mapOf(
-        Key.EVENT_NAME.str to EventName.INNTEKT_REQUESTED.toJson(),
-        Key.KONTEKST_ID.str to UUID.randomUUID().toJson(),
+        Key.EVENT_NAME to EventName.INNTEKT_REQUESTED.toJson(),
+        Key.KONTEKST_ID to UUID.randomUUID().toJson(),
     ).toJson()

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
@@ -60,7 +60,7 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
 
             testRapid.sendJson(
                 Pri.Key.BEHOV to Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to forespoerselListeSvarMock.toJson(ForespoerselListeSvar.serializer()),
+                Pri.Key.LOESNING to forespoerselListeSvarMock.toJson(ForespoerselListeSvar.serializer()),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
@@ -96,7 +96,7 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
 
             testRapid.sendJson(
                 Pri.Key.BEHOV to Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to forespoerselListeSvarMock.toJson(ForespoerselListeSvar.serializer()),
+                Pri.Key.LOESNING to forespoerselListeSvarMock.toJson(ForespoerselListeSvar.serializer()),
             )
 
             val actual = testRapid.firstMessage().lesFail()

--- a/inntektservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektServiceTest.kt
+++ b/inntektservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektServiceTest.kt
@@ -55,7 +55,7 @@ class InntektServiceTest {
                 utloesendeMelding =
                     JsonObject(
                         mapOf(
-                            Key.BEHOV.str to BehovType.HENT_INNTEKT.toJson(),
+                            Key.BEHOV.toString() to BehovType.HENT_INNTEKT.toJson(),
                         ),
                     ),
             )

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -301,7 +301,7 @@ abstract class EndToEndTest : ContainerTest() {
         } answers {
             publish(
                 Pri.Key.BEHOV to Pri.BehovType.TRENGER_FORESPØRSEL.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to
+                Pri.Key.LOESNING to
                     ForespoerselSvar(
                         forespoerselId = forespoerselId,
                         resultat = forespoerselSvar,
@@ -341,7 +341,7 @@ abstract class EndToEndTest : ContainerTest() {
         } answers {
             publish(
                 Pri.Key.BEHOV to Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(Pri.BehovType.serializer()),
-                Pri.Key.LØSNING to
+                Pri.Key.LOESNING to
                     ForespoerselListeSvar(
                         resultat = forespoerselListeSvar,
                         boomerang = boomerang.shouldNotBeNull(),

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/MessagesTest.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/MessagesTest.kt
@@ -9,9 +9,12 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 
 class MessagesTest :
     FunSpec({
@@ -55,7 +58,7 @@ class MessagesTest :
 
             funnetMelding.also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
-                data[Key.VIRKSOMHET]?.fromJson(String.serializer()) shouldBe Mock.ORGNR
+                data[Key.VIRKSOMHET]?.fromJson(String.serializer()) shouldBe Mock.orgnr
             }
         }
 
@@ -68,15 +71,15 @@ class MessagesTest :
     })
 
 private object Mock {
-    const val ORGNR = "orgnr-pai"
+    val orgnr = Orgnr.genererGyldig().verdi
 
     val meldinger =
         mapOf(
-            Key.EVENT_NAME.str to EventName.TRENGER_REQUESTED.toJson(EventName.serializer()),
-            Key.BEHOV.str to BehovType.HENT_VIRKSOMHET_NAVN.toJson(BehovType.serializer()),
-            Key.DATA.str to
+            Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
+            Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
+            Key.DATA to
                 mapOf(
-                    Key.VIRKSOMHET.str to ORGNR.toJson(),
+                    Key.VIRKSOMHET to orgnr.toJson(),
                 ).toJson(),
         ).toJson()
             .toMessages()

--- a/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangForespoerselServiceTest.kt
+++ b/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangForespoerselServiceTest.kt
@@ -52,7 +52,7 @@ class TilgangForespoerselServiceTest {
                 utloesendeMelding =
                     JsonObject(
                         mapOf(
-                            Key.BEHOV.str to BehovType.TILGANGSKONTROLL.toJson(),
+                            Key.BEHOV.toString() to BehovType.TILGANGSKONTROLL.toJson(),
                         ),
                     ),
             )

--- a/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangOrgServiceTest.kt
+++ b/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangOrgServiceTest.kt
@@ -51,7 +51,7 @@ class TilgangOrgServiceTest {
                 utloesendeMelding =
                     JsonObject(
                         mapOf(
-                            Key.BEHOV.str to BehovType.TILGANGSKONTROLL.toJson(),
+                            Key.BEHOV.toString() to BehovType.TILGANGSKONTROLL.toJson(),
                         ),
                     ),
             )


### PR DESCRIPTION
Med strengene så hadde vi en slags dobbel definisjon. Nå som vi sammenstilt strengverdi med enumnavn de fleste tilfellene, så kan vi kvitte oss med den unødvendige strengen.