### PR TITLE
Send svarnøkkel til rivers som bruker det

### DIFF
--- a/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -160,6 +160,7 @@ class AktiveOrgnrService(
                     Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
                     Key.DATA to
                         mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(steg0.sykmeldtFnr).toJson(),
                             Key.ORGNR_UNDERENHETER to arbeidsgivere.toJson(String.serializer()),
                         ).toJson(),
                 )

--- a/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -15,6 +15,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed4Steg
@@ -127,8 +128,12 @@ class BerikInntektsmeldingService(
                 Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
                 Key.DATA to
                     data
-                        .plus(Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(Orgnr.serializer()))
-                        .toJson(),
+                        .plus(
+                            mapOf(
+                                Key.SVAR_KAFKA_KEY to KafkaKey(steg0.skjema.forespoerselId).toJson(),
+                                Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(Orgnr.serializer()),
+                            ),
+                        ).toJson(),
             ).also { loggBehovPublisert(BehovType.HENT_VIRKSOMHET_NAVN, it) }
     }
 
@@ -147,11 +152,14 @@ class BerikInntektsmeldingService(
                 Key.DATA to
                     data
                         .plus(
-                            Key.FNR_LISTE to
-                                listOf(
-                                    steg1.forespoersel.fnr,
-                                    steg0.avsenderFnr,
-                                ).toJson(Fnr.serializer()),
+                            mapOf(
+                                Key.SVAR_KAFKA_KEY to KafkaKey(steg0.skjema.forespoerselId).toJson(),
+                                Key.FNR_LISTE to
+                                    listOf(
+                                        steg1.forespoersel.fnr,
+                                        steg0.avsenderFnr,
+                                    ).toJson(Fnr.serializer()),
+                            ),
                         ).toJson(),
             ).also { loggBehovPublisert(BehovType.HENT_PERSONER, it) }
     }

--- a/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
+++ b/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
@@ -74,6 +75,7 @@ class InntektSelvbestemtService(
                     data
                         .plus(
                             mapOf(
+                                Key.SVAR_KAFKA_KEY to KafkaKey(steg0.sykmeldtFnr).toJson(),
                                 Key.ORGNR_UNDERENHET to steg0.orgnr.toJson(),
                                 Key.FNR to steg0.sykmeldtFnr.toJson(),
                                 Key.INNTEKTSDATO to steg0.inntektsdato.toJson(),

--- a/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -11,6 +11,7 @@ import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
@@ -105,6 +106,7 @@ class InntektService(
                     data
                         .plus(
                             mapOf(
+                                Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
                                 Key.ORGNR_UNDERENHET to steg1.forespoersel.orgnr.toJson(),
                                 Key.FNR to steg1.forespoersel.fnr.toJson(),
                                 Key.INNTEKTSDATO to steg0.skjaeringstidspunkt.toJson(),

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
@@ -9,6 +9,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.april
@@ -49,6 +50,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
                     Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
                     Key.DATA to
                         mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(Mock.fnr).toJson(),
                             Key.ORGNR_UNDERENHET to Mock.orgnr.toJson(),
                             Key.FNR to Mock.fnr.toJson(),
                             Key.INNTEKTSDATO to Mock.inntektsdato.toJson(),
@@ -65,6 +67,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
                     Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
                     Key.DATA to
                         mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(Mock.fnr).toJson(),
                             Key.ORGNR_UNDERENHET to Mock.orgnr.toJson(),
                             Key.FNR to Mock.fnr.toJson(),
                             Key.INNTEKTSDATO to Mock.inntektsdato.toJson(),

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
@@ -10,6 +10,7 @@ import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
 import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed2Steg
@@ -80,7 +81,10 @@ class HentDataTilPaaminnelseService(
             Key.DATA to
                 data
                     .plus(
-                        Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(Orgnr.serializer()),
+                        mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
+                            Key.ORGNR_UNDERENHETER to setOf(steg1.forespoersel.orgnr).toJson(Orgnr.serializer()),
+                        ),
                     ).toJson(),
         )
     }

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
@@ -12,6 +12,7 @@ import no.nav.helsearbeidsgiver.felles.json.les
 import no.nav.helsearbeidsgiver.felles.json.orgMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.publish
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceMed2Steg
@@ -82,7 +83,10 @@ class HentDataTilSakOgOppgaveService(
             Key.DATA to
                 data
                     .plus(
-                        Key.ORGNR_UNDERENHETER to setOf(steg0.forespoersel.orgnr).toJson(Orgnr.serializer()),
+                        mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
+                            Key.ORGNR_UNDERENHETER to setOf(steg0.forespoersel.orgnr).toJson(Orgnr.serializer()),
+                        ),
                     ).toJson(),
         )
     }
@@ -100,7 +104,10 @@ class HentDataTilSakOgOppgaveService(
             Key.DATA to
                 data
                     .plus(
-                        Key.FNR_LISTE to setOf(steg0.forespoersel.fnr).toJson(Fnr.serializer()),
+                        mapOf(
+                            Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
+                            Key.FNR_LISTE to setOf(steg0.forespoersel.fnr).toJson(Fnr.serializer()),
+                        ),
                     ).toJson(),
         )
     }


### PR DESCRIPTION
En håndfull rivers trenger av og til at man sender dem en verdi som kan brukes som nøkkel på meldingen riveren publiserer som svar. De som må sende denne svarnøkkelen gjør det allerede. Denne PR-en gjør at alle andre som kaller de bestemte riverne også sendre denne svarnøkkelen. Da slipper man å ha en backupløsning i riverne som forventer å få tilsendt svarnøkkel, og man slipper å vurdere om man må sende svarnøkkel eller ikke.