### PR TITLE
Fiks henting av tags i prod workflow (v2)

### DIFF
--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -20,9 +20,10 @@ jobs:
       is_deploy_matrix_empty: ${{ steps.set_matrix.outputs.is_deploy_matrix_empty }}
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 25
-          fetch-tags: true
+
+        # We fetch tags here because 'fetch-tags'-option on checkout-action doesn't work on release
+      - name: Fetch tags
+        run: git fetch --depth=1 --tags --quiet
 
       - name: Cache gradle wrapper
         uses: actions/cache@v4
@@ -49,6 +50,7 @@ jobs:
           PREVIOUS_TAG=$(git tag --sort version:refname | tail -n 2 | head -n 1)
           # Create a comma-separated list of changed files for use in build.gradle.kts
           CHANGED_FILES=$(git diff-tree --no-commit-id --name-only -r -m $PREVIOUS_TAG $GITHUB_REF | tr '\r\n' ',' | sed -e 's/,$//' | tr -d '"')
+          echo Files changed from $PREVIOUS_TAG to $GITHUB_REF are [$CHANGED_FILES]
           echo "CHANGED_FILES=$CHANGED_FILES" >> $GITHUB_ENV
 
       - name: Determine projects to deploy


### PR DESCRIPTION
Et nytt forsøk på å fikse prod workflow. Siste feil skyldes at `fetch-tags: true` ikke fungerer med en workflow som trigges av en tag, slik vår gjør.

Se https://github.com/navikt/helsearbeidsgiver-inntektsmelding/actions/runs/12235255860/job/34126166060#step:2:58 for feilende workflow.

Se https://github.com/actions/checkout/issues/1467 for Github issue for `checkout`-actionen.