### PR TITLE
Fjern bestemmenede fraværsdag (del 1)

### DIFF
--- a/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -204,7 +204,7 @@ class BerikInntektsmeldingService(
                         .plus(
                             mapOf(
                                 Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-                                // TODO vurder å flytte denne inn i Inntektsmelding (ikke sikker om det er en god idé, så avventer til v1 er brukt overalt)
+                                // TODO fjern etter overgangsfase
                                 Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(),
                                 Key.INNSENDING_ID to steg0.innsendingId.toJson(Long.serializer()),
                             ),

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -15,12 +15,10 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
-import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
-import java.time.LocalDate
 import java.util.UUID
 
 data class LagreImMelding(
@@ -29,7 +27,6 @@ data class LagreImMelding(
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
     val inntektsmelding: Inntektsmelding,
-    val bestemmendeFravaersdag: LocalDate,
     val innsendingId: Long,
 )
 
@@ -51,13 +48,12 @@ class LagreImRiver(
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
-                bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.les(LocalDateSerializer, data),
                 innsendingId = Key.INNSENDING_ID.les(Long.serializer(), data),
             )
         }
 
     override fun LagreImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
-        val inntektsmeldingGammeltFormat = inntektsmelding.convert().copy(bestemmendeFraværsdag = bestemmendeFravaersdag)
+        val inntektsmeldingGammeltFormat = inntektsmelding.convert()
 
         imRepo.oppdaterMedBeriketDokument(inntektsmelding.type.id, innsendingId, inntektsmeldingGammeltFormat)
         sikkerLogger.info("Lagret inntektsmelding.")

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -15,7 +15,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
-import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -84,13 +83,11 @@ class LagreJournalpostIdRiver(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
             Key.KONTEKST_ID to transaksjonId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-            Key.BESTEMMENDE_FRAVAERSDAG to json[Key.BESTEMMENDE_FRAVAERSDAG],
             Key.JOURNALPOST_ID to journalpostId.toJson(),
-        ).mapValuesNotNull { it }
-            .also {
-                logger.info("Publiserer event '${EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET}' med journalpost-ID '$journalpostId'.")
-                sikkerLogger.info("Publiserer event:\n${it.toPretty()}")
-            }
+        ).also {
+            logger.info("Publiserer event '${EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET}' med journalpost-ID '$journalpostId'.")
+            sikkerLogger.info("Publiserer event:\n${it.toPretty()}")
+        }
     }
 
     override fun LagreJournalpostIdMelding.haandterFeil(

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
@@ -28,7 +28,6 @@ import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import java.util.UUID
 
 class LagreImRiverTest :
@@ -63,7 +62,6 @@ class LagreImRiverTest :
                     Key.DATA to
                         mapOf(
                             Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                            Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(),
                             Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
                             Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                         ).toJson(),
@@ -122,8 +120,6 @@ class LagreImRiverTest :
         }
     })
 
-private val bestemmendeFravaersdag = 20.oktober
-
 private fun innkommendeMelding(
     innsendingId: Long,
     inntektsmelding: Inntektsmelding = mockInntektsmeldingV1(),
@@ -135,11 +131,9 @@ private fun innkommendeMelding(
         data =
             mapOf(
                 Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-                Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(),
                 Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
             ),
         inntektsmelding = inntektsmelding,
-        bestemmendeFravaersdag = bestemmendeFravaersdag,
         innsendingId = innsendingId,
     )
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -31,7 +31,6 @@ import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.INNSENDING_ID
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import java.util.UUID
 
 class LagreJournalpostIdRiverTest :
@@ -64,7 +63,6 @@ class LagreJournalpostIdRiverTest :
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
                         Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
                         Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                        Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     )
 
@@ -93,7 +91,6 @@ class LagreJournalpostIdRiverTest :
                 testRapid.sendJson(
                     innkommendeMelding
                         .toMap()
-                        .minus(Key.BESTEMMENDE_FRAVAERSDAG)
                         .minus(Key.INNSENDING_ID),
                 )
 
@@ -225,8 +222,6 @@ class LagreJournalpostIdRiverTest :
 private object Mock {
     const val INNSENDING_ID = 1L
 
-    val bestemmendeFravaersdag = 20.oktober
-
     fun innkommendeMelding(inntektsmelding: Inntektsmelding = mockInntektsmeldingV1()): LagreJournalpostIdMelding =
         LagreJournalpostIdMelding(
             eventName = EventName.INNTEKTSMELDING_JOURNALFOERT,
@@ -242,7 +237,6 @@ private object Mock {
             Key.KONTEKST_ID to transaksjonId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-            Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag.toJson(),
             Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
         )
 

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -1,21 +1,18 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.distribusjon
 
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.JournalfoertInntektsmelding
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toPretty
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
-import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
-import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toJsonStr
@@ -23,7 +20,6 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import org.apache.kafka.clients.producer.KafkaProducer
 import org.apache.kafka.clients.producer.ProducerRecord
-import java.time.LocalDate
 import java.util.UUID
 
 const val TOPIC_HELSEARBEIDSGIVER_INNTEKTSMELDING_EKSTERN = "helsearbeidsgiver.inntektsmelding"
@@ -32,7 +28,6 @@ data class Melding(
     val eventName: EventName,
     val transaksjonId: UUID,
     val inntektsmelding: Inntektsmelding,
-    val bestemmendeFravaersdag: LocalDate?,
     val journalpostId: String,
 )
 
@@ -50,7 +45,6 @@ class DistribusjonRiver(
                 eventName = Key.EVENT_NAME.krev(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET, EventName.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
-                bestemmendeFravaersdag = Key.BESTEMMENDE_FRAVAERSDAG.lesOrNull(LocalDateSerializer, json),
                 journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
             )
         }
@@ -61,7 +55,7 @@ class DistribusjonRiver(
             sikkerLogger.info("$it Innkommende melding:\n${json.toPretty()}")
         }
 
-        distribuerInntektsmelding(inntektsmelding, bestemmendeFravaersdag, journalpostId)
+        distribuerInntektsmelding(journalpostId, inntektsmelding)
 
         "Distribuerte IM med journalpost-ID '$journalpostId'.".also {
             logger.info(it)
@@ -73,8 +67,7 @@ class DistribusjonRiver(
             Key.KONTEKST_ID to transaksjonId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-            Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag?.toJson(),
-        ).mapValuesNotNull { it }
+        )
     }
 
     override fun Melding.haandterFeil(
@@ -106,15 +99,13 @@ class DistribusjonRiver(
         )
 
     private fun distribuerInntektsmelding(
-        inntektsmelding: Inntektsmelding,
-        bestemmendeFravaersdag: LocalDate?,
         journalpostId: String,
+        inntektsmelding: Inntektsmelding,
     ) {
         val journalfoertInntektsmelding =
             JournalfoertInntektsmelding(
                 journalpostId = journalpostId,
-                inntektsmeldingV1 = inntektsmelding,
-                bestemmendeFravaersdag = bestemmendeFravaersdag,
+                inntektsmelding = inntektsmelding,
             )
 
         val record =
@@ -126,12 +117,3 @@ class DistribusjonRiver(
         kafkaProducer.send(record)
     }
 }
-
-// Midlertidig klasse som inneholder bestemmende fraværsdag
-@Serializable
-data class JournalfoertInntektsmelding(
-    val journalpostId: String,
-    val inntektsmeldingV1: Inntektsmelding,
-    @Serializable(LocalDateSerializer::class)
-    val bestemmendeFravaersdag: LocalDate?,
-)

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
@@ -5,7 +5,6 @@ import no.nav.helsearbeidsgiver.dokarkiv.domene.DokumentVariant
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument.PdfDokument
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument.transformToXML
-import java.time.LocalDate
 import java.util.Base64
 import java.util.UUID
 
@@ -14,7 +13,6 @@ private val base64 = Base64.getEncoder()
 fun tilDokumenter(
     uuid: UUID,
     inntektsmelding: Inntektsmelding,
-    bestemmendeFravaersdag: LocalDate?,
 ): List<Dokument> =
     listOf(
         Dokument(
@@ -25,7 +23,7 @@ fun tilDokumenter(
                 listOf(
                     DokumentVariant(
                         filtype = "XML",
-                        fysiskDokument = transformToXML(inntektsmelding, bestemmendeFravaersdag).toByteArray().encode(),
+                        fysiskDokument = transformToXML(inntektsmelding).toByteArray().encode(),
                         variantFormat = "ORIGINAL",
                         filnavn = "ari-$uuid.xml",
                     ),

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLUtils.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLUtils.kt
@@ -4,16 +4,12 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.tilXmlInntektsmelding
 import no.seres.xsd.nav.inntektsmelding_m._20181211.ObjectFactory
 import java.io.StringWriter
-import java.time.LocalDate
 import javax.xml.bind.JAXBContext
 
 val CONTEXT: JAXBContext = JAXBContext.newInstance(ObjectFactory::class.java)
 
-fun transformToXML(
-    inntektsmeldingDokument: Inntektsmelding,
-    bestemmendeFravaersdag: LocalDate?,
-): String {
-    val inntektM = tilXmlInntektsmelding(inntektsmeldingDokument, bestemmendeFravaersdag)
+fun transformToXML(inntektsmeldingDokument: Inntektsmelding): String {
+    val inntektM = tilXmlInntektsmelding(inntektsmeldingDokument)
     val writer = StringWriter()
     CONTEXT.createMarshaller().marshal(ObjectFactory().createMelding(inntektM), writer)
     return writer.toString()

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -31,9 +31,7 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.Mock.toMap
-import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import java.time.LocalDate
 import java.util.UUID
 import no.nav.helsearbeidsgiver.dokarkiv.domene.Avsender as KlientAvsender
@@ -56,7 +54,7 @@ class JournalfoerImRiverTest :
                 val journalpostId = UUID.randomUUID().toString()
                 val innsendingId = 1L
 
-                val innkommendeMelding = Mock.innkommendeMelding(EventName.INNTEKTSMELDING_MOTTATT, Mock.inntektsmelding, Mock.bestemmendeFravaersdag)
+                val innkommendeMelding = Mock.innkommendeMelding(EventName.INNTEKTSMELDING_MOTTATT, Mock.inntektsmelding)
 
                 coEvery {
                     mockDokArkivKlient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
@@ -78,7 +76,6 @@ class JournalfoerImRiverTest :
                         Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
                         Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                        Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(),
                         Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                     )
 
@@ -124,7 +121,6 @@ class JournalfoerImRiverTest :
                         Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
                         Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                        Key.BESTEMMENDE_FRAVAERSDAG to Mock.bestemmendeFravaersdag.toJson(),
                     )
 
                 coVerifySequence {
@@ -203,20 +199,17 @@ class JournalfoerImRiverTest :
 
 private object Mock {
     val inntektsmelding = mockInntektsmeldingV1()
-    val bestemmendeFravaersdag = 20.oktober
 
     val fail = mockFail("I don't think we're in Kansas anymore.", EventName.INNTEKTSMELDING_MOTTATT)
 
     fun innkommendeMelding(
         eventName: EventName,
         inntektsmelding: Inntektsmelding,
-        bestemmendeFravaersdag: LocalDate? = null,
     ): JournalfoerImMelding =
         JournalfoerImMelding(
             eventName = eventName,
             transaksjonId = UUID.randomUUID(),
             inntektsmelding = inntektsmelding,
-            bestemmendeFravaersdag = bestemmendeFravaersdag,
         )
 
     fun JournalfoerImMelding.toMap(imKey: Key = Key.INNTEKTSMELDING): Map<Key, JsonElement> =
@@ -226,9 +219,7 @@ private object Mock {
             Key.DATA to
                 mapOf(
                     imKey to inntektsmelding.toJson(Inntektsmelding.serializer()),
-                    Key.BESTEMMENDE_FRAVAERSDAG to bestemmendeFravaersdag?.toJson(),
-                ).mapValuesNotNull { it }
-                    .toJson(),
+                ).toJson(),
         )
 
     fun opprettOgFerdigstillResponse(journalpostId: String): OpprettOgFerdigstillResponse =

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
@@ -1,7 +1,6 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.joark
 
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
-import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 import java.util.UUID
@@ -11,7 +10,7 @@ class TilDokumenterKtTest {
     fun tilDokumenter() {
         val mockInntektsmelding = mockInntektsmeldingV1()
 
-        val dokumenter = tilDokumenter(UUID.randomUUID(), mockInntektsmelding, 20.oktober)
+        val dokumenter = tilDokumenter(UUID.randomUUID(), mockInntektsmelding)
 
         assertEquals(1, dokumenter.size)
         assertEquals(2, dokumenter[0].dokumentVarianter.size)

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -23,8 +23,7 @@ class TilXmlInntektsmeldingTest {
     @Test
     fun `skal mappe inntektsmelding til xml-skjema`() {
         val im = mockInntektsmeldingV1()
-        val bestemmendeFravaersdag = 20.oktober
-        val imXml = tilXmlInntektsmelding(im, bestemmendeFravaersdag)
+        val imXml = tilXmlInntektsmelding(im)
         val skjema = imXml.skjemainnhold
         Assertions.assertNotNull(skjema.aarsakTilInnsending)
         Assertions.assertNotNull(skjema.arbeidsgiver)
@@ -32,7 +31,7 @@ class TilXmlInntektsmeldingTest {
         Assertions.assertEquals(im.avsender.tlf, skjema.arbeidsgiver.kontaktinformasjon.telefonnummer)
         Assertions.assertEquals(im.avsender.navn, skjema.arbeidsgiver.kontaktinformasjon.kontaktinformasjonNavn)
         Assertions.assertEquals(im.sykmeldt.fnr.verdi, skjema.arbeidstakerFnr)
-        Assertions.assertEquals(bestemmendeFravaersdag, skjema.arbeidsforhold.foersteFravaersdag)
+        Assertions.assertEquals(20.oktober, skjema.arbeidsforhold.foersteFravaersdag)
         Assertions.assertNotNull(skjema.arbeidsforhold.beregnetInntekt)
         Assertions.assertEquals(2, skjema.sykepengerIArbeidsgiverperioden.arbeidsgiverperiodeListe.size)
         Assertions.assertNotNull(skjema.sykepengerIArbeidsgiverperioden.bruttoUtbetalt)
@@ -65,7 +64,7 @@ class TilXmlInntektsmeldingTest {
                         endringAarsak = null,
                     ),
             )
-        val im = tilXmlInntektsmelding(inntektmeldingUtenAarsak, bestemmendeFravaersdag)
+        val im = tilXmlInntektsmelding(inntektmeldingUtenAarsak)
         Assertions.assertNull(im.skjemainnhold.arbeidsforhold.beregnetInntekt.aarsakVedEndring)
     }
 

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLMapperTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLMapperTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.tilXmlInntektsmelding
-import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import org.junit.jupiter.api.Test
 import java.io.StringReader
 import javax.xml.XMLConstants
@@ -22,10 +21,10 @@ class XMLMapperTest {
     }
 
     private fun mapToXML(mockInntektsmelding: Inntektsmelding) {
-        val inntektM = tilXmlInntektsmelding(mockInntektsmelding, 20.oktober)
+        val inntektM = tilXmlInntektsmelding(mockInntektsmelding)
         val sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI)
         val xsdSchema = sf.newSchema(inntektM.javaClass.classLoader.getResource("xsd/Inntektsmelding20181211_V7.xsd"))
-        val xml = transformToXML(mockInntektsmelding, 20.oktober)
+        val xml = transformToXML(mockInntektsmelding)
         val stringReader = StringReader(xml)
         val unmarshaller = CONTEXT.createUnmarshaller()
         unmarshaller.schema = xsdSchema
@@ -37,7 +36,6 @@ class XMLMapperTest {
 private fun mockInntektsmeldingDokumentMedTommeLister(): Inntektsmelding =
     mockInntektsmeldingV1().let {
         it.copy(
-            sykmeldingsperioder = emptyList(),
             agp =
                 it.agp?.copy(
                     perioder = emptyList(),


### PR DESCRIPTION
Spleis bruker ikke lenger denne datoen, så da kan vi fjerne den. Gjør det i to deler for å unngå problemer med in-flight meldinger.