### PR TITLE
Publiser meldinger på Kafka sammen med nøkkel (i rivers)

### DIFF
--- a/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
+++ b/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
@@ -54,7 +54,7 @@ class HentArbeidsforholdRiver(
             )
         }
 
-    override fun HentArbeidsforholdMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentArbeidsforholdMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun HentArbeidsforholdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val arbeidsforhold =

--- a/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
+++ b/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
@@ -54,6 +54,8 @@ class HentArbeidsforholdRiver(
             )
         }
 
+    override fun HentArbeidsforholdMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun HentArbeidsforholdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val arbeidsforhold =
             Metrics.aaregRequest

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
@@ -55,7 +55,7 @@ class AltinnRiver(
             )
         }
 
-    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val rettigheterForenklet =

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
@@ -55,6 +55,8 @@ class AltinnRiver(
             )
         }
 
+    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val rettigheterForenklet =
             Metrics.altinnRequest.recordTime(altinnClient::hentRettighetOrganisasjoner) {

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -52,6 +53,8 @@ class TilgangRiver(
                 fnr = Key.FNR.les(Fnr.serializer(), data),
             )
         }
+
+    override fun TilgangMelding.skrivNoekkel(): KafkaKey = KafkaKey(fnr)
 
     override fun TilgangMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val harTilgang =

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
@@ -54,7 +54,7 @@ class TilgangRiver(
             )
         }
 
-    override fun TilgangMelding.skrivNoekkel(): KafkaKey = KafkaKey(fnr)
+    override fun TilgangMelding.bestemNoekkel(): KafkaKey = KafkaKey(fnr)
 
     override fun TilgangMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val harTilgang =

--- a/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
+++ b/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
@@ -48,7 +48,7 @@ class HentEksternImRiver(
             )
         }
 
-    override fun HentEksternImMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun HentEksternImMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun HentEksternImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Henter ekstern inntektsmelding med ID '$spinnImId' fra Spinn.")

--- a/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
+++ b/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -46,6 +47,8 @@ class HentEksternImRiver(
                 spinnImId = Key.SPINN_INNTEKTSMELDING_ID.les(UuidSerializer, data),
             )
         }
+
+    override fun HentEksternImMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun HentEksternImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Henter ekstern inntektsmelding med ID '$spinnImId' fra Spinn.")

--- a/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
+++ b/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
@@ -56,7 +56,7 @@ class HentVirksomhetNavnRiver(
             )
         }
 
-    override fun HentVirksomhetMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentVirksomhetMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun HentVirksomhetMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val orgnrMedNavn =

--- a/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
+++ b/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
@@ -56,6 +56,8 @@ class HentVirksomhetNavnRiver(
             )
         }
 
+    override fun HentVirksomhetMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun HentVirksomhetMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val orgnrMedNavn =
             if (isPreProd) {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
@@ -59,6 +59,8 @@ class HentLagretImRiver(
             )
         }
 
+    override fun HentLagretImMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun HentLagretImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val (
             skjema,

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
@@ -59,7 +59,7 @@ class HentLagretImRiver(
             )
         }
 
-    override fun HentLagretImMelding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentLagretImMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun HentLagretImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val (

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
@@ -49,7 +49,7 @@ class HentSelvbestemtImRiver(
             )
         }
 
-    override fun HentSelvbestemtImMelding.skrivNoekkel(): KafkaKey = KafkaKey(selvbestemtId)
+    override fun HentSelvbestemtImMelding.bestemNoekkel(): KafkaKey = KafkaKey(selvbestemtId)
 
     override fun HentSelvbestemtImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Skal hente selvbestemt inntektsmelding.".also {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -47,6 +48,8 @@ class HentSelvbestemtImRiver(
                 selvbestemtId = Key.SELVBESTEMT_ID.les(UuidSerializer, data),
             )
         }
+
+    override fun HentSelvbestemtImMelding.skrivNoekkel(): KafkaKey = KafkaKey(selvbestemtId)
 
     override fun HentSelvbestemtImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Skal hente selvbestemt inntektsmelding.".also {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -44,6 +45,8 @@ class LagreEksternImRiver(
                 eksternInntektsmelding = Key.EKSTERN_INNTEKTSMELDING.les(EksternInntektsmelding.serializer(), data),
             )
         }
+
+    override fun LagreEksternImMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun LagreEksternImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         imRepo.lagreEksternInntektsmelding(forespoerselId, eksternInntektsmelding)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
@@ -46,7 +46,7 @@ class LagreEksternImRiver(
             )
         }
 
-    override fun LagreEksternImMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun LagreEksternImMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun LagreEksternImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         imRepo.lagreEksternInntektsmelding(forespoerselId, eksternInntektsmelding)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -51,6 +52,8 @@ class LagreImRiver(
                 innsendingId = Key.INNSENDING_ID.les(Long.serializer(), data),
             )
         }
+
+    override fun LagreImMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val inntektsmeldingGammeltFormat = inntektsmelding.convert()

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -53,7 +53,7 @@ class LagreImRiver(
             )
         }
 
-    override fun LagreImMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
+    override fun LagreImMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val inntektsmeldingGammeltFormat = inntektsmelding.convert()

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -59,7 +59,7 @@ class LagreImSkjemaRiver(
             )
         }
 
-    override fun LagreImSkjemaMelding.skrivNoekkel(): KafkaKey = KafkaKey(skjema.forespoerselId)
+    override fun LagreImSkjemaMelding.bestemNoekkel(): KafkaKey = KafkaKey(skjema.forespoerselId)
 
     override fun LagreImSkjemaMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val sisteImSkjema = repository.hentNyesteInntektsmeldingSkjema(skjema.forespoerselId)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -57,6 +58,8 @@ class LagreImSkjemaRiver(
                 mottatt = Key.MOTTATT.les(LocalDateTimeSerializer, data),
             )
         }
+
+    override fun LagreImSkjemaMelding.skrivNoekkel(): KafkaKey = KafkaKey(skjema.forespoerselId)
 
     override fun LagreImSkjemaMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val sisteImSkjema = repository.hentNyesteInntektsmeldingSkjema(skjema.forespoerselId)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -48,6 +49,8 @@ class LagreJournalpostIdRiver(
                 innsendingId = Key.INNSENDING_ID.lesOrNull(Long.serializer(), json),
             )
         }
+
+    override fun LagreJournalpostIdMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreJournalpostIdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok melding.")

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -50,7 +50,7 @@ class LagreJournalpostIdRiver(
             )
         }
 
-    override fun LagreJournalpostIdMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
+    override fun LagreJournalpostIdMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreJournalpostIdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok melding.")

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
@@ -51,7 +51,7 @@ class LagreSelvbestemtImRiver(
             )
         }
 
-    override fun LagreSelvbestemtImMelding.skrivNoekkel(): KafkaKey = KafkaKey(selvbestemtInntektsmelding.type.id)
+    override fun LagreSelvbestemtImMelding.bestemNoekkel(): KafkaKey = KafkaKey(selvbestemtInntektsmelding.type.id)
 
     override fun LagreSelvbestemtImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Skal lagre selvbestemt inntektsmelding.".also {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -49,6 +50,8 @@ class LagreSelvbestemtImRiver(
                 selvbestemtInntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
             )
         }
+
+    override fun LagreSelvbestemtImMelding.skrivNoekkel(): KafkaKey = KafkaKey(selvbestemtInntektsmelding.type.id)
 
     override fun LagreSelvbestemtImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Skal lagre selvbestemt inntektsmelding.".also {

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -48,6 +49,8 @@ class DistribusjonRiver(
                 journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
             )
         }
+
+    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Forsøker å distribuere IM med journalpost-ID '$journalpostId'.".also {

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -50,7 +50,7 @@ class DistribusjonRiver(
             )
         }
 
-    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
+    override fun Melding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Forsøker å distribuere IM med journalpost-ID '$journalpostId'.".also {

--- a/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -12,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -53,6 +54,9 @@ class FeilLytter(
         Melding(
             fail = Key.FAIL.les(Fail.serializer(), json),
         )
+
+    // Riveren publiserer ikke via ObjectRiver, så denne nøkkelen blir ikke brukt
+    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok feil.")

--- a/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -56,7 +56,7 @@ class FeilLytter(
         )
 
     // Riveren publiserer ikke via ObjectRiver, så denne nøkkelen blir ikke brukt
-    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
+    override fun Melding.bestemNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok feil.")

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/ObjectRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/ObjectRiver.kt
@@ -40,7 +40,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
  *             height = Key.HEIGHT.lesOrNull(Int.serializer(), json)
  *         )
  *
- *     override fun LotrCharacter.skrivNoekkel(): KafkaKey = KafkaKey(name)
+ *     override fun LotrCharacter.bestemNoekkel(): KafkaKey = KafkaKey(name)
  *
  *     override fun LotrCharacter.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
  *         val favouriteFood = when (name) {
@@ -103,7 +103,7 @@ abstract class ObjectRiver<Melding : Any> {
      * Nøkkel som utgående melding sendes sammen med.
      * Meldinger sendt med samme nøkkel vil opprettholde rekkefølgen mellom dem (og konsumeres av samme pod).
      */
-    protected abstract fun Melding.skrivNoekkel(): KafkaKey?
+    protected abstract fun Melding.bestemNoekkel(): KafkaKey?
 
     /**
      * Riverens hovedfunksjon. Agerer på innkommende melding.
@@ -162,7 +162,7 @@ abstract class ObjectRiver<Melding : Any> {
             } else {
                 val key =
                     runCatching {
-                        innkommende.skrivNoekkel()
+                        innkommende.bestemNoekkel()
                     }.getOrElse { e ->
                         "Klarte ikke lage Kafka-nøkkel.".also {
                             logger.error(it)

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/OpenRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/OpenRiver.kt
@@ -6,6 +6,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.MessageContext
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.utils.json.parseJson
 
@@ -17,7 +18,7 @@ import no.nav.helsearbeidsgiver.utils.json.parseJson
  */
 internal class OpenRiver(
     rapid: RapidsConnection,
-    private val haandterMelding: JsonElement.() -> Map<Key, JsonElement>?,
+    private val haandterMelding: JsonElement.() -> Pair<KafkaKey?, Map<Key, JsonElement>>?,
 ) : River.PacketListener {
     init {
         River(rapid).register(this)
@@ -31,6 +32,9 @@ internal class OpenRiver(
             .toJson()
             .parseJson()
             .haandterMelding()
-            ?.also { context.publish(null, it) }
+            ?.also { (kafkaKey, melding) ->
+                // TODO gjør key non-nullable
+                context.publish(kafkaKey?.key, melding)
+            }
     }
 }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/PriObjectRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/PriObjectRiver.kt
@@ -27,7 +27,7 @@ abstract class PriObjectRiver<Melding : Any> {
 
     protected abstract fun les(json: Map<Pri.Key, JsonElement>): Melding?
 
-    protected abstract fun Melding.skrivNoekkel(): KafkaKey?
+    protected abstract fun Melding.bestemNoekkel(): KafkaKey?
 
     protected abstract fun Melding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement>?
 
@@ -62,7 +62,7 @@ abstract class PriObjectRiver<Melding : Any> {
             } else {
                 val key =
                     runCatching {
-                        innkommende.skrivNoekkel()
+                        innkommende.bestemNoekkel()
                     }.getOrElse { e ->
                         "Klarte ikke lage Kafka-nøkkel.".also {
                             logger.error(it)

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -16,6 +17,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import java.util.UUID
 
 class ServiceRiverStateless(
     override val service: Service,
@@ -124,6 +126,9 @@ sealed class ServiceRiver : ObjectRiver<ServiceMelding>() {
                 }
             }
         }
+
+    // Servicer publiserer ikke via ObjectRiver, så denne nøkkelen blir ikke brukt
+    final override fun ServiceMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     final override fun ServiceMelding.haandterFeil(
         json: Map<Key, JsonElement>,

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiver.kt
@@ -128,7 +128,7 @@ sealed class ServiceRiver : ObjectRiver<ServiceMelding>() {
         }
 
     // Servicer publiserer ikke via ObjectRiver, så denne nøkkelen blir ikke brukt
-    final override fun ServiceMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
+    final override fun ServiceMelding.bestemNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     final override fun ServiceMelding.haandterFeil(
         json: Map<Key, JsonElement>,

--- a/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
@@ -40,7 +40,7 @@ class ForespoerselBesvartRiver : PriObjectRiver<BesvartMelding>() {
             spinnInntektsmeldingId = Pri.Key.SPINN_INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, json),
         )
 
-    override fun BesvartMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun BesvartMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun BesvartMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_BESVART}.")

--- a/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.toPretty
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
@@ -38,6 +39,8 @@ class ForespoerselBesvartRiver : PriObjectRiver<BesvartMelding>() {
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             spinnInntektsmeldingId = Pri.Key.SPINN_INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, json),
         )
+
+    override fun BesvartMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun BesvartMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_BESVART}.")

--- a/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
+++ b/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
@@ -35,7 +35,7 @@ class ForespoerselForkastetRiver : PriObjectRiver<ForkastetMelding>() {
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
 
-    override fun ForkastetMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun ForkastetMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun ForkastetMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_FORKASTET}.")

--- a/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
+++ b/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
@@ -6,6 +6,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.toPretty
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
@@ -33,6 +34,8 @@ class ForespoerselForkastetRiver : PriObjectRiver<ForkastetMelding>() {
             transaksjonId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
+
+    override fun ForkastetMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun ForkastetMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_FORKASTET}.")

--- a/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
+++ b/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
@@ -6,6 +6,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.toPretty
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
@@ -33,6 +34,8 @@ class ForespoerselKastetTilInfotrygdRiver : PriObjectRiver<KastetTilInfotrygdMel
             transaksjonId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
+
+    override fun KastetTilInfotrygdMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun KastetTilInfotrygdMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_KASTET_TIL_INFOTRYGD}.")

--- a/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
+++ b/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
@@ -35,7 +35,7 @@ class ForespoerselKastetTilInfotrygdRiver : PriObjectRiver<KastetTilInfotrygdMel
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
 
-    override fun KastetTilInfotrygdMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun KastetTilInfotrygdMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun KastetTilInfotrygdMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_KASTET_TIL_INFOTRYGD}.")

--- a/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -7,6 +7,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
@@ -42,6 +43,8 @@ class MarkerForespoerselBesvartRiver(
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
             )
         }
+
+    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok melding om ${EventName.INNTEKTSMELDING_MOTTATT}.")

--- a/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -44,7 +44,7 @@ class MarkerForespoerselBesvartRiver(
             )
         }
 
-    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun Melding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         logger.info("Mottok melding om ${EventName.INNTEKTSMELDING_MOTTATT}.")

--- a/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -43,7 +43,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
             skalHaPaaminnelse = Pri.Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), json),
         )
 
-    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun Melding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun Melding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPØRSEL_MOTTATT}.")

--- a/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.domene.ForespoerselFraBro
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -41,6 +42,8 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
             forespoerselFraBro = Pri.Key.FORESPOERSEL.les(ForespoerselFraBro.serializer(), json),
             skalHaPaaminnelse = Pri.Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), json),
         )
+
+    override fun Melding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun Melding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding på pri-topic om ${Pri.NotisType.FORESPØRSEL_MOTTATT}.")

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
@@ -46,7 +46,7 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
         )
     }
 
-    override fun ForespoerselSvarMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselSvar.forespoerselId)
+    override fun ForespoerselSvarMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselSvar.forespoerselId)
 
     override fun ForespoerselSvarMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok løsning på pri-topic om $behovType.")

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
@@ -44,6 +45,8 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
             forespoerselSvar = forespoerselSvar,
         )
     }
+
+    override fun ForespoerselSvarMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselSvar.forespoerselId)
 
     override fun ForespoerselSvarMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok løsning på pri-topic om $behovType.")

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
@@ -49,6 +50,9 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
                 vedtaksperiodeIdListe = Key.VEDTAKSPERIODE_ID_LISTE.les(UuidSerializer.list(), data),
             )
         }
+
+    // Vi har ingen gode alternativer til Kafka-nøkkel, men det er heller ikke nøye her, så det holder med en tilfeldig verdi
+    override fun HentForespoerslerForVedtaksperiodeIdListeMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun HentForespoerslerForVedtaksperiodeIdListeMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         priProducer

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
@@ -52,7 +52,7 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
         }
 
     // Vi har ingen gode alternativer til Kafka-nøkkel, men det er heller ikke nøye her, så det holder med en tilfeldig verdi
-    override fun HentForespoerslerForVedtaksperiodeIdListeMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
+    override fun HentForespoerslerForVedtaksperiodeIdListeMelding.bestemNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun HentForespoerslerForVedtaksperiodeIdListeMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         priProducer

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.PriProducer
@@ -48,6 +49,8 @@ class TrengerForespoerselRiver(
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
             )
         }
+
+    override fun TrengerForespoerselMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun TrengerForespoerselMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         priProducer

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
@@ -50,7 +50,7 @@ class TrengerForespoerselRiver(
             )
         }
 
-    override fun TrengerForespoerselMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun TrengerForespoerselMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun TrengerForespoerselMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         priProducer

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
@@ -48,7 +48,7 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
     }
 
     // Vi har ingen gode alternativer til Kafka-nøkkel, men det er heller ikke nøye her, så det holder med en tilfeldig verdi
-    override fun VedtaksperiodeIdForespoerselSvarMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
+    override fun VedtaksperiodeIdForespoerselSvarMelding.bestemNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun VedtaksperiodeIdForespoerselSvarMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok løsning på pri-topic om $behovType.")

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.pritopic.Pri
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.PriObjectRiver
@@ -45,6 +46,9 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
             forespoerselSvar = forespoerselSvar,
         )
     }
+
+    // Vi har ingen gode alternativer til Kafka-nøkkel, men det er heller ikke nøye her, så det holder med en tilfeldig verdi
+    override fun VedtaksperiodeIdForespoerselSvarMelding.skrivNoekkel(): KafkaKey = KafkaKey(UUID.randomUUID())
 
     override fun VedtaksperiodeIdForespoerselSvarMelding.haandter(json: Map<Pri.Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok løsning på pri-topic om $behovType.")

--- a/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
+++ b/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
@@ -64,7 +64,7 @@ class HentInntektRiver(
             )
         }
 
-    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val fom = inntektsdato.minusMaaneder(3)

--- a/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
+++ b/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
@@ -64,6 +64,8 @@ class HentInntektRiver(
             )
         }
 
+    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val fom = inntektsdato.minusMaaneder(3)
         val middle = inntektsdato.minusMaaneder(2)

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -12,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.json.toPretty
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -60,6 +61,8 @@ class JournalfoerImRiver(
                 )
             }
         }
+
+    override fun JournalfoerImMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun JournalfoerImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Mottok melding med event '$eventName'.".also {

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -62,7 +62,7 @@ class JournalfoerImRiver(
             }
         }
 
-    override fun JournalfoerImMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
+    override fun JournalfoerImMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun JournalfoerImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Mottok melding med event '$eventName'.".also {

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
@@ -14,6 +14,7 @@ import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -53,6 +54,8 @@ class EndrePaaminnelseRiver(
                 orgNavn = Key.VIRKSOMHET.les(String.serializer(), data),
             )
         }
+
+    override fun EndrePaaminnelseMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun EndrePaaminnelseMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         endreOppgavePaaminnelser(

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
@@ -55,7 +55,7 @@ class EndrePaaminnelseRiver(
             )
         }
 
-    override fun EndrePaaminnelseMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun EndrePaaminnelseMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun EndrePaaminnelseMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         endreOppgavePaaminnelser(

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -51,6 +52,8 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
                 )
             }
         }
+
+    override fun FerdigstillForespoerselSakMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun FerdigstillForespoerselSakMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val lenke = NotifikasjonTekst.lenkeFerdigstiltForespoersel(linkUrl, forespoerselId)

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
@@ -53,7 +53,7 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
             }
         }
 
-    override fun FerdigstillForespoerselSakMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun FerdigstillForespoerselSakMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun FerdigstillForespoerselSakMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val lenke = NotifikasjonTekst.lenkeFerdigstiltForespoersel(linkUrl, forespoerselId)

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -42,6 +43,8 @@ class FjernPaaminnelseRiver(
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             )
         }
+
+    override fun FjernPaaminnelseMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun FjernPaaminnelseMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         if (paaminnelseToggle.oppgavePaaminnelseAktivert) {

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
@@ -44,7 +44,7 @@ class FjernPaaminnelseRiver(
             )
         }
 
-    override fun FjernPaaminnelseMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun FjernPaaminnelseMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun FjernPaaminnelseMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement>? {
         if (paaminnelseToggle.oppgavePaaminnelseAktivert) {

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -58,6 +59,8 @@ class OpprettForespoerselSakOgOppgaveRiver(
                 skalHaPaaminnelse = Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), data),
             )
         }
+
+    override fun OpprettForespoerselSakOgOppgaveMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun OpprettForespoerselSakOgOppgaveMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val lenke = NotifikasjonTekst.lenkeAktivForespoersel(lenkeBaseUrl, forespoerselId)

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
@@ -60,7 +60,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
             )
         }
 
-    override fun OpprettForespoerselSakOgOppgaveMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun OpprettForespoerselSakOgOppgaveMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun OpprettForespoerselSakOgOppgaveMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val lenke = NotifikasjonTekst.lenkeAktivForespoersel(lenkeBaseUrl, forespoerselId)

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
@@ -54,7 +54,7 @@ class OpprettSelvbestemtSakRiver(
             )
         }
 
-    override fun OpprettSelvbestemtSakMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
+    override fun OpprettSelvbestemtSakMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun OpprettSelvbestemtSakMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val sakId =

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
@@ -12,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -52,6 +53,8 @@ class OpprettSelvbestemtSakRiver(
                 inntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
             )
         }
+
+    override fun OpprettSelvbestemtSakMelding.skrivNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun OpprettSelvbestemtSakMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val sakId =

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
@@ -74,7 +74,7 @@ class UtgaattForespoerselRiver(
             }
         }
 
-    override fun UtgaattForespoerselMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
+    override fun UtgaattForespoerselMelding.bestemNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun UtgaattForespoerselMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding med event '$eventName'.")

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.json.toPretty
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
@@ -72,6 +73,8 @@ class UtgaattForespoerselRiver(
                 }
             }
         }
+
+    override fun UtgaattForespoerselMelding.skrivNoekkel(): KafkaKey = KafkaKey(forespoerselId)
 
     override fun UtgaattForespoerselMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         logger.info("Mottok melding med event '$eventName'.")

--- a/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
+++ b/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
@@ -56,6 +56,8 @@ class HentPersonerRiver(
             )
         }
 
+    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Henter navn for ${fnrListe.size} personer.".also {
             logger.info(it)

--- a/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
+++ b/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
@@ -56,7 +56,7 @@ class HentPersonerRiver(
             )
         }
 
-    override fun Melding.skrivNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Henter navn for ${fnrListe.size} personer.".also {


### PR DESCRIPTION
De fleste har naturlige nøkler tilgjengelige, mens noen rivers er brukt av stateful servicer, som trenger mer kontroll på hvilke nøkler som brukes. Disse får allerede tilsendt nøkkel i dag, i feltet `Key.SVAR_KAFKA_KEY`. 