### PR TITLE
Integrasjonstest: Bruk Kafka-versjon som ligner prod

### DIFF
--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/ContainerTest.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/ContainerTest.kt
@@ -14,7 +14,7 @@ import java.util.Properties
 abstract class ContainerTest {
     private val topic = "helsearbeidsgiver.inntektsmelding"
 
-    private val kafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.5.1"))
+    private val kafkaContainer = KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.7.2"))
     val redisContainer = RedisContainer(DockerImageName.parse("redis:7"))
     val postgresContainerOne = postgresContainer()
     val postgresContainerTwo = postgresContainer()


### PR DESCRIPTION
Siste annonserte oppdatering, så vidt jeg kan se: https://nav-it.slack.com/archives/C01DE3M9YBV/p1724826006909269?thread_ts=1724222746.503759&cid=C01DE3M9YBV

Sammenheng mellom Confluent- og Kafka-versjon: https://docs.confluent.io/platform/current/installation/versions-interoperability.html#cp-and-apache-ak-compatibility