### PR TITLE
Definér klientavhengighetene i appene de brukes i

### DIFF
--- a/aareg/gradle.properties
+++ b/aareg/gradle.properties
@@ -1,0 +1,1 @@
+aaregClientVersion=0.7.0

--- a/altinn/gradle.properties
+++ b/altinn/gradle.properties
@@ -1,2 +1,4 @@
+altinnClientVersion=0.4.0
+maskinportenClientVersion=0.1.9
 mockwebserverVersion=5.0.0-alpha.14
 nimbusJoseJwtVersion=9.47

--- a/bro-spinn/gradle.properties
+++ b/bro-spinn/gradle.properties
@@ -1,0 +1,1 @@
+spinnInntektsmeldingKontraktVersion=2023.10.13-04-47-c372d

--- a/brreg/gradle.properties
+++ b/brreg/gradle.properties
@@ -1,0 +1,1 @@
+brregKlientVersion=0.5.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,3 @@ ktorVersion=2.3.12
 mockkVersion=1.13.13
 tokenProviderVersion=0.4.0
 utilsVersion=0.9.0
-
-# Client dependency versions
-aaregClientVersion=0.7.0
-altinnClientVersion=0.4.0
-maskinportenClientVersion=0.1.9
-arbeidsgiverNotifikasjonKlientVersion=3.3.2
-brregKlientVersion=0.5.0
-dokarkivKlientVersion=0.3.1
-inntektKlientVersion=0.4.0
-pdlKlientVersion=0.6.2
-spinnInntektsmeldingKontraktVersion=2023.10.13-04-47-c372d

--- a/inntekt/gradle.properties
+++ b/inntekt/gradle.properties
@@ -1,0 +1,1 @@
+inntektKlientVersion=0.4.0

--- a/integrasjonstest/build.gradle.kts
+++ b/integrasjonstest/build.gradle.kts
@@ -32,7 +32,8 @@ val apps =
     )
 
 val props = Properties()
-apps.map { file("../$it/gradle.properties") }
+apps
+    .map { file("../$it/gradle.properties") }
     .filter { it.exists() }
     .forEach { file ->
         file.inputStream().use { props.load(it) }

--- a/integrasjonstest/build.gradle.kts
+++ b/integrasjonstest/build.gradle.kts
@@ -1,48 +1,63 @@
-val aaregClientVersion: String by project
-val altinnClientVersion: String by project
-val arbeidsgiverNotifikasjonKlientVersion: String by project
-val bakgrunnsjobbVersion: String by project
-val brregKlientVersion: String by project
-val dokarkivKlientVersion: String by project
-val inntektKlientVersion: String by project
+import java.util.Properties
+
+val apps =
+    setOf(
+        "aareg",
+        "aktiveorgnrservice",
+        "altinn",
+        "api",
+        "berik-inntektsmelding-service",
+        "bro-spinn",
+        "brreg",
+        "db",
+        "distribusjon",
+        "feil-behandler",
+        "forespoersel-besvart",
+        "forespoersel-forkastet",
+        "forespoersel-infotrygd",
+        "forespoersel-marker-besvart",
+        "forespoersel-mottatt",
+        "helsebro",
+        "innsending",
+        "inntekt",
+        "inntekt-selvbestemt-service",
+        "inntektservice",
+        "joark",
+        "notifikasjon",
+        "pdl",
+        "selvbestemt-hent-im-service",
+        "selvbestemt-lagre-im-service",
+        "tilgangservice",
+        "trengerservice",
+    )
+
+val props = Properties()
+apps.map { file("../$it/gradle.properties") }
+    .filter { it.exists() }
+    .forEach { file ->
+        file.inputStream().use { props.load(it) }
+    }
+
+val aaregClientVersion: String by props
+val altinnClientVersion: String by props
+val arbeidsgiverNotifikasjonKlientVersion: String by props
+val bakgrunnsjobbVersion: String by props
+val brregKlientVersion: String by props
+val dokarkivKlientVersion: String by props
+val inntektKlientVersion: String by props
+val pdlKlientVersion: String by props
+
 val junitJupiterVersion: String by project
-val pdlKlientVersion: String by project
 val testcontainersRedisJunitVersion: String by project
 val testcontainersVersion: String by project
 
 dependencies {
-    testImplementation(project(":aareg"))
-    testImplementation(project(":aktiveorgnrservice"))
-    testImplementation(project(":altinn"))
-    testImplementation(project(":api"))
-    testImplementation(project(":bro-spinn"))
-    testImplementation(project(":brreg"))
-    testImplementation(project(":db"))
-    testImplementation(project(":distribusjon"))
-    testImplementation(project(":forespoersel-besvart"))
-    testImplementation(project(":forespoersel-forkastet"))
-    testImplementation(project(":forespoersel-infotrygd"))
-    testImplementation(project(":forespoersel-marker-besvart"))
-    testImplementation(project(":forespoersel-mottatt"))
-    testImplementation(project(":helsebro"))
-    testImplementation(project(":innsending"))
-    testImplementation(project(":inntekt"))
-    testImplementation(project(":inntekt-selvbestemt-service"))
-    testImplementation(project(":inntektservice"))
-    testImplementation(project(":joark"))
-    testImplementation(project(":notifikasjon"))
-    testImplementation(project(":pdl"))
-    testImplementation(project(":selvbestemt-hent-im-service"))
-    testImplementation(project(":selvbestemt-lagre-im-service"))
-    testImplementation(project(":tilgangservice"))
-    testImplementation(project(":trengerservice"))
-    testImplementation(project(":berik-inntektsmelding-service"))
-    testImplementation(project(":feil-behandler"))
+    apps.forEach {
+        testImplementation(project(":$it"))
+    }
 
     testImplementation(project(":felles"))
     testImplementation(project(":felles-db-exposed"))
-
-    testImplementation("no.nav.helsearbeidsgiver:hag-bakgrunnsjobb:$bakgrunnsjobbVersion")
 
     testImplementation(testFixtures(project(":felles")))
     testImplementation(testFixtures(project(":felles-db-exposed")))
@@ -57,6 +72,7 @@ dependencies {
     testImplementation("no.nav.helsearbeidsgiver:pdl-client:$pdlKlientVersion")
 
     testImplementation("com.redis.testcontainers:testcontainers-redis-junit:$testcontainersRedisJunitVersion")
+    testImplementation("no.nav.helsearbeidsgiver:hag-bakgrunnsjobb:$bakgrunnsjobbVersion")
     testImplementation("org.junit.jupiter:junit-jupiter:$junitJupiterVersion")
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")

--- a/integrasjonstest/gradle.properties
+++ b/integrasjonstest/gradle.properties
@@ -1,5 +1,3 @@
 # Dependency versions
-bakgrunnsjobbVersion=1.0.4
-junitJupiterVersion=5.11.3
 testcontainersRedisJunitVersion=1.6.4
 testcontainersVersion=1.20.3

--- a/joark/gradle.properties
+++ b/joark/gradle.properties
@@ -1,3 +1,4 @@
+dokarkivKlientVersion=0.3.1
 hagImXmlKontraktVersion=1.0.8
 jacksonVersion=2.14.2
 jaxbAPIVersion=2.3.1

--- a/notifikasjon/gradle.properties
+++ b/notifikasjon/gradle.properties
@@ -1,0 +1,1 @@
+arbeidsgiverNotifikasjonKlientVersion=3.3.2

--- a/pdl/gradle.properties
+++ b/pdl/gradle.properties
@@ -1,0 +1,1 @@
+pdlKlientVersion=0.6.2


### PR DESCRIPTION
Klientavhengigheten ble i sin tid lagt til filen med fellesavhengigheter for integrasjonstestene trengte dem. Det løser vi her ved å la integrasjonstestene lese avhengighetsfilene til alle appene.

En bonus med dette er at når vi flytter dem ut av fellesfilen så trenger vi ikke lenger å prodsette alle appene dersom vi oppdaterer en enkelt klient. Det gjør vi i dag fordi endringer i fellesfilen skal i utgangspunktet påvirke hver eneste app.