### PR TITLE
Krev tilsendt svarnøkkel i utvalgte rivers

### DIFF
--- a/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
+++ b/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
@@ -8,7 +8,6 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Arbeidsforhold
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
@@ -28,7 +27,7 @@ data class HentArbeidsforholdMelding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val fnr: Fnr,
 )
 
@@ -49,12 +48,12 @@ class HentArbeidsforholdRiver(
                 behovType = Key.BEHOV.krev(BehovType.HENT_ARBEIDSFORHOLD, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnr = Key.FNR.les(Fnr.serializer(), data),
             )
         }
 
-    override fun HentArbeidsforholdMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentArbeidsforholdMelding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun HentArbeidsforholdMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val arbeidsforhold =

--- a/apps/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
+++ b/apps/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Arbeidsforhold
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockFail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
@@ -122,6 +123,7 @@ class HentArbeidsforholdRiverTest :
 private object Mock {
     fun innkommendeMelding(): HentArbeidsforholdMelding {
         val fnr = Fnr.genererGyldig()
+        val svarKafkaKey = KafkaKey(fnr)
 
         return HentArbeidsforholdMelding(
             eventName = EventName.AKTIVE_ORGNR_REQUESTED,
@@ -129,9 +131,10 @@ private object Mock {
             transaksjonId = UUID.randomUUID(),
             data =
                 mapOf(
+                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
                     Key.FNR to fnr.toJson(Fnr.serializer()),
                 ),
-            svarKafkaKey = null,
+            svarKafkaKey = svarKafkaKey,
             fnr = fnr,
         )
     }

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
@@ -8,7 +8,6 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
@@ -29,7 +28,7 @@ data class Melding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val fnr: Fnr,
 )
 
@@ -50,12 +49,12 @@ class AltinnRiver(
                 behovType = Key.BEHOV.krev(BehovType.ARBEIDSGIVERE, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), data),
             )
         }
 
-    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val rettigheterForenklet =

--- a/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/Mock.kt
+++ b/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/Mock.kt
@@ -6,6 +6,7 @@ import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.test.mock.mockFail
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -15,6 +16,7 @@ import java.util.UUID
 object Mock {
     fun innkommendeMelding(): Melding {
         val fnr = Fnr.genererGyldig()
+        val svarKafkaKey = KafkaKey(fnr)
 
         return Melding(
             eventName = EventName.AKTIVE_ORGNR_REQUESTED,
@@ -22,9 +24,10 @@ object Mock {
             transaksjonId = UUID.randomUUID(),
             data =
                 mapOf(
+                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
                     Key.ARBEIDSGIVER_FNR to fnr.toJson(),
                 ),
-            svarKafkaKey = null,
+            svarKafkaKey = svarKafkaKey,
             fnr = fnr,
         )
     }
@@ -34,10 +37,7 @@ object Mock {
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
             Key.KONTEKST_ID to transaksjonId.toJson(),
-            Key.DATA to
-                mapOf(
-                    Key.ARBEIDSGIVER_FNR to fnr.toJson(),
-                ).toJson(),
+            Key.DATA to data.toJson(),
         )
 
     val fail = mockFail("One does not simply walk into Mordor.", EventName.AKTIVE_ORGNR_REQUESTED)

--- a/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
+++ b/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
@@ -8,7 +8,6 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
@@ -29,7 +28,7 @@ data class HentVirksomhetMelding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val orgnr: Set<Orgnr>,
 )
 
@@ -51,12 +50,12 @@ class HentVirksomhetNavnRiver(
                 behovType = Key.BEHOV.krev(BehovType.HENT_VIRKSOMHET_NAVN, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 orgnr = Key.ORGNR_UNDERENHETER.les(Orgnr.serializer().set(), data),
             )
         }
 
-    override fun HentVirksomhetMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentVirksomhetMelding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun HentVirksomhetMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val orgnrMedNavn =

--- a/apps/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
+++ b/apps/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockFail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
@@ -181,18 +182,22 @@ class HentVirksomhetNavnRiverTest :
     })
 
 private object Mock {
-    fun innkommendeMelding(orgnr: Set<Orgnr>): HentVirksomhetMelding =
-        HentVirksomhetMelding(
+    fun innkommendeMelding(orgnr: Set<Orgnr>): HentVirksomhetMelding {
+        val svarKafkaKey = KafkaKey(UUID.randomUUID())
+
+        return HentVirksomhetMelding(
             eventName = EventName.TRENGER_REQUESTED,
             behovType = BehovType.HENT_VIRKSOMHET_NAVN,
             transaksjonId = UUID.randomUUID(),
             data =
                 mapOf(
+                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
                     Key.ORGNR_UNDERENHETER to orgnr.toJson(Orgnr.serializer()),
                 ),
-            svarKafkaKey = null,
+            svarKafkaKey = svarKafkaKey,
             orgnr = orgnr,
         )
+    }
 
     fun HentVirksomhetMelding.toMap(): Map<Key, JsonElement> =
         mapOf(

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
@@ -13,7 +13,6 @@ import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
@@ -33,7 +32,7 @@ data class HentLagretImMelding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val forespoerselId: UUID,
 )
 
@@ -54,12 +53,12 @@ class HentLagretImRiver(
                 behovType = Key.BEHOV.krev(BehovType.HENT_LAGRET_IM, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
             )
         }
 
-    override fun HentLagretImMelding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun HentLagretImMelding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun HentLagretImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val (

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
@@ -21,6 +21,7 @@ import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.test.mock.mockFail
@@ -197,6 +198,7 @@ class HentLagretImRiverTest :
 private object MockHentIm {
     fun innkommendeMelding(): HentLagretImMelding {
         val forespoerselId = UUID.randomUUID()
+        val svarKafkaKey = KafkaKey(forespoerselId)
 
         return HentLagretImMelding(
             eventName = EventName.KVITTERING_REQUESTED,
@@ -204,9 +206,10 @@ private object MockHentIm {
             transaksjonId = UUID.randomUUID(),
             data =
                 mapOf(
+                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),
                 ),
-            svarKafkaKey = null,
+            svarKafkaKey = svarKafkaKey,
             forespoerselId = forespoerselId,
         )
     }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtils.kt
@@ -24,7 +24,7 @@ fun MessageContext.publish(
 ): JsonElement = publish(key.toString(), messageFields.toMap())
 
 internal fun MessageContext.publish(
-    key: String?,
+    key: String,
     messageFields: Map<Key, JsonElement>,
 ): JsonElement =
     messageFields
@@ -41,9 +41,5 @@ internal fun MessageContext.publish(
             )
         }.toJson()
         .also {
-            if (key == null) {
-                publish(it)
-            } else {
-                publish(key, it)
-            }
+            publish(key, it)
         }.parseJson()

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/OpenRiver.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/river/OpenRiver.kt
@@ -18,7 +18,7 @@ import no.nav.helsearbeidsgiver.utils.json.parseJson
  */
 internal class OpenRiver(
     rapid: RapidsConnection,
-    private val haandterMelding: JsonElement.() -> Pair<KafkaKey?, Map<Key, JsonElement>>?,
+    private val haandterMelding: JsonElement.() -> Pair<KafkaKey, Map<Key, JsonElement>>?,
 ) : River.PacketListener {
     init {
         River(rapid).register(this)
@@ -33,8 +33,7 @@ internal class OpenRiver(
             .parseJson()
             .haandterMelding()
             ?.also { (kafkaKey, melding) ->
-                // TODO gjør key non-nullable
-                context.publish(kafkaKey?.key, melding)
+                context.publish(kafkaKey.key, melding)
             }
     }
 }

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/RiverUtilsKtTest.kt
@@ -72,25 +72,6 @@ class RiverUtilsKtTest :
                 }
             }
 
-            test("map (uten key)") {
-                val melding =
-                    mapOf(
-                        Key.FORESPOERSEL_ID to UUID.randomUUID().toJson(),
-                        Key.INNTEKTSMELDING to mockInntektsmeldingV1().toJson(Inntektsmelding.serializer()),
-                        Key.ORGNR_UNDERENHETER to setOf("666", "444", "222").toJson(String.serializer()),
-                    )
-
-                testRapid.publish(null, melding)
-
-                verifySequence {
-                    testRapid.publish(
-                        withArg<String> {
-                            it.parseJson().toMap() shouldContainExactly melding
-                        },
-                    )
-                }
-            }
-
             test("map") {
                 val key = UUID.randomUUID()
                 val melding =

--- a/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
+++ b/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
@@ -8,7 +8,6 @@ import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
@@ -34,7 +33,7 @@ data class Melding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val orgnr: Orgnr,
     val fnr: Fnr,
     val inntektsdato: LocalDate,
@@ -57,14 +56,14 @@ class HentInntektRiver(
                 behovType = Key.BEHOV.krev(BehovType.HENT_INNTEKT, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 orgnr = Key.ORGNR_UNDERENHET.les(Orgnr.serializer(), data),
                 fnr = Key.FNR.les(Fnr.serializer(), data),
                 inntektsdato = Key.INNTEKTSDATO.les(LocalDateSerializer, data),
             )
         }
 
-    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         val fom = inntektsdato.minusMaaneder(3)

--- a/apps/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
+++ b/apps/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
@@ -18,6 +18,7 @@ import no.nav.helsearbeidsgiver.felles.domene.Inntekt
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.KafkaKey
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.model.Fail
 import no.nav.helsearbeidsgiver.felles.test.mock.mockFail
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
@@ -166,6 +167,7 @@ private object Mock {
     fun innkommendeMelding(inntektsdato: LocalDate): Melding {
         val orgnr = Orgnr.genererGyldig()
         val fnr = Fnr.genererGyldig()
+        val svarKafkaKey = KafkaKey(fnr)
 
         return Melding(
             eventName = EventName.TRENGER_REQUESTED,
@@ -173,11 +175,12 @@ private object Mock {
             transaksjonId = UUID.randomUUID(),
             data =
                 mapOf(
+                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
                     Key.ORGNR_UNDERENHET to orgnr.toJson(),
                     Key.FNR to fnr.toJson(),
                     Key.INNTEKTSDATO to inntektsdato.toJson(),
                 ),
-            svarKafkaKey = null,
+            svarKafkaKey = svarKafkaKey,
             orgnr = orgnr,
             fnr = fnr,
             inntektsdato = inntektsdato,

--- a/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
+++ b/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
@@ -7,7 +7,6 @@ import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.json.krev
 import no.nav.helsearbeidsgiver.felles.json.les
-import no.nav.helsearbeidsgiver.felles.json.lesOrNull
 import no.nav.helsearbeidsgiver.felles.json.personMapSerializer
 import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
@@ -30,7 +29,7 @@ data class Melding(
     val behovType: BehovType,
     val transaksjonId: UUID,
     val data: Map<Key, JsonElement>,
-    val svarKafkaKey: KafkaKey?,
+    val svarKafkaKey: KafkaKey,
     val fnrListe: Set<Fnr>,
 )
 
@@ -51,12 +50,12 @@ class HentPersonerRiver(
                 behovType = Key.BEHOV.krev(BehovType.HENT_PERSONER, BehovType.serializer(), json),
                 transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
-                svarKafkaKey = Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), data),
+                svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnrListe = Key.FNR_LISTE.les(Fnr.serializer().set(), data),
             )
         }
 
-    override fun Melding.bestemNoekkel(): KafkaKey? = svarKafkaKey
+    override fun Melding.bestemNoekkel(): KafkaKey = svarKafkaKey
 
     override fun Melding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
         "Henter navn for ${fnrListe.size} personer.".also {


### PR DESCRIPTION
Utvalgte rivers får tilsendt hvilken nøkkel de skal bruke når de publiserer en svarmelding. Disse nøklene blir alltid sendt i dag. Denne endringen gjør at nøklene går fra å være valgfri til påkrevd i riverne som mottar dem.