### PR TITLE
Oppdater gradle-actions i workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,19 +26,7 @@ jobs:
         with:
           fetch-depth: 2
 
-      - name: Cache gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-
-      - name: Cache gradle caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Determine short SHA
         id: set_short_sha
@@ -96,21 +84,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Cache gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-
-      - name: Cache gradle caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Test and build
         run: ./gradlew ${{ matrix.project }}:test ${{ matrix.project }}:build

--- a/.github/workflows/gradle-dependabot.yml
+++ b/.github/workflows/gradle-dependabot.yml
@@ -16,9 +16,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
       - name: Generate and submit dependency graph
-        uses: gradle/actions/dependency-submission@v3
+        uses: gradle/actions/dependency-submission@v4
         env:
           ORG_GRADLE_PROJECT_githubPassword: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/integrasjonstest.yml
+++ b/.github/workflows/integrasjonstest.yml
@@ -14,25 +14,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches/build-cache-1/
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Build
         run: ./gradlew assemble --build-cache --parallel
@@ -75,7 +58,6 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
       - name: Download build artifacts
         uses: actions/download-artifact@v4
@@ -83,7 +65,7 @@ jobs:
           name: build-artifacts
           path: build/libs/
 
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Integrasjonstest
         run: ./gradlew integrasjonstest:test --build-cache --tests no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.${{ matrix.test }}

--- a/.github/workflows/prod.yml
+++ b/.github/workflows/prod.yml
@@ -25,19 +25,7 @@ jobs:
       - name: Fetch tags
         run: git fetch --depth=1 --tags --quiet
 
-      - name: Cache gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-
-      - name: Cache gradle caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Determine short SHA
         id: set_short_sha
@@ -98,21 +86,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Cache gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('**/gradle/wrapper/gradle-wrapper.properties') }}
-
-      - name: Cache gradle caches
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches
-          key: ${{ runner.os }}-gradle-caches-${{ hashFiles('**/build.gradle.kts') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-caches-
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Test and build
         run: ./gradlew ${{ matrix.project }}:test ${{ matrix.project }}:build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,25 +11,8 @@ jobs:
         with:
           java-version: 21
           distribution: temurin
-          cache: gradle
 
-      - name: Cache Gradle wrapper
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-wrapper-${{ hashFiles('gradle/wrapper/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-wrapper-
-
-      - name: Cache Gradle packages
-        uses: actions/cache@v4
-        with:
-          path: ~/.gradle/caches/build-cache-1/
-          key: ${{ runner.os }}-gradle-cache-${{ hashFiles('build.gradle') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-cache-
-
-      - uses: gradle/actions/setup-gradle@v3
+      - uses: gradle/actions/setup-gradle@v4
 
       - name: Test
         run: ./gradlew test --tests --parallel --build-cache '*Test' jacocoTestReport -Dorg.gradle.jvmargs=-Xmx32g


### PR DESCRIPTION
Bumper `setup-gradle` fra v3 til v4. Det medfører at caching via `actions/cache` og/eller `with.cache: gradle` fra `actions/setup-java` fjernes, som beskrevet [her](https://github.com/gradle/actions/blob/main/docs/setup-gradle.md#incompatibility-with-other-caching-mechanisms).

Bumper `dependency-submission` fra v3 til v4.