### PR TITLE
Fiks henting av tags i prod workflow

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -22,6 +22,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 25
+          fetch-tags: true
 
       - name: Cache gradle wrapper
         uses: actions/cache@v4


### PR DESCRIPTION
Jeg misforsto noe dokumentasjon. Vi bruker tags i prodsetting, men tags blir ikke hentet fra repoet i Github Actions. Denne endringen må med for at prod workflowen skal fungere som tiltenkt.