### PR TITLE
Legg til upresis opprettet dato

### DIFF
--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
@@ -26,6 +26,7 @@ data class HentForespoerselResponse(
     val bruttoinntekt: Double?,
     val tidligereinntekter: List<InntektPerMaaned>,
     val forespurtData: ForespurtData?,
+    val opprettetUpresisIkkeBruk: LocalDate,
     val erBesvart: Boolean,
     val feilReport: FeilReport? = null,
     val success: JsonElement? = null,

--- a/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -109,6 +109,7 @@ private fun HentForespoerselResultat.toResponse(): HentForespoerselResponse {
             bruttoinntekt = inntekt?.gjennomsnitt(),
             tidligereinntekter = inntekt?.maanedOversikt.orEmpty(),
             forespurtData = forespoersel.forespurtData,
+            opprettetUpresisIkkeBruk = forespoersel.opprettetUpresisIkkeBruk,
             erBesvart = forespoersel.erBesvart,
             feilReport =
                 if (feil.isEmpty()) {

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -168,6 +168,7 @@ private object Mock {
             forespurtData = mockForespurtData(),
             erBesvart = false,
             vedtaksperiodeId = UUID.randomUUID(),
+            opprettetUpresisIkkeBruk = 31.mars,
         )
 
     private val inntekt =

--- a/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -235,6 +235,7 @@ private object Mock {
             "bruttoinntekt": ${inntekt.gjennomsnitt()},
             "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
             "forespurtData": ${forespoersel.forespurtData.hardcodedJson()},
+            "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
             "erBesvart": ${forespoersel.erBesvart},
             "success": {
                 "navn": "Ola Normann",
@@ -249,6 +250,7 @@ private object Mock {
                 "bruttoinntekt": ${inntekt.gjennomsnitt()},
                 "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
                 "forespurtData": ${forespoersel.forespurtData.hardcodedJson()},
+                "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
                 "erBesvart": ${forespoersel.erBesvart}
             }
         }
@@ -269,6 +271,7 @@ private object Mock {
             "bruttoinntekt": ${inntekt.gjennomsnitt()},
             "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
             "forespurtData": ${mockForespurtDataMedForrigeInntekt().hardcodedJson()},
+            "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
             "erBesvart": ${forespoersel.erBesvart},
             "success": {
                 "navn": "Ola Normann",
@@ -283,6 +286,7 @@ private object Mock {
                 "bruttoinntekt": ${inntekt.gjennomsnitt()},
                 "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
                 "forespurtData": ${mockForespurtDataMedForrigeInntekt().hardcodedJson()},
+                "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
                 "erBesvart": ${forespoersel.erBesvart}
             }
         }

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -21,6 +21,7 @@ data class Forespoersel(
     val bestemmendeFravaersdager: Map<String, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
+    val opprettetUpresisIkkeBruk: LocalDate,
 ) {
     fun forslagBestemmendeFravaersdag(): LocalDate {
         val forslag = bestemmendeFravaersdager[orgnr]

--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -24,6 +24,7 @@ data class ForespoerselFraBro(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
+    val opprettetUpresisIkkeBruk: LocalDate,
 ) {
     fun toForespoersel(): Forespoersel =
         Forespoersel(
@@ -35,5 +36,6 @@ data class ForespoerselFraBro(
             bestemmendeFravaersdager = bestemmendeFravaersdager.mapKeys { it.key.verdi },
             forespurtData = forespurtData,
             erBesvart = erBesvart,
+            opprettetUpresisIkkeBruk = opprettetUpresisIkkeBruk,
         )
 }

--- a/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
+++ b/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
@@ -28,6 +28,7 @@ fun mockForespoersel(): Forespoersel {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 

--- a/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -91,5 +91,6 @@ object Mock {
             bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
             forespurtData = mockForespurtData(),
             erBesvart = false,
+            opprettetUpresisIkkeBruk = 17.januar,
         )
 }

--- a/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -42,6 +42,7 @@ fun mockForespoerselListeSvarMedSuksess(): ForespoerselListeSvar {
                     bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
                     forespurtData = mockForespurtData(),
                     erBesvart = false,
+                    opprettetUpresisIkkeBruk = 17.januar,
                 ),
             ),
         boomerang = mockBoomerang(),
@@ -85,6 +86,7 @@ fun mockForespoerselSvarSuksess(forespoerselId: UUID): ForespoerselFraBro {
         bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 
@@ -104,6 +106,7 @@ fun mockForespoerselSvarSuksessMedFastsattInntekt(forespoerselId: UUID): Forespo
         bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
         forespurtData = mockForespurtDataMedFastsattInntekt(),
         erBesvart = false,
+        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -347,6 +347,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr.verdi to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = 2.august,
             )
 
         val forespoerselSvar =
@@ -360,6 +361,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = forespoersel.bestemmendeFravaersdager.mapKeys { Orgnr(it.key) },
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = forespoersel.opprettetUpresisIkkeBruk,
             )
     }
 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -140,6 +141,7 @@ class ForespoerselMottattIT : EndToEndTest() {
                 bestemmendeFravaersdager = emptyMap(),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = 10.februar,
             )
         val sakId = UUID.randomUUID().toString()
         val oppgaveId = UUID.randomUUID().toString()

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -232,6 +232,7 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr.verdi to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = 17.juli,
             )
 
         val forespoerselSvar =
@@ -245,6 +246,7 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = forespoersel.bestemmendeFravaersdager.mapKeys { Orgnr(it.key) },
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = forespoersel.opprettetUpresisIkkeBruk,
             )
     }
 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -176,6 +176,7 @@ class InnsendingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 17.mars),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                opprettetUpresisIkkeBruk = 19.mars,
             )
     }
 }

--- a/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
+++ b/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
@@ -25,6 +25,7 @@ fun mockForespoerselSvarSuksess(): ForespoerselFraBro {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 
@@ -47,6 +48,7 @@ fun mockForespoerselListeSvarResultat(
                 ),
             forespurtData = mockForespurtData(),
             erBesvart = false,
+            opprettetUpresisIkkeBruk = 17.januar,
         )
     return listOf(forespoersel, forespoersel.copy(vedtaksperiodeId = vedtaksperiodeId2))
 }


### PR DESCRIPTION
**Forklaring av variabel:**

Denne datoen er tidspunktet forespørselen i helsebro ble opprettet, men kan være et tilfeldig tidspunkt etter opprettelse.

For flexjar usecase kan vi for eksempel garantere at forespørselen har en alder av 28 eller mer dager.

________

**Testing av funksjonalitet:**

✅ Testet opprettelse av IM i dev miljø

✅ Funnet endring i API: `"opprettetUpresisIkkeBruk": "2024-12-04",`

✅ Funnet endring i dev logs for im-api: `"opprettetUpresisIkkeBruk":"2024-12-04"`
