### PR TITLE
Logg melding som mangler startdata for service

### DIFF
--- a/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
+++ b/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
@@ -4,6 +4,7 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.json.toPretty
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
 import no.nav.helsearbeidsgiver.utils.log.MdcUtils
@@ -77,7 +78,7 @@ abstract class ServiceMed1Steg<S0, S1> : Service {
         }.onFailure {
             "Klarte ikke lese startdata for service.".also {
                 logger.error(it)
-                sikkerLogger.error(it)
+                sikkerLogger.error("$it\n${melding.toPretty()}")
             }
         }
     }


### PR DESCRIPTION
Vi ønsker å logge mer slik at vi kan bedre forstå situasjonene hvor dette skjer.