### PR TITLE
Utled bestemmende fraværsdag for selvbestemt IM for bruk i XML-dokument

### DIFF
--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -5,6 +5,7 @@ import no.nav.helsearbeidsgiver.dokarkiv.DokArkivClient
 import no.nav.helsearbeidsgiver.dokarkiv.domene.Avsender
 import no.nav.helsearbeidsgiver.dokarkiv.domene.GjelderPerson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.les
@@ -55,13 +56,19 @@ class JournalfoerImRiver(
                         bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, data),
                     )
 
-                EventName.SELVBESTEMT_IM_LAGRET ->
+                EventName.SELVBESTEMT_IM_LAGRET -> {
+                    val im = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data)
                     JournalfoerImMelding(
                         eventName = eventName,
                         transaksjonId = transaksjonId,
-                        inntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
-                        bestemmendeFravaersdag = null,
+                        inntektsmelding = im,
+                        bestemmendeFravaersdag =
+                            bestemmendeFravaersdag(
+                                arbeidsgiverperioder = im.agp?.perioder.orEmpty(),
+                                sykefravaersperioder = im.sykmeldingsperioder,
+                            ),
                     )
+                }
 
                 else ->
                     null

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -124,6 +124,7 @@ class JournalfoerImRiverTest :
                         Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
                         Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                        Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(),
                     )
 
                 coVerifySequence {


### PR DESCRIPTION
Denne skulle alltid ha vært med, men har feilaktig blitt `null`.