### PR TITLE
Bytt alle variabelnavn fra transaksjon-ID til kontekst-ID

### DIFF
--- a/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
+++ b/apps/aareg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aareg/HentArbeidsforholdRiver.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 data class HentArbeidsforholdMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val fnr: Fnr,
@@ -46,7 +46,7 @@ class HentArbeidsforholdRiver(
             HentArbeidsforholdMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_ARBEIDSFORHOLD, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnr = Key.FNR.les(Fnr.serializer(), data),
@@ -59,7 +59,7 @@ class HentArbeidsforholdRiver(
         val arbeidsforhold =
             Metrics.aaregRequest
                 .recordTime(aaregClient::hentArbeidsforhold) {
-                    aaregClient.hentArbeidsforhold(fnr.verdi, transaksjonId.toString())
+                    aaregClient.hentArbeidsforhold(fnr.verdi, kontekstId.toString())
                 }.map { it.tilArbeidsforhold() }
 
         "Fant ${arbeidsforhold.size} arbeidsforhold.".also {
@@ -75,7 +75,7 @@ class HentArbeidsforholdRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -91,7 +91,7 @@ class HentArbeidsforholdRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente arbeidsforhold fra Aareg.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -106,6 +106,6 @@ class HentArbeidsforholdRiver(
             Log.klasse(this@HentArbeidsforholdRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
+++ b/apps/aareg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentArbeidsforholdRiverTest.kt
@@ -61,7 +61,7 @@ class HentArbeidsforholdRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(Key.ARBEIDSFORHOLD to expectedArbeidsforhold.toJson(Arbeidsforhold.serializer()))
@@ -69,7 +69,7 @@ class HentArbeidsforholdRiverTest :
                 )
 
             coVerifySequence {
-                mockAaregClient.hentArbeidsforhold(innkommendeMelding.fnr.verdi, innkommendeMelding.transaksjonId.toString())
+                mockAaregClient.hentArbeidsforhold(innkommendeMelding.fnr.verdi, innkommendeMelding.kontekstId.toString())
             }
         }
 
@@ -81,7 +81,7 @@ class HentArbeidsforholdRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente arbeidsforhold fra Aareg.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -92,7 +92,7 @@ class HentArbeidsforholdRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
 
             coVerifySequence {
-                mockAaregClient.hentArbeidsforhold(innkommendeMelding.fnr.verdi, innkommendeMelding.transaksjonId.toString())
+                mockAaregClient.hentArbeidsforhold(innkommendeMelding.fnr.verdi, innkommendeMelding.kontekstId.toString())
             }
         }
 
@@ -128,7 +128,7 @@ private object Mock {
         return HentArbeidsforholdMelding(
             eventName = EventName.AKTIVE_ORGNR_REQUESTED,
             behovType = BehovType.HENT_ARBEIDSFORHOLD,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -143,7 +143,7 @@ private object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiver.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 data class Melding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val fnr: Fnr,
@@ -47,7 +47,7 @@ class AltinnRiver(
             Melding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.ARBEIDSGIVERE, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), data),
@@ -67,7 +67,7 @@ class AltinnRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -83,7 +83,7 @@ class AltinnRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente organisasjonsrettigheter fra Altinn.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -98,6 +98,6 @@ class AltinnRiver(
             Log.klasse(this@AltinnRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiver.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 data class TilgangMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val orgnr: Orgnr,
     val fnr: Fnr,
@@ -47,7 +47,7 @@ class TilgangRiver(
             TilgangMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.TILGANGSKONTROLL, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 orgnr = Key.ORGNR_UNDERENHET.les(Orgnr.serializer(), data),
                 fnr = Key.FNR.les(Fnr.serializer(), data),
@@ -66,7 +66,7 @@ class TilgangRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -82,7 +82,7 @@ class TilgangRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke sjekke tilgang i Altinn.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -97,6 +97,6 @@ class TilgangRiver(
             Log.klasse(this@TilgangRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiverTest.kt
+++ b/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/AltinnRiverTest.kt
@@ -53,7 +53,7 @@ class AltinnRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(
@@ -74,7 +74,7 @@ class AltinnRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente organisasjonsrettigheter fra Altinn.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeJsonMap,
                 )
 

--- a/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/Mock.kt
+++ b/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/Mock.kt
@@ -21,7 +21,7 @@ object Mock {
         return Melding(
             eventName = EventName.AKTIVE_ORGNR_REQUESTED,
             behovType = BehovType.ARBEIDSGIVERE,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -36,7 +36,7 @@ object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiverTest.kt
+++ b/apps/altinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/TilgangRiverTest.kt
@@ -60,7 +60,7 @@ class TilgangRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.DATA to
                             innkommendeMelding.data
                                 .plus(Key.TILGANG to forventetTilgang.toJson(Tilgang.serializer()))
@@ -81,7 +81,7 @@ class TilgangRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke sjekke tilgang i Altinn.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -128,7 +128,7 @@ private object MockTilgang {
         return TilgangMelding(
             eventName = EventName.TILGANG_FORESPOERSEL_REQUESTED,
             behovType = BehovType.TILGANGSKONTROLL,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.ORGNR_UNDERENHET to orgnr.toJson(Orgnr.serializer()),
@@ -143,7 +143,7 @@ private object MockTilgang {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducer.kt
@@ -22,20 +22,20 @@ class AktiveOrgnrProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         arbeidsgiverFnr: Fnr,
         arbeidstagerFnr: Fnr,
     ) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.AKTIVE_ORGNR_REQUESTED),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         ) {
             rapid
                 .publish(
                     key = arbeidstagerFnr,
                     Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FNR to arbeidstagerFnr.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
@@ -33,15 +33,15 @@ fun Route.aktiveOrgnrRoute(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.AktiveOrgnr).let(::RedisPoller)
 
     post(Routes.AKTIVEORGNR) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         try {
             val request = call.receive<AktiveOrgnrRequest>()
             val arbeidsgiverFnr = call.request.lesFnrFraAuthToken()
 
-            aktiveOrgnrProducer.publish(transaksjonId, arbeidsgiverFnr = arbeidsgiverFnr, arbeidstagerFnr = request.identitetsnummer)
+            aktiveOrgnrProducer.publish(kontekstId, arbeidsgiverFnr = arbeidsgiverFnr, arbeidstagerFnr = request.identitetsnummer)
 
-            val resultatJson = redisPoller.hent(transaksjonId)
+            val resultatJson = redisPoller.hent(kontekstId)
 
             val resultat = resultatJson.success?.fromJson(AktiveArbeidsgivere.serializer())
             if (resultat != null) {

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/auth/TilgangProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/auth/TilgangProducer.kt
@@ -24,43 +24,43 @@ class TilgangProducer(
     }
 
     fun publishForespoerselId(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         fnr: Fnr,
         forespoerselId: UUID,
     ) = publish(
         EventName.TILGANG_FORESPOERSEL_REQUESTED,
-        transaksjonId,
+        kontekstId,
         fnr,
         Key.FORESPOERSEL_ID to forespoerselId.toJson(),
     )
 
     fun publishOrgnr(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         fnr: Fnr,
         orgnr: String,
     ) = publish(
         EventName.TILGANG_ORG_REQUESTED,
-        transaksjonId,
+        kontekstId,
         fnr,
         Key.ORGNR_UNDERENHET to orgnr.toJson(),
     )
 
     private fun publish(
         eventName: EventName,
-        transaksjonId: UUID,
+        kontekstId: UUID,
         fnr: Fnr,
         dataField: Pair<Key, JsonElement>,
     ) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         ) {
             rapid
                 .publish(
                     key = fnr,
                     Key.EVENT_NAME to eventName.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FNR to fnr.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/auth/Tilgangskontroll.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/auth/Tilgangskontroll.kt
@@ -25,8 +25,8 @@ class Tilgangskontroll(
         request: ApplicationRequest,
         forespoerselId: UUID,
     ) {
-        validerTilgang(redisPollerForespoersel, request, forespoerselId.toString()) { transaksjonId, fnr ->
-            tilgangProducer.publishForespoerselId(transaksjonId, fnr, forespoerselId)
+        validerTilgang(redisPollerForespoersel, request, forespoerselId.toString()) { kontekstId, fnr ->
+            tilgangProducer.publishForespoerselId(kontekstId, fnr, forespoerselId)
         }
     }
 
@@ -34,8 +34,8 @@ class Tilgangskontroll(
         request: ApplicationRequest,
         orgnr: String,
     ) {
-        validerTilgang(redisPollerOrg, request, orgnr) { transaksjonId, fnr ->
-            tilgangProducer.publishOrgnr(transaksjonId, fnr, orgnr)
+        validerTilgang(redisPollerOrg, request, orgnr) { kontekstId, fnr ->
+            tilgangProducer.publishOrgnr(kontekstId, fnr, orgnr)
         }
     }
 
@@ -45,7 +45,7 @@ class Tilgangskontroll(
         cacheKeyPostfix: String,
         publish: (UUID, Fnr) -> Unit,
     ) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
         val innloggerFnr = request.lesFnrFraAuthToken()
 
         val tilgang =
@@ -53,11 +53,11 @@ class Tilgangskontroll(
                 cache.get("$innloggerFnr:$cacheKeyPostfix") {
                     logger.info("Fant ikke tilgang i cache, ber om tilgangskontroll.")
 
-                    publish(transaksjonId, innloggerFnr)
+                    publish(kontekstId, innloggerFnr)
 
                     val tilgang =
                         redisPoller
-                            .hent(transaksjonId)
+                            .hent(kontekstId)
                             .success
                             ?.fromJson(Tilgang.serializer())
 

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducer.kt
@@ -20,7 +20,7 @@ class HentForespoerselProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         request: HentForespoerselRequest,
         arbeidsgiverFnr: Fnr,
     ) {
@@ -28,15 +28,15 @@ class HentForespoerselProducer(
             .publish(
                 key = request.uuid,
                 Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to request.uuid.toJson(),
                         Key.ARBEIDSGIVER_FNR to arbeidsgiverFnr.toJson(),
                     ).toJson(),
             ).also {
-                logger.info("Publiserte trenger behov med transaksjonId=$transaksjonId")
-                sikkerLogger.info("Publiserte trenger behov med transaksjonId=$transaksjonId json=${it.toPretty()}")
+                logger.info("Publiserte trenger behov med kontekstId=$kontekstId")
+                sikkerLogger.info("Publiserte trenger behov med kontekstId=$kontekstId json=${it.toPretty()}")
             }
     }
 }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -39,7 +39,7 @@ fun Route.hentForespoersel(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.HentForespoersel).let(::RedisPoller)
 
     post(Routes.HENT_FORESPOERSEL) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         Metrics.hentForespoerselEndpoint.recordTime(Route::hentForespoersel) {
             runCatching {
@@ -51,9 +51,9 @@ fun Route.hentForespoersel(
 
                     val arbeidsgiverFnr = call.request.lesFnrFraAuthToken()
 
-                    hentForespoerselProducer.publish(transaksjonId, request, arbeidsgiverFnr)
+                    hentForespoerselProducer.publish(kontekstId, request, arbeidsgiverFnr)
 
-                    val resultatJson = redisPoller.hent(transaksjonId)
+                    val resultatJson = redisPoller.hent(kontekstId)
 
                     sikkerLogger.info("Hentet forespørsel: $resultatJson")
 

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRoute.kt
@@ -86,11 +86,11 @@ suspend fun PipelineContext<Unit, ApplicationCall>.hentForespoersler(
 ) {
     loggInfoSikkerOgUsikker("Henter forespørsler for liste med vedtaksperiode-IDer: ${request.vedtaksperiodeIdListe}")
 
-    val transaksjonId = UUID.randomUUID()
+    val kontekstId = UUID.randomUUID()
 
-    hentForespoerslerProducer.publish(transaksjonId, request)
+    hentForespoerslerProducer.publish(kontekstId, request)
 
-    val resultatJson = redisPoller.hent(transaksjonId)
+    val resultatJson = redisPoller.hent(kontekstId)
 
     sikkerLogger.info("Hentet forespørslene: $resultatJson")
 

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerslerProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerslerProducer.kt
@@ -20,14 +20,14 @@ class HentForespoerslerProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         request: HentForespoerslerRequest,
     ) {
         rapid
             .publish(
                 key = UUID.randomUUID(),
                 Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.VEDTAKSPERIODE_ID_LISTE to request.vedtaksperiodeIdListe.toJson(UuidSerializer),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducer.kt
@@ -21,19 +21,19 @@ class HentSelvbestemtImProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         selvbestemtId: UUID,
     ) {
         MdcUtils.withLogFields(
             Log.event(EventName.SELVBESTEMT_IM_REQUESTED),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.selvbestemtId(selvbestemtId),
         ) {
             rapid
                 .publish(
                     key = selvbestemtId,
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_ID to selvbestemtId.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -39,7 +39,7 @@ fun Route.hentSelvbestemtImRoute(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.HentSelvbestemtIm).let(::RedisPoller)
 
     get(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         val selvbestemtId =
             call.parameters["selvbestemtId"]
@@ -56,12 +56,12 @@ fun Route.hentSelvbestemtImRoute(
             MdcUtils.withLogFields(
                 Log.apiRoute(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID),
                 Log.selvbestemtId(selvbestemtId),
-                Log.transaksjonId(transaksjonId),
+                Log.kontekstId(kontekstId),
             ) {
-                producer.publish(transaksjonId, selvbestemtId)
+                producer.publish(kontekstId, selvbestemtId)
 
                 runCatching {
-                    redisPoller.hent(transaksjonId)
+                    redisPoller.hent(kontekstId)
                 }.onSuccess { result ->
                     val inntektsmelding = result.success?.fromJson(Inntektsmelding.serializer())
 

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingProducer.kt
@@ -22,7 +22,7 @@ class InnsendingProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         arbeidsgiverFnr: Fnr,
         skjemaInntektsmelding: SkjemaInntektsmelding,
         mottatt: LocalDateTime,
@@ -31,7 +31,7 @@ class InnsendingProducer(
             .publish(
                 key = skjemaInntektsmelding.forespoerselId,
                 Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.ARBEIDSGIVER_FNR to arbeidsgiverFnr.toJson(),
@@ -39,7 +39,7 @@ class InnsendingProducer(
                         Key.MOTTATT to mottatt.toJson(),
                     ).toJson(),
             ).also {
-                logger.info("Publiserte til kafka forespørselId: ${skjemaInntektsmelding.forespoerselId} og transaksjonId=$transaksjonId")
+                logger.info("Publiserte til kafka forespørselId: ${skjemaInntektsmelding.forespoerselId} og kontekstId=$kontekstId")
                 sikkerLogger.info("Publiserte til kafka forespørselId: ${skjemaInntektsmelding.forespoerselId} json=${it.toPretty()}")
             }
     }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -43,7 +43,7 @@ fun Route.innsending(
 
     post(Routes.INNSENDING) {
         Metrics.innsendingEndpoint.recordTime(Route::innsending) {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val mottatt = LocalDateTime.now()
 
             val skjema = lesRequestOrNull()
@@ -70,9 +70,9 @@ fun Route.innsending(
 
                     val avsenderFnr = call.request.lesFnrFraAuthToken()
 
-                    producer.publish(transaksjonId, avsenderFnr, skjema, mottatt)
+                    producer.publish(kontekstId, avsenderFnr, skjema, mottatt)
 
-                    val resultat = runCatching { redisPoller.hent(transaksjonId) }
+                    val resultat = runCatching { redisPoller.hent(kontekstId) }
 
                     resultat
                         .onSuccess {

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducer.kt
@@ -21,20 +21,20 @@ class InntektProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         request: InntektRequest,
     ) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.INNTEKT_REQUESTED),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(request.forespoerselId),
         ) {
             rapid
                 .publish(
                     key = request.forespoerselId,
                     Key.EVENT_NAME to EventName.INNTEKT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to request.forespoerselId.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
@@ -38,7 +38,7 @@ fun Route.inntektRoute(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.Inntekt).let(::RedisPoller)
 
     post(Routes.INNTEKT) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         val request = call.receive<InntektRequest>()
 
@@ -50,9 +50,9 @@ fun Route.inntektRoute(
         }
 
         try {
-            inntektProducer.publish(transaksjonId, request)
+            inntektProducer.publish(kontekstId, request)
 
-            val resultatJson = redisPoller.hent(transaksjonId)
+            val resultatJson = redisPoller.hent(kontekstId)
             sikkerLogger.info("Fikk inntektresultat:\n$resultatJson")
 
             val resultat = resultatJson.success?.fromJson(Inntekt.serializer())

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducer.kt
@@ -21,19 +21,19 @@ class InntektSelvbestemtProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         request: InntektSelvbestemtRequest,
     ) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.INNTEKT_SELVBESTEMT_REQUESTED),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         ) {
             rapid
                 .publish(
                     key = request.sykmeldtFnr,
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FNR to request.sykmeldtFnr.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
@@ -37,7 +37,7 @@ fun Route.inntektSelvbestemtRoute(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.InntektSelvbestemt).let(::RedisPoller)
 
     post(Routes.INNTEKT_SELVBESTEMT) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         val request = call.receive<InntektSelvbestemtRequest>()
 
@@ -49,9 +49,9 @@ fun Route.inntektSelvbestemtRoute(
         }
 
         try {
-            inntektSelvbestemtProducer.publish(transaksjonId, request)
+            inntektSelvbestemtProducer.publish(kontekstId, request)
 
-            val resultatJson = redisPoller.hent(transaksjonId)
+            val resultatJson = redisPoller.hent(kontekstId)
             sikkerLogger.info("Fikk inntektsresultat for selvbestemt inntektsmelding:\n$resultatJson")
 
             val resultat = resultatJson.success?.fromJson(Inntekt.serializer())

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducer.kt
@@ -21,20 +21,20 @@ class KvitteringProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         forespoerselId: UUID,
     ) {
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(EventName.KVITTERING_REQUESTED),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         ) {
             rapid
                 .publish(
                     key = forespoerselId,
                     Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -57,7 +57,7 @@ fun Route.kvittering(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.Kvittering).let(::RedisPoller)
 
     get(Routes.KVITTERING) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         val forespoerselId =
             call.parameters["uuid"]
@@ -76,8 +76,8 @@ fun Route.kvittering(
                 try {
                     tilgangskontroll.validerTilgangTilForespoersel(call.request, forespoerselId)
 
-                    kvitteringProducer.publish(transaksjonId, forespoerselId)
-                    val resultatJson = redisPoller.hent(transaksjonId)
+                    kvitteringProducer.publish(kontekstId, forespoerselId)
+                    val resultatJson = redisPoller.hent(kontekstId)
 
                     val resultat = resultatJson.success?.fromJson(KvitteringResultat.serializer())
                     if (resultat != null) {

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducer.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducer.kt
@@ -24,20 +24,20 @@ class LagreSelvbestemtImProducer(
     }
 
     fun publish(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         avsenderFnr: Fnr,
         skjema: SkjemaInntektsmeldingSelvbestemt,
         mottatt: LocalDateTime,
     ) {
         MdcUtils.withLogFields(
             Log.event(EventName.SELVBESTEMT_IM_MOTTATT),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         ) {
             rapid
                 .publish(
                     key = skjema.sykmeldtFnr,
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.ARBEIDSGIVER_FNR to avsenderFnr.toJson(),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRoute.kt
@@ -48,12 +48,12 @@ fun Route.lagreSelvbestemtImRoute(
     val redisPoller = RedisStore(redisConnection, RedisPrefix.LagreSelvbestemtIm).let(::RedisPoller)
 
     post(Routes.SELVBESTEMT_INNTEKTSMELDING) {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
         val mottatt = LocalDateTime.now()
 
         MdcUtils.withLogFields(
             Log.apiRoute(Routes.SELVBESTEMT_INNTEKTSMELDING),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         ) {
             val skjema = lesRequestOrNull()
             when {
@@ -79,11 +79,11 @@ fun Route.lagreSelvbestemtImRoute(
 
                     val avsenderFnr = call.request.lesFnrFraAuthToken()
 
-                    producer.publish(transaksjonId, avsenderFnr, skjema, mottatt)
+                    producer.publish(kontekstId, avsenderFnr, skjema, mottatt)
 
                     val resultat =
                         runCatching {
-                            redisPoller.hent(transaksjonId)
+                            redisPoller.hent(kontekstId)
                         }
 
                     sendResponse(resultat)

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/InnsendingProducerTest.kt
@@ -24,18 +24,18 @@ class InnsendingProducerTest :
         val producer = InnsendingProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val avsenderFnr = Fnr.genererGyldig()
             val skjema = mockSkjemaInntektsmelding()
             val mottatt = 12.oktober.atStartOfDay()
 
-            producer.publish(transaksjonId, avsenderFnr, skjema, mottatt)
+            producer.publish(kontekstId, avsenderFnr, skjema, mottatt)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.ARBEIDSGIVER_FNR to avsenderFnr.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrProducerTest.kt
@@ -20,17 +20,17 @@ class AktiveOrgnrProducerTest :
         val producer = AktiveOrgnrProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val arbeidsgiverFnr = Fnr.genererGyldig()
             val arbeidstagerFnr = Fnr.genererGyldig()
 
-            producer.publish(transaksjonId, arbeidsgiverFnr, arbeidstagerFnr)
+            producer.publish(kontekstId, arbeidsgiverFnr, arbeidstagerFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FNR to arbeidstagerFnr.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselProducerTest.kt
@@ -20,17 +20,17 @@ class HentForespoerselProducerTest :
         val producer = HentForespoerselProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val forespoerselId = UUID.randomUUID()
             val avsenderFnr = Fnr.genererGyldig()
 
-            producer.publish(transaksjonId, HentForespoerselRequest(forespoerselId), avsenderFnr)
+            producer.publish(kontekstId, HentForespoerselRequest(forespoerselId), avsenderFnr)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeProducerTest.kt
@@ -19,16 +19,16 @@ class HentForespoerselIdListeProducerTest :
         val producer = HentForespoerslerProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val vedtaksperiodeIdListe = listOf(UUID.randomUUID(), UUID.randomUUID())
 
-            producer.publish(transaksjonId, HentForespoerslerRequest(vedtaksperiodeIdListe))
+            producer.publish(kontekstId, HentForespoerslerRequest(vedtaksperiodeIdListe))
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.VEDTAKSPERIODE_ID_LISTE to vedtaksperiodeIdListe.toJson(UuidSerializer),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImProducerTest.kt
@@ -19,16 +19,16 @@ class HentSelvbestemtImProducerTest :
         val producer = HentSelvbestemtImProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val selvbestemtId = UUID.randomUUID()
 
-            producer.publish(transaksjonId, selvbestemtId)
+            producer.publish(kontekstId, selvbestemtId)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_ID to selvbestemtId.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektProducerTest.kt
@@ -18,17 +18,17 @@ class InntektProducerTest :
         val inntektProducer = InntektProducer(testRapid)
 
         test("Publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val request = InntektRequest(UUID.randomUUID(), 18.januar)
 
-            inntektProducer.publish(transaksjonId, request)
+            inntektProducer.publish(kontekstId, request)
 
             val publisert = testRapid.firstMessage().toMap()
 
             publisert shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to request.forespoerselId.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtProducerTest.kt
@@ -22,18 +22,18 @@ class InntektSelvbestemtProducerTest :
         val producer = InntektSelvbestemtProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val sykmeldtFnr = Fnr.genererGyldig()
             val orgnr = Orgnr.genererGyldig()
             val inntektsdato = 12.april
 
-            producer.publish(transaksjonId, InntektSelvbestemtRequest(sykmeldtFnr, orgnr, inntektsdato))
+            producer.publish(kontekstId, InntektSelvbestemtRequest(sykmeldtFnr, orgnr, inntektsdato))
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FNR to sykmeldtFnr.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringProducerTest.kt
@@ -18,16 +18,16 @@ class KvitteringProducerTest :
         val producer = KvitteringProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val forespoerselId = UUID.randomUUID()
 
-            producer.publish(transaksjonId, forespoerselId)
+            producer.publish(kontekstId, forespoerselId)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImProducerTest.kt
@@ -24,18 +24,18 @@ class LagreSelvbestemtImProducerTest :
         val producer = LagreSelvbestemtImProducer(testRapid)
 
         test("publiserer melding på forventet format") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val avsenderFnr = Fnr.genererGyldig()
             val skjema = mockSkjemaInntektsmeldingSelvbestemt()
             val mottatt = 14.oktober.atStartOfDay()
 
-            producer.publish(transaksjonId, avsenderFnr, skjema, mottatt)
+            producer.publish(kontekstId, avsenderFnr, skjema, mottatt)
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.ARBEIDSGIVER_FNR to avsenderFnr.toJson(),

--- a/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -36,7 +36,7 @@ private const val UKJENT_NAVN = "Ukjent navn"
 private const val UKJENT_VIRKSOMHET = "Ukjent virksomhet"
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val avsenderFnr: Fnr,
     val skjema: SkjemaInntektsmelding,
     val innsendingId: Long,
@@ -70,7 +70,7 @@ class BerikInntektsmeldingService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), melding),
             skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), melding),
             innsendingId = Key.INNSENDING_ID.les(Long.serializer(), melding),
@@ -107,7 +107,7 @@ class BerikInntektsmeldingService(
                 key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson())
@@ -125,7 +125,7 @@ class BerikInntektsmeldingService(
                 key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -148,7 +148,7 @@ class BerikInntektsmeldingService(
                 key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -192,7 +192,7 @@ class BerikInntektsmeldingService(
                 key = steg0.skjema.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.LAGRE_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -217,7 +217,7 @@ class BerikInntektsmeldingService(
                 rapid.publish(
                     key = steg0.skjema.forespoerselId,
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_MOTTATT.toJson(),
-                    Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
@@ -246,7 +246,7 @@ class BerikInntektsmeldingService(
         mapOf(
             Log.klasse(this@BerikInntektsmeldingService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(skjema.forespoerselId),
         )
 

--- a/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
+++ b/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
@@ -55,9 +55,9 @@ class BerikInntektsmeldingServiceTest :
         }
 
         test("nytt inntektsmeldingskjema berikes, lagres og sendes videre til journalføring") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
-            testRapid.sendJson(Mock.steg0(transaksjonId))
+            testRapid.sendJson(Mock.steg0(kontekstId))
 
             // Melding med forventet behov og data sendt for å hente forespørsel
             testRapid.inspektør.size shouldBeExactly 1
@@ -68,7 +68,7 @@ class BerikInntektsmeldingServiceTest :
                 Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data) shouldBe Mock.skjema.forespoerselId
             }
 
-            testRapid.sendJson(Mock.steg1(transaksjonId))
+            testRapid.sendJson(Mock.steg1(kontekstId))
 
             // Melding med forventet behov og data sendt for å hente virksomhetsnavn
             testRapid.inspektør.size shouldBeExactly 2
@@ -79,7 +79,7 @@ class BerikInntektsmeldingServiceTest :
                 Key.ORGNR_UNDERENHETER.lesOrNull(Orgnr.serializer().set(), data) shouldNotBe null
             }
 
-            testRapid.sendJson(Mock.steg2(transaksjonId))
+            testRapid.sendJson(Mock.steg2(kontekstId))
 
             // Melding med forventet behov og data sendt for å hente personnavn
             testRapid.inspektør.size shouldBeExactly 3
@@ -90,7 +90,7 @@ class BerikInntektsmeldingServiceTest :
                 Key.FNR_LISTE.lesOrNull(Fnr.serializer().set(), data) shouldNotBe null
             }
 
-            testRapid.sendJson(Mock.steg3(transaksjonId))
+            testRapid.sendJson(Mock.steg3(kontekstId))
 
             // Melding med forventet behov og data sendt for å lagre inntektsmelding
             testRapid.inspektør.size shouldBeExactly 4
@@ -102,7 +102,7 @@ class BerikInntektsmeldingServiceTest :
                 Key.INNSENDING_ID.lesOrNull(Long.serializer(), data) shouldBe Mock.INNSENDING_ID
             }
 
-            testRapid.sendJson(Mock.steg4(transaksjonId))
+            testRapid.sendJson(Mock.steg4(kontekstId))
 
             // Inntektsmelding sendt videre til journalføring med forventet data
             testRapid.inspektør.size shouldBeExactly 5
@@ -167,10 +167,10 @@ private object Mock {
             sykmeldt.fnr to sykmeldt,
         )
 
-    fun steg0(transaksjonId: UUID): Map<Key, JsonElement> =
+    fun steg0(kontekstId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to avsender.fnr.toJson(),
@@ -180,23 +180,23 @@ private object Mock {
                 ).toJson(),
         )
 
-    fun steg1(transaksjonId: UUID): Map<Key, JsonElement> =
-        steg0(transaksjonId).plusData(
+    fun steg1(kontekstId: UUID): Map<Key, JsonElement> =
+        steg0(kontekstId).plusData(
             Key.FORESPOERSEL_SVAR to forespoersel.toJson(Forespoersel.serializer()),
         )
 
-    fun steg2(transaksjonId: UUID): Map<Key, JsonElement> =
-        steg1(transaksjonId).plusData(
+    fun steg2(kontekstId: UUID): Map<Key, JsonElement> =
+        steg1(kontekstId).plusData(
             Key.VIRKSOMHETER to orgnrMedNavn.toJson(orgMapSerializer),
         )
 
-    fun steg3(transaksjonId: UUID): Map<Key, JsonElement> =
-        steg2(transaksjonId).plusData(
+    fun steg3(kontekstId: UUID): Map<Key, JsonElement> =
+        steg2(kontekstId).plusData(
             Key.PERSONER to personer.toJson(personMapSerializer),
         )
 
-    fun steg4(transaksjonId: UUID): Map<Key, JsonElement> =
-        steg3(transaksjonId).plusData(
+    fun steg4(kontekstId: UUID): Map<Key, JsonElement> =
+        steg3(kontekstId).plusData(
             mapOf(
                 Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
                 Key.INNTEKTSMELDING to mockInntektsmeldingV1().toJson(Inntektsmelding.serializer()),

--- a/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
+++ b/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiver.kt
@@ -23,7 +23,7 @@ private const val AVSENDER_NAV_NO_SELVBESTEMT = "NAV_NO_SELVBESTEMT"
 
 class HentEksternImMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val spinnImId: UUID,
 )
@@ -42,7 +42,7 @@ class HentEksternImRiver(
 
             HentEksternImMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.FORESPOERSEL_BESVART, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 spinnImId = Key.SPINN_INNTEKTSMELDING_ID.les(UuidSerializer, data),
             )
@@ -60,7 +60,7 @@ class HentEksternImRiver(
         } else {
             mapOf(
                 Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_MOTTATT.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -83,7 +83,7 @@ class HentEksternImRiver(
         val fail =
             Fail(
                 feilmelding = feilmelding,
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -97,7 +97,7 @@ class HentEksternImRiver(
         mapOf(
             Log.klasse(this@HentEksternImRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiverTest.kt
+++ b/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/HentEksternImRiverTest.kt
@@ -52,7 +52,7 @@ class HentEksternImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_MOTTATT.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
@@ -112,7 +112,7 @@ class HentEksternImRiverTest :
                 val forventetFail =
                     Fail(
                         feilmelding = expectedFeilmelding,
-                        kontekstId = innkommendeMelding.transaksjonId,
+                        kontekstId = innkommendeMelding.kontekstId,
                         utloesendeMelding = innkommendeJsonMap,
                     )
 
@@ -157,7 +157,7 @@ private object Mock {
     fun innkommendeMelding(): HentEksternImMelding =
         HentEksternImMelding(
             eventName = EventName.FORESPOERSEL_BESVART,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = UUID.randomUUID(),
             spinnImId = UUID.randomUUID(),
         )
@@ -165,7 +165,7 @@ private object Mock {
     fun HentEksternImMelding.toMap(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
+++ b/apps/brreg/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiver.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 data class HentVirksomhetMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val orgnr: Set<Orgnr>,
@@ -48,7 +48,7 @@ class HentVirksomhetNavnRiver(
             HentVirksomhetMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_VIRKSOMHET_NAVN, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 orgnr = Key.ORGNR_UNDERENHETER.les(Orgnr.serializer().set(), data),
@@ -76,7 +76,7 @@ class HentVirksomhetNavnRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(Key.VIRKSOMHETER to orgnrMedNavn.toJson())
@@ -91,7 +91,7 @@ class HentVirksomhetNavnRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente virksomhet fra Brreg.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -106,7 +106,7 @@ class HentVirksomhetNavnRiver(
             Log.klasse(this@HentVirksomhetNavnRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }
 

--- a/apps/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
+++ b/apps/brreg/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brreg/HentVirksomhetNavnRiverTest.kt
@@ -60,7 +60,7 @@ class HentVirksomhetNavnRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(Key.VIRKSOMHETER to orgnrMedNavn.mapKeys { it.key.verdi }.toJson())
@@ -91,7 +91,7 @@ class HentVirksomhetNavnRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(Key.VIRKSOMHETER to orgnrMedNavn.mapKeys { it.key.verdi }.toJson())
@@ -122,7 +122,7 @@ class HentVirksomhetNavnRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(Key.VIRKSOMHETER to emptyMap<String, String>().toJson())
@@ -142,7 +142,7 @@ class HentVirksomhetNavnRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente virksomhet fra Brreg.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -188,7 +188,7 @@ private object Mock {
         return HentVirksomhetMelding(
             eventName = EventName.TRENGER_REQUESTED,
             behovType = BehovType.HENT_VIRKSOMHET_NAVN,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -203,7 +203,7 @@ private object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
@@ -30,7 +30,7 @@ import java.util.UUID
 data class HentLagretImMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val forespoerselId: UUID,
@@ -51,7 +51,7 @@ class HentLagretImRiver(
             HentLagretImMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_LAGRET_IM, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
@@ -87,7 +87,7 @@ class HentLagretImRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -107,7 +107,7 @@ class HentLagretImRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente inntektsmelding fra database.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -122,7 +122,7 @@ class HentLagretImRiver(
             Log.klasse(this@HentLagretImRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiver.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 data class HentSelvbestemtImMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val selvbestemtId: UUID,
 )
@@ -43,7 +43,7 @@ class HentSelvbestemtImRiver(
             HentSelvbestemtImMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_SELVBESTEMT_IM, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 selvbestemtId = Key.SELVBESTEMT_ID.les(UuidSerializer, data),
             )
@@ -67,7 +67,7 @@ class HentSelvbestemtImRiver(
 
             mapOf(
                 Key.EVENT_NAME to eventName.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -89,7 +89,7 @@ class HentSelvbestemtImRiver(
             Log.klasse(this@HentSelvbestemtImRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.selvbestemtId(selvbestemtId),
         )
 
@@ -101,7 +101,7 @@ class HentSelvbestemtImRiver(
         val fail =
             Fail(
                 feilmelding = feilmelding,
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiver.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 
 data class LagreEksternImMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val eksternInntektsmelding: EksternInntektsmelding,
 )
@@ -40,7 +40,7 @@ class LagreEksternImRiver(
 
             LagreEksternImMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.EKSTERN_INNTEKTSMELDING_MOTTATT, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 eksternInntektsmelding = Key.EKSTERN_INNTEKTSMELDING.les(EksternInntektsmelding.serializer(), data),
             )
@@ -58,7 +58,7 @@ class LagreEksternImRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_LAGRET.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
     }
@@ -70,7 +70,7 @@ class LagreEksternImRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre ekstern inntektsmelding i database.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -84,7 +84,7 @@ class LagreEksternImRiver(
         mapOf(
             Log.klasse(this@LagreEksternImRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 data class LagreImMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val inntektsmelding: Inntektsmelding,
     val innsendingId: Long,
@@ -46,7 +46,7 @@ class LagreImRiver(
             LagreImMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.LAGRE_IM, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
                 innsendingId = Key.INNSENDING_ID.les(Long.serializer(), data),
@@ -63,7 +63,7 @@ class LagreImRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -83,7 +83,7 @@ class LagreImRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre inntektsmelding i database.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -98,7 +98,7 @@ class LagreImRiver(
             Log.klasse(this@LagreImRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(inntektsmelding.type.id),
         )
 }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -30,7 +30,7 @@ private const val INNSENDING_ID_VED_DUPLIKAT = -1L
 data class LagreImSkjemaMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val forespoersel: Forespoersel,
     val skjema: SkjemaInntektsmelding,
@@ -51,7 +51,7 @@ class LagreImSkjemaRiver(
             LagreImSkjemaMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.LAGRE_IM_SKJEMA, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 forespoersel = Key.FORESPOERSEL_SVAR.les(Forespoersel.serializer(), data),
                 skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), data),
@@ -77,7 +77,7 @@ class LagreImSkjemaRiver(
             }
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -96,7 +96,7 @@ class LagreImSkjemaRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre inntektsmeldingskjema i database.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -111,7 +111,7 @@ class LagreImSkjemaRiver(
             Log.klasse(this@LagreImSkjemaRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(skjema.forespoerselId),
         )
 }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 
 data class LagreJournalpostIdMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val inntektsmelding: Inntektsmelding,
     val journalpostId: String,
     val innsendingId: Long?,
@@ -43,7 +43,7 @@ class LagreJournalpostIdRiver(
         } else {
             LagreJournalpostIdMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.INNTEKTSMELDING_JOURNALFOERT, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
                 journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
                 innsendingId = Key.INNSENDING_ID.lesOrNull(Long.serializer(), json),
@@ -84,7 +84,7 @@ class LagreJournalpostIdRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
         ).also {
@@ -100,7 +100,7 @@ class LagreJournalpostIdRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre journalpost-ID '$journalpostId'.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -114,7 +114,7 @@ class LagreJournalpostIdRiver(
         mapOf(
             Log.klasse(this@LagreJournalpostIdRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt -> Log.forespoerselId(inntektsmelding.type.id)
                 is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 data class LagreSelvbestemtImMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val selvbestemtInntektsmelding: Inntektsmelding,
 )
@@ -45,7 +45,7 @@ class LagreSelvbestemtImRiver(
             LagreSelvbestemtImMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.LAGRE_SELVBESTEMT_IM, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 selvbestemtInntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
             )
@@ -79,7 +79,7 @@ class LagreSelvbestemtImRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -95,7 +95,7 @@ class LagreSelvbestemtImRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre selvbestemt inntektsmelding i database.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -110,7 +110,7 @@ class LagreSelvbestemtImRiver(
             Log.klasse(this@LagreSelvbestemtImRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.selvbestemtId(selvbestemtInntektsmelding.type.id),
         )
 }

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
@@ -73,7 +73,7 @@ class HentLagretImRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.DATA to
                             innkommendeMelding.data
                                 .plus(
@@ -129,7 +129,7 @@ class HentLagretImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(
@@ -156,7 +156,7 @@ class HentLagretImRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente inntektsmelding fra database.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -203,7 +203,7 @@ private object MockHentIm {
         return HentLagretImMelding(
             eventName = EventName.KVITTERING_REQUESTED,
             behovType = BehovType.HENT_LAGRET_IM,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -218,7 +218,7 @@ private object MockHentIm {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentSelvbestemtImRiverTest.kt
@@ -58,7 +58,7 @@ class HentSelvbestemtImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_ID to innkommendeMelding.selvbestemtId.toJson(),
@@ -134,7 +134,7 @@ private fun innkommendeMelding(): HentSelvbestemtImMelding {
     return HentSelvbestemtImMelding(
         eventName = EventName.SELVBESTEMT_IM_REQUESTED,
         behovType = BehovType.HENT_SELVBESTEMT_IM,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         data =
             mapOf(
                 Key.SELVBESTEMT_ID to selvbestemtId.toJson(),
@@ -147,14 +147,14 @@ private fun HentSelvbestemtImMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
         Key.BEHOV to behovType.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to data.toJson(),
     )
 
 private fun HentSelvbestemtImMelding.toFail(feilmelding: String): Fail =
     Fail(
         feilmelding = feilmelding,
-        kontekstId = transaksjonId,
+        kontekstId = kontekstId,
         utloesendeMelding = toMap(),
     )
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreEksternImRiverTest.kt
@@ -52,7 +52,7 @@ class LagreEksternImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.EKSTERN_INNTEKTSMELDING_LAGRET.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
                 )
 
@@ -69,7 +69,7 @@ class LagreEksternImRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke lagre ekstern inntektsmelding i database.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeJsonMap,
                 )
 
@@ -112,7 +112,7 @@ class LagreEksternImRiverTest :
 private fun mockInnkommendeMelding(): LagreEksternImMelding =
     LagreEksternImMelding(
         eventName = EventName.EKSTERN_INNTEKTSMELDING_MOTTATT,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
         eksternInntektsmelding = mockEksternInntektsmelding(),
     )
@@ -120,7 +120,7 @@ private fun mockInnkommendeMelding(): LagreEksternImMelding =
 private fun LagreEksternImMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to
             mapOf(
                 Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
@@ -58,7 +58,7 @@ class LagreImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -82,7 +82,7 @@ class LagreImRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke lagre inntektsmelding i database.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -127,7 +127,7 @@ private fun innkommendeMelding(
     LagreImMelding(
         eventName = EventName.INNTEKTSMELDING_SKJEMA_LAGRET,
         behovType = BehovType.LAGRE_IM,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         data =
             mapOf(
                 Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -141,7 +141,7 @@ private fun LagreImMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
         Key.BEHOV to behovType.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to data.toJson(),
     )
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiverTest.kt
@@ -83,7 +83,7 @@ class LagreImSkjemaRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.FORESPOERSEL_SVAR to innkommendeMelding.forespoersel.toJson(Forespoersel.serializer()),
@@ -117,7 +117,7 @@ class LagreImSkjemaRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_SVAR to innkommendeMelding.forespoersel.toJson(Forespoersel.serializer()),
@@ -146,7 +146,7 @@ class LagreImSkjemaRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke lagre inntektsmeldingskjema i database.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -195,7 +195,7 @@ private fun innkommendeMelding(
     return LagreImSkjemaMelding(
         eventName = EventName.INSENDING_STARTED,
         behovType = BehovType.LAGRE_IM_SKJEMA,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         data =
             mapOf(
                 Key.FORESPOERSEL_SVAR to forespoersel.toJson(Forespoersel.serializer()),
@@ -212,7 +212,7 @@ private fun LagreImSkjemaMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
         Key.BEHOV to behovType.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to data.toJson(),
     )
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -61,7 +61,7 @@ class LagreJournalpostIdRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     )
@@ -99,7 +99,7 @@ class LagreJournalpostIdRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     )
@@ -141,7 +141,7 @@ class LagreJournalpostIdRiverTest :
                 val forventetFail =
                     Fail(
                         feilmelding = "Klarte ikke lagre journalpost-ID '${innkommendeMelding.journalpostId}'.",
-                        kontekstId = innkommendeMelding.transaksjonId,
+                        kontekstId = innkommendeMelding.kontekstId,
                         utloesendeMelding = innkommendeMelding.toMap(),
                     )
 
@@ -175,7 +175,7 @@ class LagreJournalpostIdRiverTest :
                 val forventetFail =
                     Fail(
                         feilmelding = "Klarte ikke lagre journalpost-ID '${innkommendeMelding.journalpostId}'.",
-                        kontekstId = innkommendeMelding.transaksjonId,
+                        kontekstId = innkommendeMelding.kontekstId,
                         utloesendeMelding = innkommendeMelding.toMap(),
                     )
 
@@ -225,7 +225,7 @@ private object Mock {
     fun innkommendeMelding(inntektsmelding: Inntektsmelding = mockInntektsmeldingV1()): LagreJournalpostIdMelding =
         LagreJournalpostIdMelding(
             eventName = EventName.INNTEKTSMELDING_JOURNALFOERT,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             inntektsmelding = inntektsmelding,
             journalpostId = randomDigitString(10),
             innsendingId = INNSENDING_ID,
@@ -234,7 +234,7 @@ private object Mock {
     fun LagreJournalpostIdMelding.toMap(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiverTest.kt
@@ -71,7 +71,7 @@ class LagreSelvbestemtImRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.SELVBESTEMT_INNTEKTSMELDING to nyInntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -113,7 +113,7 @@ class LagreSelvbestemtImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_INNTEKTSMELDING to nyInntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -139,7 +139,7 @@ class LagreSelvbestemtImRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke lagre selvbestemt inntektsmelding i database.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -185,7 +185,7 @@ private fun innkommendeMelding(selvbestemtInntektsmelding: Inntektsmelding = moc
     LagreSelvbestemtImMelding(
         eventName = EventName.SELVBESTEMT_IM_MOTTATT,
         behovType = BehovType.LAGRE_SELVBESTEMT_IM,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         data =
             mapOf(
                 Key.SELVBESTEMT_INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -197,7 +197,7 @@ private fun LagreSelvbestemtImMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
         Key.BEHOV to behovType.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to data.toJson(),
     )
 

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -27,7 +27,7 @@ const val TOPIC_HELSEARBEIDSGIVER_INNTEKTSMELDING_EKSTERN = "helsearbeidsgiver.i
 
 data class Melding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val inntektsmelding: Inntektsmelding,
     val journalpostId: String,
 )
@@ -44,7 +44,7 @@ class DistribusjonRiver(
         } else {
             Melding(
                 eventName = Key.EVENT_NAME.krev(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), json),
                 journalpostId = Key.JOURNALPOST_ID.les(String.serializer(), json),
             )
@@ -67,7 +67,7 @@ class DistribusjonRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
         )
@@ -80,7 +80,7 @@ class DistribusjonRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke distribuere IM med journalpost-ID '$journalpostId'.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -94,7 +94,7 @@ class DistribusjonRiver(
         mapOf(
             Log.klasse(this@DistribusjonRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt -> Log.forespoerselId(inntektsmelding.type.id)
                 is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)

--- a/apps/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
+++ b/apps/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
@@ -57,7 +57,7 @@ class DistribusjonRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     Key.INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
                 )
@@ -100,7 +100,7 @@ class DistribusjonRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKTSMELDING_DISTRIBUERT.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.JOURNALPOST_ID to innkommendeMelding.journalpostId.toJson(),
                     Key.INNTEKTSMELDING to selvbestemtInntektsmelding.toJson(Inntektsmelding.serializer()),
                 )
@@ -129,7 +129,7 @@ class DistribusjonRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke distribuere IM med journalpost-ID '${innkommendeMelding.journalpostId}'.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeJsonMap,
                 )
 
@@ -175,7 +175,7 @@ private object Mock {
     fun innkommendeMelding(): Melding =
         Melding(
             eventName = EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             inntektsmelding = mockInntektsmeldingV1(),
             journalpostId = randomDigitString(13),
         )
@@ -183,7 +183,7 @@ private object Mock {
     fun Melding.toMap(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
         )

--- a/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
+++ b/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytter.kt
@@ -63,8 +63,8 @@ class FeilLytter(
         sikkerLogger.info("Mottok feil.\n${json.toPretty()}")
 
         if (eventSkalHaandteres(fail.utloesendeMelding)) {
-            // slå opp transaksjonID. Hvis den finnes, kan det være en annen feilende melding i samme transaksjon: Lagre i så fall
-            // med egen id. Denne id vil så sendes med som ny transaksjonID ved rekjøring.
+            // slå opp kontekst-ID. Hvis den finnes, kan det være en annen feilende melding i samme kontekst: Lagre i så fall
+            // med egen id. Denne id vil så sendes med som ny kontekst-ID ved rekjøring.
             val eksisterendeJobb = repository.getById(fail.kontekstId)
 
             when {
@@ -138,7 +138,7 @@ class FeilLytter(
         return listOf(
             Log.klasse(this@FeilLytter),
             eventName?.let(Log::event),
-            kontekstId?.let(Log::transaksjonId),
+            kontekstId?.let(Log::kontekstId),
             behovType?.let(Log::behov),
             forespoerselId?.let(Log::forespoerselId),
             selvbestemtId?.let(Log::selvbestemtId),

--- a/apps/feil-behandler/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytterTest.kt
+++ b/apps/feil-behandler/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/river/FeilLytterTest.kt
@@ -36,7 +36,7 @@ class FeilLytterTest :
             repository.deleteAll()
         }
 
-        test("ved flere feil på samme transaksjon-ID og event, så oppdateres eksisterende jobb") {
+        test("ved flere feil på samme kontekst-ID og event, så oppdateres eksisterende jobb") {
             val omEttMinutt = LocalDateTime.now().plusMinutes(1)
             val forespoerselMottattFail = mockFail("skux life", EventName.FORESPOERSEL_MOTTATT)
 
@@ -56,12 +56,12 @@ class FeilLytterTest :
             jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding
         }
 
-        test("ved flere feil på samme transaksjon-ID og event, men ulikt innhold, så lagres to jobber med ulik transaksjon-ID") {
+        test("ved flere feil på samme kontekst-ID og event, men ulikt innhold, så lagres to jobber med ulik kontekst-ID") {
             val omEttMinutt = LocalDateTime.now().plusMinutes(1)
-            val transaksjonId = UUID.randomUUID()
-            val forespoerselMottattFail = mockFail("tux life", EventName.FORESPOERSEL_MOTTATT, transaksjonId)
+            val kontekstId = UUID.randomUUID()
+            val forespoerselMottattFail = mockFail("tux life", EventName.FORESPOERSEL_MOTTATT, kontekstId)
             val forespoerselMottattFailMedUliktInnhold =
-                mockFail("hux life", EventName.FORESPOERSEL_MOTTATT, transaksjonId).let {
+                mockFail("hux life", EventName.FORESPOERSEL_MOTTATT, kontekstId).let {
                     it.copy(
                         utloesendeMelding =
                             it.utloesendeMelding.plus(
@@ -82,24 +82,24 @@ class FeilLytterTest :
 
             jobber.size shouldBeExactly 2
 
-            jobber[0].uuid shouldBe transaksjonId
+            jobber[0].uuid shouldBe kontekstId
             jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding
 
-            jobber[1].uuid shouldNotBe transaksjonId
+            jobber[1].uuid shouldNotBe kontekstId
             jobber[1].data.parseJson().toMap().also {
                 it[Key.EVENT_NAME]?.fromJson(EventName.serializer()) shouldBe
                     forespoerselMottattFailMedUliktInnhold.utloesendeMelding[Key.EVENT_NAME]?.fromJson(EventName.serializer())
                 it[Key.ER_DUPLIKAT_IM]?.fromJson(String.serializer()) shouldBe "kanskje"
 
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldNotBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldNotBe kontekstId
             }
         }
 
-        test("ved flere feil på samme transaksjon-ID, men ulik event, så lagres to jobber med ulik transaksjon-ID") {
+        test("ved flere feil på samme kontekst-ID, men ulik event, så lagres to jobber med ulik kontekst-ID") {
             val omEttMinutt = LocalDateTime.now().plusMinutes(1)
-            val transaksjonId = UUID.randomUUID()
-            val forespoerselMottattFail = mockFail("fox life", EventName.FORESPOERSEL_MOTTATT, transaksjonId)
-            val forespoerselBesvartFail = mockFail("nox life", EventName.FORESPOERSEL_BESVART, transaksjonId)
+            val kontekstId = UUID.randomUUID()
+            val forespoerselMottattFail = mockFail("fox life", EventName.FORESPOERSEL_MOTTATT, kontekstId)
+            val forespoerselBesvartFail = mockFail("nox life", EventName.FORESPOERSEL_BESVART, kontekstId)
 
             rapid.sendJson(forespoerselMottattFail.tilMelding())
 
@@ -113,18 +113,18 @@ class FeilLytterTest :
 
             jobber.size shouldBeExactly 2
 
-            jobber[0].uuid shouldBe transaksjonId
+            jobber[0].uuid shouldBe kontekstId
             jobber[0].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail.utloesendeMelding
 
-            jobber[1].uuid shouldNotBe transaksjonId
+            jobber[1].uuid shouldNotBe kontekstId
             jobber[1].data.parseJson().toMap().also {
                 it[Key.EVENT_NAME]?.fromJson(EventName.serializer()) shouldBe
                     forespoerselBesvartFail.utloesendeMelding[Key.EVENT_NAME]?.fromJson(EventName.serializer())
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldNotBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldNotBe kontekstId
             }
         }
 
-        test("ved flere feil på ulik transaksjon-ID, men samme event, så lagres to jobber (med ulik transaksjon-ID)") {
+        test("ved flere feil på ulik kontekst-ID, men samme event, så lagres to jobber (med ulik kontekst-ID)") {
             val omEttMinutt = LocalDateTime.now().plusMinutes(1)
             val forespoerselMottattFail1 = mockFail("ux life", EventName.FORESPOERSEL_MOTTATT)
             val forespoerselMottattFail2 = mockFail("ux life", EventName.FORESPOERSEL_MOTTATT)
@@ -148,7 +148,7 @@ class FeilLytterTest :
             jobber[1].data.parseJson().toMap() shouldContainExactly forespoerselMottattFail2.utloesendeMelding
         }
 
-        test("ved flere feil på ulik transaksjon-ID og ulik event, så lagres to jobber (med ulik transaksjon-ID)") {
+        test("ved flere feil på ulik kontekst-ID og ulik event, så lagres to jobber (med ulik kontekst-ID)") {
             val omEttMinutt = LocalDateTime.now().plusMinutes(1)
             val forespoerselMottattFail = mockFail("lux life", EventName.FORESPOERSEL_MOTTATT)
             val forespoerselBesvartFail = mockFail("rux life", EventName.FORESPOERSEL_BESVART)

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStore.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStore.kt
@@ -25,25 +25,25 @@ class RedisStore(
     private val logger = logger()
     private val sikkerLogger = sikkerLogger()
 
-    fun lesResultat(transaksjonId: UUID): ResultJson? =
-        resultatKey(transaksjonId)
+    fun lesResultat(kontekstId: UUID): ResultJson? =
+        resultatKey(kontekstId)
             .les()
             ?.fromJson(ResultJson.serializer())
 
-    fun lesAlleMellomlagrede(transaksjonId: UUID): Map<Key, JsonElement> {
-        val prefix = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator(withPostfix = true)
+    fun lesAlleMellomlagrede(kontekstId: UUID): Map<Key, JsonElement> {
+        val prefix = listOf(keyPrefix.name, kontekstId.toString()).joinKeySeparator(withPostfix = true)
 
         return Key.entries
-            .map { mellomlagringKey(transaksjonId, it) }
+            .map { mellomlagringKey(kontekstId, it) }
             .lesAlle { removePrefix(prefix) }
     }
 
-    fun lesAlleFeil(transaksjonId: UUID): Map<Key, String> {
-        val prefix = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator(withPostfix = true)
+    fun lesAlleFeil(kontekstId: UUID): Map<Key, String> {
+        val prefix = listOf(keyPrefix.name, kontekstId.toString()).joinKeySeparator(withPostfix = true)
         val postfix = KEY_PART_SEPARATOR + KEY_FEIL_POSTFIX
 
         return Key.entries
-            .map { feilKey(transaksjonId, it) }
+            .map { feilKey(kontekstId, it) }
             .lesAlle {
                 removePrefix(prefix)
                     .removeSuffix(postfix)
@@ -51,26 +51,26 @@ class RedisStore(
     }
 
     fun skrivResultat(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         value: ResultJson,
     ) {
-        resultatKey(transaksjonId).skriv(value.toJson())
+        resultatKey(kontekstId).skriv(value.toJson())
     }
 
     fun skrivMellomlagring(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         key: Key,
         value: JsonElement,
     ) {
-        mellomlagringKey(transaksjonId, key).skriv(value)
+        mellomlagringKey(kontekstId, key).skriv(value)
     }
 
     fun skrivFeil(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         key: Key,
         value: String,
     ) {
-        feilKey(transaksjonId, key).skriv(value.toJson())
+        feilKey(kontekstId, key).skriv(value.toJson())
     }
 
     private fun String.les(): JsonElement? =
@@ -112,23 +112,23 @@ class RedisStore(
         redis.set(this, value.toString())
     }
 
-    private fun resultatKey(transaksjonId: UUID): String = listOf(keyPrefix.name, transaksjonId.toString()).joinKeySeparator()
+    private fun resultatKey(kontekstId: UUID): String = listOf(keyPrefix.name, kontekstId.toString()).joinKeySeparator()
 
     private fun mellomlagringKey(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         key: Key,
     ): String =
         listOf(
-            resultatKey(transaksjonId),
+            resultatKey(kontekstId),
             key.toString(),
         ).joinKeySeparator()
 
     private fun feilKey(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         key: Key,
     ): String =
         listOf(
-            mellomlagringKey(transaksjonId, key),
+            mellomlagringKey(kontekstId, key),
             KEY_FEIL_POSTFIX,
         ).joinKeySeparator()
 }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/Service.kt
@@ -27,7 +27,7 @@ sealed interface Service {
     )
 }
 
-// TODO lese påkrevde felt som transaksjonId her?
+// TODO lese påkrevde felt som kontekstId her?
 abstract class ServiceMed1Steg<S0, S1> : Service {
     protected abstract val logger: Logger
     protected abstract val sikkerLogger: Logger

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceMelding.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceMelding.kt
@@ -10,12 +10,12 @@ sealed class ServiceMelding
 
 data class DataMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val dataMap: Map<Key, JsonElement>,
 ) : ServiceMelding()
 
 data class FailMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val fail: Fail,
 ) : ServiceMelding()

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/Log.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/Log.kt
@@ -14,7 +14,7 @@ object Log {
 
     fun behov(value: BehovType) = "hag_behov" to value.name
 
-    fun transaksjonId(value: UUID) = "hag_kontekst_id" to value.toString()
+    fun kontekstId(value: UUID) = "hag_kontekst_id" to value.toString()
 
     fun forespoerselId(value: UUID) = "hag_forespoersel_id" to value.toString()
 

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/json/KotlinxUtilsKtTest.kt
@@ -26,7 +26,7 @@ class KotlinxUtilsKtTest :
                     mapOf(
                         Key.EVENT_NAME to "test_event",
                         Key.BEHOV to "test_behov",
-                        Key.KONTEKST_ID to "test_transaksjonId",
+                        Key.KONTEKST_ID to "test_kontekstId",
                     )
 
                 val json =

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStoreTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/redis/RedisStoreTest.kt
@@ -19,7 +19,7 @@ class RedisStoreTest :
         context(RedisStore::lesAlleMellomlagrede.name) {
             test("leser mellomlagrede OK") {
                 val keyPrefix = RedisPrefix.Kvittering
-                val transaksjonId = UUID.randomUUID()
+                val kontekstId = UUID.randomUUID()
 
                 val redisStore =
                     RedisStore(
@@ -27,11 +27,11 @@ class RedisStoreTest :
                             redisWithMockRedisClient(
                                 mockStorageInit =
                                     mapOf(
-                                        "$keyPrefix#$transaksjonId" to "\"mango\"",
-                                        "$keyPrefix#$transaksjonId#${Key.SAK_ID}#feil" to "\"papaya\"",
-                                        "$keyPrefix#$transaksjonId#${Key.FNR}" to "\"ananas\"",
-                                        "$keyPrefix#$transaksjonId#${Key.ORGNR_UNDERENHET}" to "\"kokosnøtt\"",
-                                        "$keyPrefix#$transaksjonId#${Key.TILGANG}" to null,
+                                        "$keyPrefix#$kontekstId" to "\"mango\"",
+                                        "$keyPrefix#$kontekstId#${Key.SAK_ID}#feil" to "\"papaya\"",
+                                        "$keyPrefix#$kontekstId#${Key.FNR}" to "\"ananas\"",
+                                        "$keyPrefix#$kontekstId#${Key.ORGNR_UNDERENHET}" to "\"kokosnøtt\"",
+                                        "$keyPrefix#$kontekstId#${Key.TILGANG}" to null,
                                     ),
                             ),
                         keyPrefix = keyPrefix,
@@ -39,7 +39,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                     mapOf(
                         Key.FNR to "ananas".toJson(),
                         Key.ORGNR_UNDERENHET to "kokosnøtt".toJson(),
@@ -48,7 +48,7 @@ class RedisStoreTest :
 
             test("ignorerer nøkler som ikke er av typen 'Key'") {
                 val keyPrefix = RedisPrefix.AktiveOrgnr
-                val transaksjonId = UUID.randomUUID()
+                val kontekstId = UUID.randomUUID()
 
                 val redisStore =
                     RedisStore(
@@ -58,9 +58,9 @@ class RedisStoreTest :
                                     mapOf(
                                         "" to "\"jordbær\"",
                                         "${Key.FNR}" to "\"bringebær\"",
-                                        "$transaksjonId#${Key.FNR}" to "\"blåbær\"",
-                                        "$keyPrefix#$transaksjonId#ikkeEnKey" to "\"tyttebær\"",
-                                        "$keyPrefix#$transaksjonId#${Key.ORGNR_UNDERENHET}" to "\"kokosnøtt\"",
+                                        "$kontekstId#${Key.FNR}" to "\"blåbær\"",
+                                        "$keyPrefix#$kontekstId#ikkeEnKey" to "\"tyttebær\"",
+                                        "$keyPrefix#$kontekstId#${Key.ORGNR_UNDERENHET}" to "\"kokosnøtt\"",
                                     ),
                             ),
                         keyPrefix = keyPrefix,
@@ -68,7 +68,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                     mapOf(
                         Key.ORGNR_UNDERENHET to "kokosnøtt".toJson(),
                     )
@@ -76,7 +76,7 @@ class RedisStoreTest :
 
             test("ignorerer verdier som ikke er gyldig JSON") {
                 val keyPrefix = RedisPrefix.TilgangForespoersel
-                val transaksjonId = UUID.randomUUID()
+                val kontekstId = UUID.randomUUID()
 
                 val redisStore =
                     RedisStore(
@@ -84,10 +84,10 @@ class RedisStoreTest :
                             redisWithMockRedisClient(
                                 mockStorageInit =
                                     mapOf(
-                                        "$keyPrefix#$transaksjonId#${Key.FNR}" to "\"ananas\"",
-                                        "$keyPrefix#$transaksjonId#${Key.ORGNR_UNDERENHET}" to "streng uten ekstra fnutter",
-                                        "$keyPrefix#$transaksjonId#${Key.PERSONER}" to "{true}",
-                                        "$keyPrefix#$transaksjonId#${Key.VIRKSOMHETER}" to "]]42[[",
+                                        "$keyPrefix#$kontekstId#${Key.FNR}" to "\"ananas\"",
+                                        "$keyPrefix#$kontekstId#${Key.ORGNR_UNDERENHET}" to "streng uten ekstra fnutter",
+                                        "$keyPrefix#$kontekstId#${Key.PERSONER}" to "{true}",
+                                        "$keyPrefix#$kontekstId#${Key.VIRKSOMHETER}" to "]]42[[",
                                     ),
                             ),
                         keyPrefix = keyPrefix,
@@ -95,7 +95,7 @@ class RedisStoreTest :
 
                 redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
-                redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+                redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                     mapOf(
                         Key.FNR to "ananas".toJson(),
                     )
@@ -105,7 +105,7 @@ class RedisStoreTest :
         context(RedisStore::lesResultat.name) {
             test("leser resultat OK") {
                 val keyPrefix = RedisPrefix.HentForespoersel
-                val transaksjonId = UUID.randomUUID()
+                val kontekstId = UUID.randomUUID()
 
                 val redisStore =
                     RedisStore(
@@ -113,10 +113,10 @@ class RedisStoreTest :
                             redisWithMockRedisClient(
                                 mockStorageInit =
                                     mapOf(
-                                        "$transaksjonId" to "\"banan\"",
-                                        "$keyPrefix#$transaksjonId" to "{\"success\":\"mango\"}",
-                                        "$keyPrefix#$transaksjonId#${Key.FNR}" to "\"ananas\"",
-                                        "$keyPrefix#$transaksjonId#${Key.SAK_ID}#feil" to "\"papaya\"",
+                                        "$kontekstId" to "\"banan\"",
+                                        "$keyPrefix#$kontekstId" to "{\"success\":\"mango\"}",
+                                        "$keyPrefix#$kontekstId#${Key.FNR}" to "\"ananas\"",
+                                        "$keyPrefix#$kontekstId#${Key.SAK_ID}#feil" to "\"papaya\"",
                                     ),
                             ),
                         keyPrefix = keyPrefix,
@@ -124,12 +124,12 @@ class RedisStoreTest :
 
                 redisStore.lesResultat(UUID.randomUUID()).shouldBeNull()
 
-                redisStore.lesResultat(transaksjonId)?.success to "mango"
+                redisStore.lesResultat(kontekstId)?.success to "mango"
             }
 
             test("feiler ved ugyldig type") {
                 val keyPrefix = RedisPrefix.HentForespoersel
-                val transaksjonId = UUID.randomUUID()
+                val kontekstId = UUID.randomUUID()
 
                 val redisStore =
                     RedisStore(
@@ -137,21 +137,21 @@ class RedisStoreTest :
                             redisWithMockRedisClient(
                                 mockStorageInit =
                                     mapOf(
-                                        "$keyPrefix#$transaksjonId" to "\"mango\"",
+                                        "$keyPrefix#$kontekstId" to "\"mango\"",
                                     ),
                             ),
                         keyPrefix = keyPrefix,
                     )
 
                 shouldThrow<SerializationException> {
-                    redisStore.lesResultat(transaksjonId)?.success to "mango"
+                    redisStore.lesResultat(kontekstId)?.success to "mango"
                 }
             }
         }
 
         test(RedisStore::lesAlleFeil.name) {
             val keyPrefix = RedisPrefix.LagreSelvbestemtIm
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
             val redisStore =
                 RedisStore(
@@ -159,12 +159,12 @@ class RedisStoreTest :
                         redisWithMockRedisClient(
                             mockStorageInit =
                                 mapOf(
-                                    "$transaksjonId" to "\"banan\"",
-                                    "$transaksjonId#${Key.SAK_ID}#feil" to "\"appelsin\"",
-                                    "$keyPrefix#$transaksjonId" to "\"mango\"",
-                                    "$keyPrefix#$transaksjonId#${Key.FNR}" to "\"ananas\"",
-                                    "$keyPrefix#$transaksjonId#${Key.SAK_ID}#feil" to "\"papaya\"",
-                                    "$keyPrefix#$transaksjonId#${Key.OPPGAVE_ID}#feil" to "\"gojibær\"",
+                                    "$kontekstId" to "\"banan\"",
+                                    "$kontekstId#${Key.SAK_ID}#feil" to "\"appelsin\"",
+                                    "$keyPrefix#$kontekstId" to "\"mango\"",
+                                    "$keyPrefix#$kontekstId#${Key.FNR}" to "\"ananas\"",
+                                    "$keyPrefix#$kontekstId#${Key.SAK_ID}#feil" to "\"papaya\"",
+                                    "$keyPrefix#$kontekstId#${Key.OPPGAVE_ID}#feil" to "\"gojibær\"",
                                 ),
                         ),
                     keyPrefix = keyPrefix,
@@ -172,7 +172,7 @@ class RedisStoreTest :
 
             redisStore.lesAlleFeil(UUID.randomUUID()).shouldBeEmpty()
 
-            redisStore.lesAlleFeil(transaksjonId) shouldContainExactly
+            redisStore.lesAlleFeil(kontekstId) shouldContainExactly
                 mapOf(
                     Key.SAK_ID to "papaya",
                     Key.OPPGAVE_ID to "gojibær",
@@ -181,7 +181,7 @@ class RedisStoreTest :
 
         test(RedisStore::skrivMellomlagring.name) {
             val keyPrefix = RedisPrefix.TilgangOrg
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
             val redisStore =
                 RedisStore(
@@ -189,35 +189,35 @@ class RedisStoreTest :
                         redisWithMockRedisClient(
                             mockStorageInit =
                                 mapOf(
-                                    "$keyPrefix#$transaksjonId" to "{\"success\":\"rabarbra\"}",
-                                    "$keyPrefix#$transaksjonId#${Key.SAK_ID}#feil" to "\"dragefrukt\"",
+                                    "$keyPrefix#$kontekstId" to "{\"success\":\"rabarbra\"}",
+                                    "$keyPrefix#$kontekstId#${Key.SAK_ID}#feil" to "\"dragefrukt\"",
                                 ),
                         ),
                     keyPrefix = keyPrefix,
                 )
 
-            redisStore.lesAlleMellomlagrede(transaksjonId).shouldBeEmpty()
+            redisStore.lesAlleMellomlagrede(kontekstId).shouldBeEmpty()
 
-            redisStore.skrivMellomlagring(transaksjonId, Key.FNR, "durian".toJson())
+            redisStore.skrivMellomlagring(kontekstId, Key.FNR, "durian".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                 mapOf(
                     Key.FNR to "durian".toJson(),
                 )
 
-            redisStore.skrivMellomlagring(transaksjonId, Key.INNTEKT, "kiwi".toJson())
-            redisStore.skrivMellomlagring(transaksjonId, Key.JOURNALPOST_ID, "litchi".toJson())
+            redisStore.skrivMellomlagring(kontekstId, Key.INNTEKT, "kiwi".toJson())
+            redisStore.skrivMellomlagring(kontekstId, Key.JOURNALPOST_ID, "litchi".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                 mapOf(
                     Key.FNR to "durian".toJson(),
                     Key.INNTEKT to "kiwi".toJson(),
                     Key.JOURNALPOST_ID to "litchi".toJson(),
                 )
 
-            redisStore.skrivMellomlagring(transaksjonId, Key.INNTEKT, "granateple".toJson())
+            redisStore.skrivMellomlagring(kontekstId, Key.INNTEKT, "granateple".toJson())
 
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly
+            redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly
                 mapOf(
                     Key.FNR to "durian".toJson(),
                     Key.INNTEKT to "granateple".toJson(),
@@ -227,14 +227,14 @@ class RedisStoreTest :
             redisStore.lesAlleMellomlagrede(UUID.randomUUID()).shouldBeEmpty()
 
             // Har ikke blitt overskrevet
-            redisStore.lesResultat(transaksjonId)?.success shouldBe "rabarbra".toJson()
-            redisStore.lesAlleFeil(transaksjonId) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
+            redisStore.lesResultat(kontekstId)?.success shouldBe "rabarbra".toJson()
+            redisStore.lesAlleFeil(kontekstId) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
         }
 
         test(RedisStore::skrivResultat.name) {
             val keyPrefix = RedisPrefix.Inntekt
-            val transaksjonId1 = UUID.randomUUID()
-            val transaksjonId2 = UUID.randomUUID()
+            val kontekstId1 = UUID.randomUUID()
+            val kontekstId2 = UUID.randomUUID()
 
             val redisStore =
                 RedisStore(
@@ -242,44 +242,44 @@ class RedisStoreTest :
                         redisWithMockRedisClient(
                             mockStorageInit =
                                 mapOf(
-                                    "$keyPrefix#$transaksjonId1#${Key.FNR}" to "\"durian\"",
-                                    "$keyPrefix#$transaksjonId1#${Key.SAK_ID}#feil" to "\"dragefrukt\"",
-                                    "$keyPrefix#$transaksjonId2" to "{\"failure\":\"rambutan\"}",
+                                    "$keyPrefix#$kontekstId1#${Key.FNR}" to "\"durian\"",
+                                    "$keyPrefix#$kontekstId1#${Key.SAK_ID}#feil" to "\"dragefrukt\"",
+                                    "$keyPrefix#$kontekstId2" to "{\"failure\":\"rambutan\"}",
                                 ),
                         ),
                     keyPrefix = keyPrefix,
                 )
 
             redisStore.lesResultat(UUID.randomUUID()).shouldBeNull()
-            redisStore.lesResultat(transaksjonId1).shouldBeNull()
-            redisStore.lesResultat(transaksjonId2)?.failure shouldBe "rambutan".toJson()
-            redisStore.lesResultat(transaksjonId2)?.success.shouldBeNull()
+            redisStore.lesResultat(kontekstId1).shouldBeNull()
+            redisStore.lesResultat(kontekstId2)?.failure shouldBe "rambutan".toJson()
+            redisStore.lesResultat(kontekstId2)?.success.shouldBeNull()
 
-            redisStore.skrivResultat(transaksjonId1, ResultJson(success = "rabarbra".toJson()))
+            redisStore.skrivResultat(kontekstId1, ResultJson(success = "rabarbra".toJson()))
 
             redisStore.lesResultat(UUID.randomUUID()).shouldBeNull()
-            redisStore.lesResultat(transaksjonId1)?.failure.shouldBeNull()
-            redisStore.lesResultat(transaksjonId1)?.success shouldBe "rabarbra".toJson()
+            redisStore.lesResultat(kontekstId1)?.failure.shouldBeNull()
+            redisStore.lesResultat(kontekstId1)?.success shouldBe "rabarbra".toJson()
 
-            redisStore.skrivResultat(transaksjonId1, ResultJson(success = "en kolossal rabarbra".toJson()))
+            redisStore.skrivResultat(kontekstId1, ResultJson(success = "en kolossal rabarbra".toJson()))
 
-            redisStore.lesResultat(transaksjonId1)?.failure.shouldBeNull()
-            redisStore.lesResultat(transaksjonId1)?.success shouldBe "en kolossal rabarbra".toJson()
+            redisStore.lesResultat(kontekstId1)?.failure.shouldBeNull()
+            redisStore.lesResultat(kontekstId1)?.success shouldBe "en kolossal rabarbra".toJson()
 
-            redisStore.skrivResultat(transaksjonId1, ResultJson(failure = "en megaloman rabarbra".toJson()))
+            redisStore.skrivResultat(kontekstId1, ResultJson(failure = "en megaloman rabarbra".toJson()))
 
-            redisStore.lesResultat(transaksjonId1)?.failure shouldBe "en megaloman rabarbra".toJson()
-            redisStore.lesResultat(transaksjonId1)?.success.shouldBeNull()
+            redisStore.lesResultat(kontekstId1)?.failure shouldBe "en megaloman rabarbra".toJson()
+            redisStore.lesResultat(kontekstId1)?.success.shouldBeNull()
 
             // Har ikke blitt overskrevet
-            redisStore.lesAlleFeil(transaksjonId1) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
-            redisStore.lesAlleMellomlagrede(transaksjonId1) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
-            redisStore.lesResultat(transaksjonId2)?.failure shouldBe "rambutan".toJson()
+            redisStore.lesAlleFeil(kontekstId1) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
+            redisStore.lesAlleMellomlagrede(kontekstId1) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
+            redisStore.lesResultat(kontekstId2)?.failure shouldBe "rambutan".toJson()
         }
 
         test(RedisStore::skrivFeil.name) {
             val keyPrefix = RedisPrefix.InntektSelvbestemt
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
             val redisStore =
                 RedisStore(
@@ -287,32 +287,32 @@ class RedisStoreTest :
                         redisWithMockRedisClient(
                             mockStorageInit =
                                 mapOf(
-                                    "$keyPrefix#$transaksjonId" to "{\"success\":\"rabarbra\"}",
-                                    "$keyPrefix#$transaksjonId#${Key.FNR}" to "\"durian\"",
+                                    "$keyPrefix#$kontekstId" to "{\"success\":\"rabarbra\"}",
+                                    "$keyPrefix#$kontekstId#${Key.FNR}" to "\"durian\"",
                                 ),
                         ),
                     keyPrefix = keyPrefix,
                 )
 
-            redisStore.lesAlleFeil(transaksjonId).shouldBeEmpty()
+            redisStore.lesAlleFeil(kontekstId).shouldBeEmpty()
 
-            redisStore.skrivFeil(transaksjonId, Key.SAK_ID, "dragefrukt")
+            redisStore.skrivFeil(kontekstId, Key.SAK_ID, "dragefrukt")
 
-            redisStore.lesAlleFeil(transaksjonId) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
+            redisStore.lesAlleFeil(kontekstId) shouldContainExactly mapOf(Key.SAK_ID to "dragefrukt")
 
-            redisStore.skrivFeil(transaksjonId, Key.OPPGAVE_ID, "gojibær")
-            redisStore.skrivFeil(transaksjonId, Key.SPINN_INNTEKTSMELDING_ID, "jackfrukt")
+            redisStore.skrivFeil(kontekstId, Key.OPPGAVE_ID, "gojibær")
+            redisStore.skrivFeil(kontekstId, Key.SPINN_INNTEKTSMELDING_ID, "jackfrukt")
 
-            redisStore.lesAlleFeil(transaksjonId) shouldContainExactly
+            redisStore.lesAlleFeil(kontekstId) shouldContainExactly
                 mapOf(
                     Key.SAK_ID to "dragefrukt",
                     Key.OPPGAVE_ID to "gojibær",
                     Key.SPINN_INNTEKTSMELDING_ID to "jackfrukt",
                 )
 
-            redisStore.skrivFeil(transaksjonId, Key.SAK_ID, "et lass med dragefrukt")
+            redisStore.skrivFeil(kontekstId, Key.SAK_ID, "et lass med dragefrukt")
 
-            redisStore.lesAlleFeil(transaksjonId) shouldContainExactly
+            redisStore.lesAlleFeil(kontekstId) shouldContainExactly
                 mapOf(
                     Key.SAK_ID to "et lass med dragefrukt",
                     Key.OPPGAVE_ID to "gojibær",
@@ -322,7 +322,7 @@ class RedisStoreTest :
             redisStore.lesAlleFeil(UUID.randomUUID()).shouldBeEmpty()
 
             // Har ikke blitt overskrevet
-            redisStore.lesResultat(transaksjonId)?.success shouldBe "rabarbra".toJson()
-            redisStore.lesAlleMellomlagrede(transaksjonId) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
+            redisStore.lesResultat(kontekstId)?.success shouldBe "rabarbra".toJson()
+            redisStore.lesAlleMellomlagrede(kontekstId) shouldContainExactly mapOf(Key.FNR to "durian".toJson())
         }
     })

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiverStatefulTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/service/ServiceRiverStatefulTest.kt
@@ -71,7 +71,7 @@ class ServiceRiverStatefulTest :
         }
 
         test("datamelding håndteres korrekt") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
             val virksomhetNavn = "Fredrikssons Fabrikk"
 
             val eksisterendeRedisValues =
@@ -80,7 +80,7 @@ class ServiceRiverStatefulTest :
                     .plus(Key.PERSONER to "mock personer".toJson())
 
             eksisterendeRedisValues.forEach {
-                mockRedis.store.skrivMellomlagring(transaksjonId, it.key, it.value)
+                mockRedis.store.skrivMellomlagring(kontekstId, it.key, it.value)
             }
 
             val data =
@@ -91,7 +91,7 @@ class ServiceRiverStatefulTest :
             val innkommendeMelding =
                 mapOf(
                     Key.EVENT_NAME to mockService.eventName.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to data.toJson(),
                 )
 
@@ -100,8 +100,8 @@ class ServiceRiverStatefulTest :
             val beriketMelding = eksisterendeRedisValues + data + innkommendeMelding
 
             verifyOrder {
-                mockRedis.store.skrivMellomlagring(transaksjonId, Key.VIRKSOMHETER, virksomhetNavn.toJson())
-                mockRedis.store.lesAlleMellomlagrede(transaksjonId)
+                mockRedis.store.skrivMellomlagring(kontekstId, Key.VIRKSOMHETER, virksomhetNavn.toJson())
+                mockRedis.store.lesAlleMellomlagrede(kontekstId)
                 mockService.onData(beriketMelding)
             }
             verify(exactly = 0) {

--- a/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselbesvart/ForespoerselBesvartRiver.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 
 data class BesvartMelding(
     val notisType: Pri.NotisType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val spinnInntektsmeldingId: UUID?,
 )
@@ -35,7 +35,7 @@ class ForespoerselBesvartRiver : PriObjectRiver<BesvartMelding>() {
     override fun les(json: Map<Pri.Key, JsonElement>): BesvartMelding =
         BesvartMelding(
             notisType = Pri.Key.NOTIS.krev(Pri.NotisType.FORESPOERSEL_BESVART, Pri.NotisType.serializer(), json),
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             spinnInntektsmeldingId = Pri.Key.SPINN_INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, json),
         )
@@ -50,7 +50,7 @@ class ForespoerselBesvartRiver : PriObjectRiver<BesvartMelding>() {
 
         return mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSEL_BESVART.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -76,7 +76,7 @@ class ForespoerselBesvartRiver : PriObjectRiver<BesvartMelding>() {
         mapOf(
             Log.klasse(this@ForespoerselBesvartRiver),
             Log.priNotis(notisType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
+++ b/apps/forespoersel-forkastet/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselforkastet/ForespoerselForkastetRiver.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 
 data class ForkastetMelding(
     val notisType: Pri.NotisType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -31,7 +31,7 @@ class ForespoerselForkastetRiver : PriObjectRiver<ForkastetMelding>() {
     override fun les(json: Map<Pri.Key, JsonElement>): ForkastetMelding =
         ForkastetMelding(
             notisType = Pri.Key.NOTIS.krev(Pri.NotisType.FORESPOERSEL_FORKASTET, Pri.NotisType.serializer(), json),
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
 
@@ -46,7 +46,7 @@ class ForespoerselForkastetRiver : PriObjectRiver<ForkastetMelding>() {
 
         return mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSEL_FORKASTET.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
     }
@@ -67,7 +67,7 @@ class ForespoerselForkastetRiver : PriObjectRiver<ForkastetMelding>() {
         mapOf(
             Log.klasse(this@ForespoerselForkastetRiver),
             Log.priNotis(notisType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
+++ b/apps/forespoersel-infotrygd/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselinfotrygd/ForespoerselKastetTilInfotrygdRiver.kt
@@ -19,7 +19,7 @@ import java.util.UUID
 
 data class KastetTilInfotrygdMelding(
     val notisType: Pri.NotisType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -31,7 +31,7 @@ class ForespoerselKastetTilInfotrygdRiver : PriObjectRiver<KastetTilInfotrygdMel
     override fun les(json: Map<Pri.Key, JsonElement>): KastetTilInfotrygdMelding =
         KastetTilInfotrygdMelding(
             notisType = Pri.Key.NOTIS.krev(Pri.NotisType.FORESPOERSEL_KASTET_TIL_INFOTRYGD, Pri.NotisType.serializer(), json),
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
         )
 
@@ -43,7 +43,7 @@ class ForespoerselKastetTilInfotrygdRiver : PriObjectRiver<KastetTilInfotrygdMel
 
         return mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSEL_KASTET_TIL_INFOTRYGD.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
     }
@@ -65,7 +65,7 @@ class ForespoerselKastetTilInfotrygdRiver : PriObjectRiver<KastetTilInfotrygdMel
         mapOf(
             Log.klasse(this@ForespoerselKastetTilInfotrygdRiver),
             Log.priNotis(notisType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -21,7 +21,7 @@ import java.util.UUID
 
 data class Melding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -39,7 +39,7 @@ class MarkerForespoerselBesvartRiver(
 
             Melding(
                 eventName = Key.EVENT_NAME.krev(EventName.INNTEKTSMELDING_MOTTATT, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
             )
         }
@@ -79,7 +79,7 @@ class MarkerForespoerselBesvartRiver(
         mapOf(
             Log.klasse(this@MarkerForespoerselBesvartRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
+++ b/apps/forespoersel-mottatt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiver.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 
 data class Melding(
     val notisType: Pri.NotisType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val forespoerselFraBro: ForespoerselFraBro,
     val skalHaPaaminnelse: Boolean,
@@ -37,7 +37,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
     override fun les(json: Map<Pri.Key, JsonElement>): Melding =
         Melding(
             notisType = Pri.Key.NOTIS.krev(Pri.NotisType.FORESPØRSEL_MOTTATT, Pri.NotisType.serializer(), json),
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = Pri.Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             forespoerselFraBro = Pri.Key.FORESPOERSEL.les(ForespoerselFraBro.serializer(), json),
             skalHaPaaminnelse = Pri.Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), json),
@@ -51,7 +51,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
 
         return mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -77,7 +77,7 @@ class ForespoerselMottattRiver : PriObjectRiver<Melding>() {
         mapOf(
             Log.klasse(this@ForespoerselMottattRiver),
             Log.priNotis(notisType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/apps/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -64,7 +64,7 @@ class ForespoerselMottattRiverTest :
 private fun mockInnkommendeMelding(): Melding =
     Melding(
         notisType = Pri.NotisType.FORESPØRSEL_MOTTATT,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
         forespoerselFraBro = Mock.forespoerselFraBro,
         skalHaPaaminnelse = true,

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiver.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 data class ForespoerselSvarMelding(
     val eventName: EventName,
     val behovType: Pri.BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val forespoerselSvar: ForespoerselSvar,
 )
@@ -40,7 +40,7 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
         return ForespoerselSvarMelding(
             eventName = Key.EVENT_NAME.les(EventName.serializer(), boomerang),
             behovType = Pri.Key.BEHOV.krev(Pri.BehovType.TRENGER_FORESPØRSEL, Pri.BehovType.serializer(), json),
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, boomerang),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, boomerang),
             data = boomerang[Key.DATA]?.toMap().orEmpty(),
             forespoerselSvar = forespoerselSvar,
         )
@@ -57,7 +57,7 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
 
             mapOf(
                 Key.EVENT_NAME to eventName.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -94,12 +94,12 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
         val fail =
             Fail(
                 feilmelding = feilmelding,
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding =
                     mapOf(
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                        Key.KONTEKST_ID to transaksjonId.toJson(),
+                        Key.KONTEKST_ID to kontekstId.toJson(),
                         Key.DATA to data.toJson(),
                     ),
             )
@@ -115,7 +115,7 @@ class ForespoerselSvarRiver : PriObjectRiver<ForespoerselSvarMelding>() {
             Log.klasse(this@ForespoerselSvarRiver),
             Log.event(eventName),
             Log.behov(BehovType.HENT_TRENGER_IM),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselSvar.forespoerselId),
         )
 }

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 data class HentForespoerslerForVedtaksperiodeIdListeMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val vedtaksperiodeIdListe: List<UUID>,
 )
@@ -45,7 +45,7 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
             HentForespoerslerForVedtaksperiodeIdListeMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 vedtaksperiodeIdListe = Key.VEDTAKSPERIODE_ID_LISTE.les(UuidSerializer.list(), data),
             )
@@ -62,7 +62,7 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
                 Pri.Key.BOOMERANG to
                     mapOf(
                         Key.EVENT_NAME to eventName.toJson(),
-                        Key.KONTEKST_ID to transaksjonId.toJson(),
+                        Key.KONTEKST_ID to kontekstId.toJson(),
                         Key.DATA to data.toJson(),
                     ).toJson(),
             ).onSuccess {
@@ -83,7 +83,7 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke spørre Storebror om forespørsel for vedtaksperiode-IDer.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -98,6 +98,6 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
             Log.klasse(this@HentForespoerslerForVedtaksperiodeIdListeRiver),
             Log.event(eventName),
             Log.behov(BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
@@ -24,7 +24,7 @@ import java.util.UUID
 data class TrengerForespoerselMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val forespoerselId: UUID,
 )
@@ -44,7 +44,7 @@ class TrengerForespoerselRiver(
             TrengerForespoerselMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_TRENGER_IM, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
             )
@@ -60,7 +60,7 @@ class TrengerForespoerselRiver(
                 Pri.Key.BOOMERANG to
                     mapOf(
                         Key.EVENT_NAME to eventName.toJson(),
-                        Key.KONTEKST_ID to transaksjonId.toJson(),
+                        Key.KONTEKST_ID to kontekstId.toJson(),
                         Key.DATA to data.toJson(),
                     ).toJson(),
             ).onSuccess {
@@ -81,7 +81,7 @@ class TrengerForespoerselRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke spørre Storebror om forespørsel.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -96,7 +96,7 @@ class TrengerForespoerselRiver(
             Log.klasse(this@TrengerForespoerselRiver),
             Log.event(eventName),
             Log.behov(BehovType.HENT_TRENGER_IM),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiver.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 data class VedtaksperiodeIdForespoerselSvarMelding(
     val eventName: EventName,
     val behovType: Pri.BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val forespoerselSvar: ForespoerselListeSvar,
 )
@@ -41,7 +41,7 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
         return VedtaksperiodeIdForespoerselSvarMelding(
             eventName = Key.EVENT_NAME.les(EventName.serializer(), boomerang),
             behovType = Pri.Key.BEHOV.krev(Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE, Pri.BehovType.serializer(), json),
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, boomerang),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, boomerang),
             data = boomerang[Key.DATA]?.toMap().orEmpty(),
             forespoerselSvar = forespoerselSvar,
         )
@@ -59,7 +59,7 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
         return if (forespoerselSvar.feil == null) {
             mapOf(
                 Key.EVENT_NAME to eventName.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -81,12 +81,12 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente forespørsler for vedtaksperiode-IDer. Ukjent feil.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding =
                     mapOf(
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(),
-                        Key.KONTEKST_ID to transaksjonId.toJson(),
+                        Key.KONTEKST_ID to kontekstId.toJson(),
                         Key.DATA to data.toJson(),
                     ),
             )
@@ -102,7 +102,7 @@ class VedtaksperiodeIdForespoerselSvarRiver : PriObjectRiver<VedtaksperiodeIdFor
             Log.klasse(this@VedtaksperiodeIdForespoerselSvarRiver),
             Log.event(eventName),
             Log.behov(BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }
 

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/ForespoerselSvarRiverTest.kt
@@ -89,17 +89,17 @@ fun mockFail(forespoerselSvar: ForespoerselSvar): Fail {
     val boomerangMap = forespoerselSvar.boomerang.toMap()
 
     val eventName = Key.EVENT_NAME.les(EventName.serializer(), boomerangMap)
-    val transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
+    val kontekstId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
     val data = boomerangMap[Key.DATA]?.toMap().orEmpty()
 
     return Fail(
         feilmelding = feilmelding,
-        kontekstId = transaksjonId,
+        kontekstId = kontekstId,
         utloesendeMelding =
             mapOf(
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to data.toJson(),
             ),
     )

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiverTest.kt
@@ -30,14 +30,14 @@ class TrengerForespoerselRiverTest :
             every { mockPriProducer.send(*anyVararg<Pair<Pri.Key, JsonElement>>()) } returns Result.success(JsonNull)
 
             val expectedEvent = EventName.INNTEKT_REQUESTED
-            val expectedTransaksjonId = UUID.randomUUID()
+            val expectedKontekstId = UUID.randomUUID()
             val expectedForespoerselId = UUID.randomUUID()
             val journalpostId = "denne skal i boomerangen"
 
             testRapid.sendJson(
                 Key.EVENT_NAME to expectedEvent.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to expectedTransaksjonId.toJson(),
+                Key.KONTEKST_ID to expectedKontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to expectedForespoerselId.toJson(),
@@ -54,7 +54,7 @@ class TrengerForespoerselRiverTest :
                     Pri.Key.BOOMERANG to
                         mapOf(
                             Key.EVENT_NAME to expectedEvent.toJson(),
-                            Key.KONTEKST_ID to expectedTransaksjonId.toJson(),
+                            Key.KONTEKST_ID to expectedKontekstId.toJson(),
                             Key.DATA to
                                 mapOf(
                                     Key.FORESPOERSEL_ID to expectedForespoerselId.toJson(),

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselRiverTest.kt
@@ -31,13 +31,13 @@ class VedtaksperiodeIdForespoerselRiverTest :
             every { mockPriProducer.send(*anyVararg<Pair<Pri.Key, JsonElement>>()) } returns Result.success(JsonNull)
 
             val expectedEvent = EventName.FORESPOERSLER_REQUESTED
-            val expectedTransaksjonId = UUID.randomUUID()
+            val expectedKontekstId = UUID.randomUUID()
             val expectedVedtaksperiodeIdListe = listOf(UUID.randomUUID(), UUID.randomUUID())
 
             testRapid.sendJson(
                 Key.EVENT_NAME to expectedEvent.toJson(),
                 Key.BEHOV to BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(),
-                Key.KONTEKST_ID to expectedTransaksjonId.toJson(),
+                Key.KONTEKST_ID to expectedKontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.VEDTAKSPERIODE_ID_LISTE to expectedVedtaksperiodeIdListe.toJson(UuidSerializer),
@@ -53,7 +53,7 @@ class VedtaksperiodeIdForespoerselRiverTest :
                     Pri.Key.BOOMERANG to
                         mapOf(
                             Key.EVENT_NAME to expectedEvent.toJson(),
-                            Key.KONTEKST_ID to expectedTransaksjonId.toJson(),
+                            Key.KONTEKST_ID to expectedKontekstId.toJson(),
                             Key.DATA to
                                 mapOf(
                                     Key.VEDTAKSPERIODE_ID_LISTE to expectedVedtaksperiodeIdListe.toJson(UuidSerializer),

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/VedtaksperiodeIdForespoerselSvarRiverTest.kt
@@ -40,14 +40,14 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
 
             val boomerangMap = forespoerselListeSvarMock.boomerang.toMap()
             val eventName = Key.EVENT_NAME.les(EventName.serializer(), boomerangMap)
-            val transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
+            val kontekstId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
             val data = boomerangMap[Key.DATA]?.toMap().orEmpty()
             val forespoersler = forespoerselListeSvarMock.resultat.associate { it.forespoerselId to it.toForespoersel() }
 
             val forventetSvar =
                 mapOf(
                     Key.EVENT_NAME to eventName.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         data
                             .plus(
@@ -74,7 +74,7 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
             val boomerangMap = forespoerselListeSvarMock.boomerang.toMap()
 
             val eventName = Key.EVENT_NAME.les(EventName.serializer(), boomerangMap)
-            val transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
+            val kontekstId = Key.KONTEKST_ID.les(UuidSerializer, boomerangMap)
             val data = boomerangMap[Key.DATA]?.toMap().orEmpty()
 
             val feilmelding = "Klarte ikke hente forespørsler for vedtaksperiode-IDer. Ukjent feil."
@@ -82,12 +82,12 @@ class VedtaksperiodeIdForespoerselSvarRiverTest :
             val forventetSvar =
                 Fail(
                     feilmelding = feilmelding,
-                    kontekstId = transaksjonId,
+                    kontekstId = kontekstId,
                     utloesendeMelding =
                         mapOf(
                             Key.EVENT_NAME to eventName.toJson(),
                             Key.BEHOV to BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(),
-                            Key.KONTEKST_ID to transaksjonId.toJson(),
+                            Key.KONTEKST_ID to kontekstId.toJson(),
                             Key.DATA to data.toJson(),
                         ),
                 )

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -154,7 +154,7 @@ class InnsendingService(
         mapOf(
             Log.klasse(this@InnsendingService),
             Log.event(eventName),
-            Log.transaksjonId(kontekstId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(skjema.forespoerselId),
         )
 

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
@@ -48,7 +48,7 @@ class KvitteringService(
     override val eventName = EventName.KVITTERING_REQUESTED
 
     data class Steg0(
-        val transaksjonId: UUID,
+        val kontekstId: UUID,
         val forespoerselId: UUID,
     )
 
@@ -70,7 +70,7 @@ class KvitteringService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
         )
 
@@ -130,7 +130,7 @@ class KvitteringService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to steg0.forespoerselId.toJson(),
@@ -148,7 +148,7 @@ class KvitteringService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
@@ -161,7 +161,7 @@ class KvitteringService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
@@ -174,7 +174,7 @@ class KvitteringService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_LAGRET_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to KafkaKey(steg0.forespoerselId).toJson(),
@@ -207,7 +207,7 @@ class KvitteringService(
                         ).toJson(KvitteringResultat.serializer()),
                 )
 
-            redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+            redisStore.skrivResultat(steg0.kontekstId, resultJson)
         }
     }
 
@@ -218,7 +218,7 @@ class KvitteringService(
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             "Klarte ikke hente kvittering for forespørsel.".also {
                 logger.warn(it)
@@ -235,7 +235,7 @@ class KvitteringService(
         mapOf(
             Log.klasse(this@KvitteringService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
+++ b/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
@@ -29,7 +29,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val orgnr: Orgnr,
     val sykmeldtFnr: Fnr,
     val inntektsdato: LocalDate,
@@ -50,7 +50,7 @@ class InntektSelvbestemtService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             orgnr = Key.ORGNR_UNDERENHET.les(Orgnr.serializer(), melding),
             sykmeldtFnr = Key.FNR.les(Fnr.serializer(), melding),
             inntektsdato = Key.INNTEKTSDATO.les(LocalDateSerializer, melding),
@@ -70,7 +70,7 @@ class InntektSelvbestemtService(
                 key = steg0.sykmeldtFnr,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -103,7 +103,7 @@ class InntektSelvbestemtService(
                 success = steg1.inntekt.toJson(Inntekt.serializer()),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+        redisStore.skrivResultat(steg0.kontekstId, resultJson)
 
         sikkerLogger.info("$eventName fullført.")
     }
@@ -115,7 +115,7 @@ class InntektSelvbestemtService(
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             val feilmelding = Tekst.TEKNISK_FEIL_FORBIGAAENDE
             val resultJson = ResultJson(failure = feilmelding.toJson())
@@ -135,6 +135,6 @@ class InntektSelvbestemtService(
         mapOf(
             Log.klasse(this@InntektSelvbestemtService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
+++ b/apps/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
@@ -45,24 +45,24 @@ class InntektSelvbestemtServiceTest :
         }
 
         test("hent inntekt") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
             testRapid.sendJson(
-                Mock.melding(transaksjonId, Mock.steg0Data),
+                Mock.melding(kontekstId, Mock.steg0Data),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().lesBehov() shouldBe BehovType.HENT_INNTEKT
 
             testRapid.sendJson(
-                Mock.melding(transaksjonId, Mock.steg1Data),
+                Mock.melding(kontekstId, Mock.steg1Data),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
 
             verify {
                 mockRedisStore.skrivResultat(
-                    transaksjonId,
+                    kontekstId,
                     ResultJson(
                         success = Mock.inntekt.toJson(Inntekt.serializer()),
                     ),
@@ -121,12 +121,12 @@ private object Mock {
         )
 
     fun melding(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         data: Map<Key, JsonElement>,
     ): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 }

--- a/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
+++ b/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiver.kt
@@ -31,7 +31,7 @@ import java.util.UUID
 data class Melding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val orgnr: Orgnr,
@@ -54,7 +54,7 @@ class HentInntektRiver(
             Melding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_INNTEKT, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 orgnr = Key.ORGNR_UNDERENHET.les(Orgnr.serializer(), data),
@@ -70,7 +70,7 @@ class HentInntektRiver(
         val middle = inntektsdato.minusMaaneder(2)
         val tom = inntektsdato.minusMaaneder(1)
 
-        val inntektPerOrgnrOgMaaned = hentInntektPerOrgnrOgMaaned(fnr, fom, tom, transaksjonId)
+        val inntektPerOrgnrOgMaaned = hentInntektPerOrgnrOgMaaned(fnr, fom, tom, kontekstId)
 
         val inntektPerMaaned = inntektPerOrgnrOgMaaned[orgnr.verdi].orEmpty()
 
@@ -82,7 +82,7 @@ class HentInntektRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -98,7 +98,7 @@ class HentInntektRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente inntekt fra Inntektskomponenten.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -113,17 +113,17 @@ class HentInntektRiver(
             Log.klasse(this@HentInntektRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 
     private fun hentInntektPerOrgnrOgMaaned(
         fnr: Fnr,
         fom: YearMonth,
         tom: YearMonth,
-        transaksjonId: UUID,
+        kontekstId: UUID,
     ): Map<String, Map<YearMonth, Double>> {
         val navConsumerId = "helsearbeidsgiver-im-inntekt"
-        val callId = "$navConsumerId-$transaksjonId"
+        val callId = "$navConsumerId-$kontekstId"
 
         sikkerLogger.info("Henter inntekt for $fnr i perioden $fom til $tom (callId: $callId).")
 

--- a/apps/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
+++ b/apps/inntekt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/HentInntektRiverTest.kt
@@ -104,7 +104,7 @@ class HentInntektRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         innkommendeMelding.data
                             .plus(Key.INNTEKT to forventetInntekt.toJson(Inntekt.serializer()))
@@ -124,7 +124,7 @@ class HentInntektRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente inntekt fra Inntektskomponenten.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeMelding.toMap(),
                 )
 
@@ -172,7 +172,7 @@ private object Mock {
         return Melding(
             eventName = EventName.TRENGER_REQUESTED,
             behovType = BehovType.HENT_INNTEKT,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -191,7 +191,7 @@ private object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 

--- a/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -28,7 +28,7 @@ import java.time.LocalDate
 import java.util.UUID
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val skjaeringstidspunkt: LocalDate,
 )
@@ -52,7 +52,7 @@ class InntektService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
             skjaeringstidspunkt = Key.INNTEKTSDATO.les(LocalDateSerializer, melding),
         )
@@ -76,7 +76,7 @@ class InntektService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -101,7 +101,7 @@ class InntektService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -132,7 +132,7 @@ class InntektService(
                 success = steg2.inntekt.toJson(Inntekt.serializer()),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+        redisStore.skrivResultat(steg0.kontekstId, resultJson)
 
         sikkerLogger.info("$eventName fullført.")
     }
@@ -152,7 +152,7 @@ class InntektService(
         redisStore.skrivResultat(fail.kontekstId, resultJson)
 
         MdcUtils.withLogFields(
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             sikkerLogger.error("$eventName terminert.")
         }
@@ -162,7 +162,7 @@ class InntektService(
         mapOf(
             Log.klasse(this@InntektService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
@@ -57,7 +57,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
     @Test
     fun `Test hente aktive organisasjoner`() {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforholdListe
         coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
@@ -66,7 +66,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FNR to Mock.fnr.toJson(),
@@ -74,7 +74,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
                 ).toJson(),
         )
 
-        redisConnection.get(RedisPrefix.AktiveOrgnr, transaksjonId) shouldBe Mock.GYLDIG_AKTIVE_ORGNR_RESPONSE
+        redisConnection.get(RedisPrefix.AktiveOrgnr, kontekstId) shouldBe Mock.GYLDIG_AKTIVE_ORGNR_RESPONSE
 
         val aktiveOrgnrMeldinger = messages.filter(EventName.AKTIVE_ORGNR_REQUESTED)
 
@@ -138,7 +138,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
     @Test
     fun `ingen arbeidsforhold`() {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns emptyList()
         coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
@@ -147,7 +147,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FNR to Mock.fnr.toJson(),
@@ -155,7 +155,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
                 ).toJson(),
         )
 
-        redisConnection.get(RedisPrefix.AktiveOrgnr, transaksjonId)?.parseJson() shouldBe Mock.resultatIngenArbeidsforholdJson
+        redisConnection.get(RedisPrefix.AktiveOrgnr, kontekstId)?.parseJson() shouldBe Mock.resultatIngenArbeidsforholdJson
 
         val aktiveOrgnrMeldinger = messages.filter(EventName.AKTIVE_ORGNR_REQUESTED)
 
@@ -202,7 +202,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
     @Test
     fun `Ved feil under henting av personer så svarer service med feil`() {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforholdListe
         coEvery { altinnClient.hentRettighetOrganisasjoner(any()) } returns Mock.altinnOrganisasjonSet
@@ -213,12 +213,12 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
         val expectedFail =
             Fail(
                 feilmelding = "Klarte ikke hente personer fra PDL.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding =
                     mapOf(
                         Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
                         Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-                        Key.KONTEKST_ID to transaksjonId.toJson(),
+                        Key.KONTEKST_ID to kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.SVAR_KAFKA_KEY to KafkaKey(Mock.fnr).toJson(),
@@ -233,7 +233,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FNR to Mock.fnr.toJson(),
@@ -243,7 +243,7 @@ class AktiveOrgnrServiceIT : EndToEndTest() {
 
         val response =
             redisConnection
-                .get(RedisPrefix.AktiveOrgnr, transaksjonId)
+                .get(RedisPrefix.AktiveOrgnr, kontekstId)
                 ?.fromJson(ResultJson.serializer())
                 .shouldNotBeNull()
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -75,7 +75,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
-            Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+            Key.KONTEKST_ID to Mock.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to Mock.fnrAg.toJson(),
@@ -90,7 +90,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.FORESPOERSEL_SVAR)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -102,7 +102,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.VIRKSOMHETER)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -114,7 +114,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -126,7 +126,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.PERSONER)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -142,7 +142,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         messages
             .filter(EventName.INNTEKTSMELDING_MOTTATT)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselId()
             .also {
                 shouldNotThrowAny {
@@ -196,7 +196,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.INNTEKTSMELDING_SKJEMA_LAGRET.toJson(),
-            Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+            Key.KONTEKST_ID to Mock.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to Mock.fnrAg.toJson(),
@@ -211,7 +211,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.FORESPOERSEL_SVAR)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -223,7 +223,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.VIRKSOMHETER)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -241,13 +241,13 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         messages.filterFeil().all().size shouldBe 1
 
         // Det blir satt opp en bakgrunnsjobb som kan gjenoppta berikelsen senere
-        val bakgrunnsjobb = bakgrunnsjobbRepository.getById(Mock.transaksjonId)
+        val bakgrunnsjobb = bakgrunnsjobbRepository.getById(Mock.kontekstId)
 
         bakgrunnsjobb.also {
             it.shouldNotBeNull()
             it.data.parseJson().also { data ->
                 data.lesBehov() shouldBe BehovType.HENT_PERSONER
-                data.toMap().verifiserForespoerselId().verifiserTransaksjonId(Mock.transaksjonId)
+                data.toMap().verifiserForespoerselId().verifiserKontekstId(Mock.kontekstId)
             }
         }
 
@@ -259,7 +259,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .filter(Key.PERSONER)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -275,7 +275,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
         messages
             .filter(EventName.INNTEKTSMELDING_MOTTATT)
             .firstAsMap()
-            .verifiserTransaksjonId(Mock.transaksjonId)
+            .verifiserKontekstId(Mock.kontekstId)
             .verifiserForespoerselId()
             .also {
                 shouldNotThrowAny {
@@ -296,9 +296,9 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
             }
     }
 
-    private fun Map<Key, JsonElement>.verifiserTransaksjonId(transaksjonId: UUID): Map<Key, JsonElement> =
+    private fun Map<Key, JsonElement>.verifiserKontekstId(kontekstId: UUID): Map<Key, JsonElement> =
         also {
-            Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
+            Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe kontekstId
         }
 
     private fun Map<Key, JsonElement>.verifiserForespoerselId(): Map<Key, JsonElement> =
@@ -318,7 +318,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
     private object Mock {
         val fnrAg = Fnr.genererGyldig()
         val orgnr = Orgnr.genererGyldig()
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val mottatt = 19.august.kl(19, 5, 0, 0)
 
         val skjema = mockSkjemaInntektsmelding()

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerselIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerselIT.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 class HentForespoerselIT : EndToEndTest() {
     @Test
     fun `forespørsel hentes`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val forespoerselId: UUID = UUID.randomUUID()
 
         mockForespoerselSvarFraHelsebro(
@@ -37,7 +37,7 @@ class HentForespoerselIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(UuidSerializer),
+            Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(UuidSerializer),
@@ -50,7 +50,7 @@ class HentForespoerselIT : EndToEndTest() {
             .filter(BehovType.HENT_TRENGER_IM)
             .firstAsMap()
             .let {
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
             }
 
         messages
@@ -58,7 +58,7 @@ class HentForespoerselIT : EndToEndTest() {
             .filter(BehovType.HENT_VIRKSOMHET_NAVN)
             .firstAsMap()
             .let {
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
             }
 
         messages
@@ -66,7 +66,7 @@ class HentForespoerselIT : EndToEndTest() {
             .filter(BehovType.HENT_PERSONER)
             .firstAsMap()
             .let {
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
             }
 
         messages
@@ -74,12 +74,12 @@ class HentForespoerselIT : EndToEndTest() {
             .filter(BehovType.HENT_INNTEKT)
             .firstAsMap()
             .let {
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
             }
 
         val resultJson =
             redisConnection
-                .get(RedisPrefix.HentForespoersel, transaksjonId)
+                .get(RedisPrefix.HentForespoersel, kontekstId)
                 ?.fromJson(ResultJson.serializer())
                 .shouldNotBeNull()
 
@@ -99,7 +99,7 @@ class HentForespoerselIT : EndToEndTest() {
 
     @Test
     fun `dersom forespørsel ikke blir funnet så settes sak og oppgave til utgått`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val forespoerselId: UUID = UUID.randomUUID()
 
         mockForespoerselSvarFraHelsebro(
@@ -109,7 +109,7 @@ class HentForespoerselIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(UuidSerializer),
+            Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(UuidSerializer),
@@ -122,20 +122,20 @@ class HentForespoerselIT : EndToEndTest() {
             .filter(BehovType.HENT_TRENGER_IM)
             .firstAsMap()
             .let {
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe kontekstId
             }
 
         messages
             .filter(EventName.SAK_OG_OPPGAVE_UTGAATT)
             .firstAsMap()
             .let {
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe kontekstId
                 Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, it) shouldBe forespoerselId
             }
 
         val resultJson =
             redisConnection
-                .get(RedisPrefix.HentForespoersel, transaksjonId)
+                .get(RedisPrefix.HentForespoersel, kontekstId)
                 ?.fromJson(ResultJson.serializer())
                 .shouldNotBeNull()
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerslerForVedtaksperiodeIdListeIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerslerForVedtaksperiodeIdListeIT.kt
@@ -25,7 +25,7 @@ import java.util.UUID
 class HentForespoerslerForVedtaksperiodeIdListeIT : EndToEndTest() {
     @Test
     fun `Test meldingsflyt for henting av forespørsler for liste av vedtaksperiode-IDer`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val vedtaksperiodeId1 = UUID.randomUUID()
         val vedtaksperiodeId2 = UUID.randomUUID()
 
@@ -39,7 +39,7 @@ class HentForespoerslerForVedtaksperiodeIdListeIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(UuidSerializer),
+            Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
             Key.DATA to
                 mapOf(
                     Key.VEDTAKSPERIODE_ID_LISTE to listOf(vedtaksperiodeId1, vedtaksperiodeId2).toJson(UuidSerializer),
@@ -52,7 +52,7 @@ class HentForespoerslerForVedtaksperiodeIdListeIT : EndToEndTest() {
             .filter(BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE)
             .firstAsMap()
             .let {
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
             }
 
         // Forespørsler hentet
@@ -61,8 +61,8 @@ class HentForespoerslerForVedtaksperiodeIdListeIT : EndToEndTest() {
             .filter(Key.FORESPOERSEL_MAP)
             .firstAsMap()
             .let {
-                // Verifiser transaksjon-ID
-                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe transaksjonId
+                // Verifiser kontekst-ID
+                it[Key.KONTEKST_ID]?.fromJson(UuidSerializer) shouldBe kontekstId
 
                 // Verifiser forespoersler
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -72,7 +72,7 @@ class HentForespoerslerForVedtaksperiodeIdListeIT : EndToEndTest() {
         // API besvart gjennom redis
         val resultJson =
             redisConnection
-                .get(RedisPrefix.HentForespoerslerForVedtaksperiodeIdListe, transaksjonId)
+                .get(RedisPrefix.HentForespoerslerForVedtaksperiodeIdListe, kontekstId)
                 ?.fromJson(ResultJson.serializer())
                 .shouldNotBeNull()
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentSelvbestemtIT.kt
@@ -36,7 +36,7 @@ class HentSelvbestemtIT : EndToEndTest() {
 
     @Test
     fun `selvbestemt inntektsmelding hentes`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val inntektsmelding =
             mockInntektsmeldingV1().copy(
                 type =
@@ -49,7 +49,7 @@ class HentSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(UuidSerializer),
+            Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
             Key.DATA to
                 mapOf(
                     Key.SELVBESTEMT_ID to inntektsmelding.type.id.toJson(UuidSerializer),
@@ -65,7 +65,7 @@ class HentSelvbestemtIT : EndToEndTest() {
             .filter(BehovType.HENT_SELVBESTEMT_IM)
             .firstAsMap()
             .let { msg ->
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe kontekstId
 
                 val data = msg[Key.DATA].shouldNotBeNull().toMap()
                 Key.SELVBESTEMT_ID.lesOrNull(UuidSerializer, data) shouldBe inntektsmelding.type.id
@@ -77,7 +77,7 @@ class HentSelvbestemtIT : EndToEndTest() {
             .filter(Key.SELVBESTEMT_INNTEKTSMELDING)
             .firstAsMap()
             .let { msg ->
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe kontekstId
 
                 val data = msg[Key.DATA].shouldNotBeNull().toMap()
                 Key.SELVBESTEMT_ID.lesOrNull(UuidSerializer, data) shouldBe inntektsmelding.type.id
@@ -87,7 +87,7 @@ class HentSelvbestemtIT : EndToEndTest() {
         // Funnet inntektsmelding legges i Redis
         val redisResponse =
             redisConnection
-                .get(RedisPrefix.HentSelvbestemtIm, transaksjonId)
+                .get(RedisPrefix.HentSelvbestemtIm, kontekstId)
                 .shouldNotBeNull()
                 .fromJson(ResultJson.serializer())
 
@@ -97,7 +97,7 @@ class HentSelvbestemtIT : EndToEndTest() {
 
     @Test
     fun `selvbestemt inntektsmelding finnes ikke`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val inntektsmelding =
             mockInntektsmeldingV1().copy(
                 type =
@@ -108,7 +108,7 @@ class HentSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(UuidSerializer),
+            Key.KONTEKST_ID to kontekstId.toJson(UuidSerializer),
             Key.DATA to
                 mapOf(
                     Key.SELVBESTEMT_ID to inntektsmelding.type.id.toJson(UuidSerializer),
@@ -124,7 +124,7 @@ class HentSelvbestemtIT : EndToEndTest() {
             .filter(BehovType.HENT_SELVBESTEMT_IM)
             .firstAsMap()
             .let { msg ->
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, msg) shouldBe kontekstId
 
                 val data = msg[Key.DATA].shouldNotBeNull().toMap()
                 Key.SELVBESTEMT_ID.lesOrNull(UuidSerializer, data) shouldBe inntektsmelding.type.id
@@ -137,14 +137,14 @@ class HentSelvbestemtIT : EndToEndTest() {
             .let {
                 val fail = Key.FAIL.lesOrNull(Fail.serializer(), it).shouldNotBeNull()
 
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, fail.utloesendeMelding) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, fail.utloesendeMelding) shouldBe kontekstId
                 Key.BEHOV.lesOrNull(BehovType.serializer(), fail.utloesendeMelding) shouldBe BehovType.HENT_SELVBESTEMT_IM
             }
 
         // Funnet feilmelding legges i Redis
         val redisResponse =
             redisConnection
-                .get(RedisPrefix.HentSelvbestemtIm, transaksjonId)
+                .get(RedisPrefix.HentSelvbestemtIm, kontekstId)
                 .shouldNotBeNull()
                 .fromJson(ResultJson.serializer())
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -43,7 +43,7 @@ import java.util.UUID
 class InnsendingServiceIT : EndToEndTest() {
     @Test
     fun `Test at innsending er mottatt`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val tidligereInntektsmelding = mockInntektsmelding()
 
         val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema, 9.desember.atStartOfDay())
@@ -79,7 +79,7 @@ class InnsendingServiceIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.INSENDING_STARTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to Mock.skjema.forespoerselId.toJson(),
@@ -94,7 +94,7 @@ class InnsendingServiceIT : EndToEndTest() {
             .filter(EventName.INSENDING_STARTED)
             .filter(Key.FORESPOERSEL_SVAR)
             .firstAsMap()
-            .verifiserTransaksjonId(transaksjonId)
+            .verifiserKontekstId(kontekstId)
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
                 data[Key.FORESPOERSEL_SVAR]?.fromJson(Forespoersel.serializer()) shouldBe Mock.forespoerselSvar.toForespoersel()
@@ -105,7 +105,7 @@ class InnsendingServiceIT : EndToEndTest() {
             .filter(EventName.INSENDING_STARTED)
             .filter(Key.ER_DUPLIKAT_IM)
             .firstAsMap()
-            .verifiserTransaksjonId(transaksjonId)
+            .verifiserKontekstId(kontekstId)
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
                 data[Key.ER_DUPLIKAT_IM]?.fromJson(Boolean.serializer()) shouldBe false
@@ -115,7 +115,7 @@ class InnsendingServiceIT : EndToEndTest() {
         messages
             .filter(EventName.INNTEKTSMELDING_SKJEMA_LAGRET)
             .firstAsMap()
-            .verifiserTransaksjonId(transaksjonId)
+            .verifiserKontekstId(kontekstId)
             .verifiserForespoerselIdFraSkjema()
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
@@ -145,7 +145,7 @@ class InnsendingServiceIT : EndToEndTest() {
         // API besvart gjennom redis
         shouldNotThrowAny {
             redisConnection
-                .get(RedisPrefix.Innsending, transaksjonId)
+                .get(RedisPrefix.Innsending, kontekstId)
                 .shouldNotBeNull()
                 .fromJson(ResultJson.serializer())
                 .success
@@ -154,9 +154,9 @@ class InnsendingServiceIT : EndToEndTest() {
         }
     }
 
-    private fun Map<Key, JsonElement>.verifiserTransaksjonId(transaksjonId: UUID): Map<Key, JsonElement> =
+    private fun Map<Key, JsonElement>.verifiserKontekstId(kontekstId: UUID): Map<Key, JsonElement> =
         also {
-            Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
+            Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe kontekstId
         }
 
     private fun Map<Key, JsonElement>.verifiserForespoerselIdFraSkjema(): Map<Key, JsonElement> =

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InntektSelvbestemtIT.kt
@@ -31,7 +31,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
-            Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+            Key.KONTEKST_ID to Mock.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FNR to Mock.fnr.toJson(),
@@ -47,7 +47,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
                     Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
-                    Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to Mock.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SVAR_KAFKA_KEY to KafkaKey(Mock.fnr).toJson(),
@@ -64,7 +64,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
             .shouldContainExactly(
                 mapOf(
                     Key.EVENT_NAME to EventName.INNTEKT_SELVBESTEMT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to Mock.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SVAR_KAFKA_KEY to KafkaKey(Mock.fnr).toJson(),
@@ -81,7 +81,7 @@ class InntektSelvbestemtIT : EndToEndTest() {
         val fnr = Fnr.genererGyldig()
         val orgnr = Orgnr.genererGyldig()
         val inntektsdato = 15.juli(2019)
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
 
         val inntektPerOrgnrOgMaaned =
             mapOf(

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -30,7 +30,7 @@ class KvitteringIT : EndToEndTest() {
 
     @Test
     fun `skal hente data til kvittering`() {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
         val skjema = mockSkjemaInntektsmelding()
 
         mockForespoerselSvarFraHelsebro(
@@ -46,7 +46,7 @@ class KvitteringIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to skjema.forespoerselId.toJson(),
@@ -68,12 +68,12 @@ class KvitteringIT : EndToEndTest() {
                 data[Key.EKSTERN_INNTEKTSMELDING] shouldBe Mock.tomResultJson
             }
 
-        redisConnection.get(RedisPrefix.Kvittering, transaksjonId).shouldNotBeNull()
+        redisConnection.get(RedisPrefix.Kvittering, kontekstId).shouldNotBeNull()
     }
 
     @Test
     fun `skal hente data til kvittering hvis fra eksternt system`() {
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
         val forespoerselId = UUID.randomUUID()
 
         mockForespoerselSvarFraHelsebro(
@@ -88,7 +88,7 @@ class KvitteringIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -112,13 +112,13 @@ class KvitteringIT : EndToEndTest() {
                 eIm shouldNotBe Mock.tomResultJson
             }
 
-        redisConnection.get(RedisPrefix.Kvittering, transaksjonId).shouldNotBeNull()
+        redisConnection.get(RedisPrefix.Kvittering, kontekstId).shouldNotBeNull()
     }
 
     @Test
     fun `skal gi feilmelding når forespørsel ikke finnes`() {
         val forespoerselId = UUID.randomUUID()
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
 
         mockForespoerselSvarFraHelsebro(
             forespoerselId = forespoerselId,
@@ -130,7 +130,7 @@ class KvitteringIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -64,7 +64,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
     @Test
     fun `inntektsmelding lagres og prosesseres`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
         val nyInntektsmelding =
             Mock.inntektsmelding.copy(
                 type =
@@ -88,7 +88,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to Mock.avsenderFnr.toJson(),
@@ -178,22 +178,22 @@ class LagreSelvbestemtIT : EndToEndTest() {
         messages
             .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, nyInntektsmelding, compareType = false)
 
         messages
             .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, nyInntektsmelding, compareType = false)
 
         messages
             .filter(EventName.INNTEKTSMELDING_DISTRIBUERT)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, nyInntektsmelding, compareType = false)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, nyInntektsmelding, compareType = false)
     }
 
     @Test
     fun `endret inntektsmelding lagres og prosesseres, men uten opprettelse av sak`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
 
         coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Mock.virksomhet)
         coEvery { pdlKlient.personBolk(any()) } returns Mock.personer
@@ -208,7 +208,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to Mock.avsenderFnr.toJson(),
@@ -253,22 +253,22 @@ class LagreSelvbestemtIT : EndToEndTest() {
         messages
             .filter(EventName.INNTEKTSMELDING_JOURNALFOERT)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, Mock.inntektsmelding, compareType = true)
 
         messages
             .filter(EventName.INNTEKTSMELDING_JOURNALPOST_ID_LAGRET)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, Mock.inntektsmelding, compareType = true)
 
         messages
             .filter(EventName.INNTEKTSMELDING_DISTRIBUERT)
             .firstAsMap()
-            .shouldContainNokTilJournalfoeringOgDistribusjon(transaksjonId, Mock.inntektsmelding, compareType = true)
+            .shouldContainNokTilJournalfoeringOgDistribusjon(kontekstId, Mock.inntektsmelding, compareType = true)
     }
 
     @Test
     fun `duplikat, endret inntektsmelding lagres, men prosesseres ikke`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
 
         selvbestemtImRepo.lagreIm(Mock.inntektsmelding)
 
@@ -278,7 +278,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
 
         publish(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.ARBEIDSGIVER_FNR to Mock.avsenderFnr.toJson(),
@@ -351,13 +351,13 @@ class LagreSelvbestemtIT : EndToEndTest() {
     }
 
     private fun Map<Key, JsonElement>.shouldContainNokTilJournalfoeringOgDistribusjon(
-        transaksjonId: UUID,
+        kontekstId: UUID,
         inntektsmelding: Inntektsmelding,
         compareType: Boolean,
     ) {
         this shouldContainAll
             mapOf(
-                Key.KONTEKST_ID to transaksjonId.toJson(),
+                Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.JOURNALPOST_ID to Mock.journalpostId.toJson(),
             )
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/TilgangskontrollIT.kt
@@ -39,7 +39,7 @@ class TilgangskontrollIT : EndToEndTest() {
 
     @Test
     fun `forespoersel - skal få tilgang`() {
-        val transaksjonId: UUID = UUID.randomUUID()
+        val kontekstId: UUID = UUID.randomUUID()
 
         mockForespoerselSvarFraHelsebro(
             forespoerselId = Mock.forespoerselId,
@@ -50,14 +50,14 @@ class TilgangskontrollIT : EndToEndTest() {
                 ),
         )
 
-        tilgangProducer.publishForespoerselId(transaksjonId, Mock.innloggetFnr, Mock.forespoerselId)
+        tilgangProducer.publishForespoerselId(kontekstId, Mock.innloggetFnr, Mock.forespoerselId)
 
         messages
             .filter(EventName.TILGANG_FORESPOERSEL_REQUESTED)
             .filter(BehovType.HENT_TRENGER_IM)
             .firstAsMap()
             .also {
-                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe transaksjonId
+                Key.KONTEKST_ID.lesOrNull(UuidSerializer, it) shouldBe kontekstId
 
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
                 Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data) shouldBe Mock.forespoerselId

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -356,8 +356,8 @@ abstract class EndToEndTest : ContainerTest() {
 
     fun RedisConnection.get(
         prefix: RedisPrefix,
-        transaksjonId: UUID,
-    ): String? = get("$prefix#$transaksjonId")
+        kontekstId: UUID,
+    ): String? = get("$prefix#$kontekstId")
 
     fun truncateDatabase() {
         transaction(inntektsmeldingDatabase.db) {

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -73,7 +73,7 @@ class JournalfoerImRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
                         Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
@@ -94,8 +94,8 @@ class JournalfoerImRiverTest :
                                 it shouldHaveSize 1
                                 it.first().dokumentVarianter.map(DokumentVariant::filtype) shouldContainExactly listOf("XML", "PDFA")
                             },
-                        eksternReferanseId = "ARI-${innkommendeMelding.transaksjonId}",
-                        callId = "callId_${innkommendeMelding.transaksjonId}",
+                        eksternReferanseId = "ARI-${innkommendeMelding.kontekstId}",
+                        callId = "callId_${innkommendeMelding.kontekstId}",
                     )
                 }
             }
@@ -118,7 +118,7 @@ class JournalfoerImRiverTest :
                 testRapid.firstMessage().toMap() shouldContainExactly
                     mapOf(
                         Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                         Key.JOURNALPOST_ID to journalpostId.toJson(),
                         Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
                     )
@@ -138,8 +138,8 @@ class JournalfoerImRiverTest :
                                 it shouldHaveSize 1
                                 it.first().dokumentVarianter.map(DokumentVariant::filtype) shouldContainExactly listOf("XML", "PDFA")
                             },
-                        eksternReferanseId = "ARI-${innkommendeMelding.transaksjonId}",
-                        callId = "callId_${innkommendeMelding.transaksjonId}",
+                        eksternReferanseId = "ARI-${innkommendeMelding.kontekstId}",
+                        callId = "callId_${innkommendeMelding.kontekstId}",
                     )
                 }
             }
@@ -157,7 +157,7 @@ class JournalfoerImRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke journalføre.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeJsonMap,
                 )
 
@@ -208,14 +208,14 @@ private object Mock {
     ): JournalfoerImMelding =
         JournalfoerImMelding(
             eventName = eventName,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             inntektsmelding = inntektsmelding,
         )
 
     fun JournalfoerImMelding.toMap(imKey: Key = Key.INNTEKTSMELDING): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     imKey to inntektsmelding.toJson(Inntektsmelding.serializer()),

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseService.kt
@@ -1,7 +1,6 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -32,7 +31,7 @@ class HentDataTilPaaminnelseService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
         )
 
@@ -59,7 +58,7 @@ class HentDataTilPaaminnelseService(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -77,7 +76,7 @@ class HentDataTilPaaminnelseService(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -105,7 +104,7 @@ class HentDataTilPaaminnelseService(
         rapid.publish(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to steg0.forespoerselId.toJson(),
@@ -119,7 +118,7 @@ class HentDataTilPaaminnelseService(
         mapOf(
             Log.klasse(this@HentDataTilPaaminnelseService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 
@@ -134,7 +133,7 @@ class HentDataTilPaaminnelseService(
     }
 
     data class Steg0(
-        val transaksjonId: UUID,
+        val kontekstId: UUID,
         val forespoerselId: UUID,
     )
 

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveService.kt
@@ -26,7 +26,7 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.util.UUID
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val forespoersel: Forespoersel,
     val skalHaPaaminnelse: Boolean,
@@ -50,7 +50,7 @@ class HentDataTilSakOgOppgaveService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
             forespoersel = Key.FORESPOERSEL.les(Forespoersel.serializer(), melding),
             skalHaPaaminnelse = Key.SKAL_HA_PAAMINNELSE.les(Boolean.serializer(), melding),
@@ -79,7 +79,7 @@ class HentDataTilSakOgOppgaveService(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -100,7 +100,7 @@ class HentDataTilSakOgOppgaveService(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -129,7 +129,7 @@ class HentDataTilSakOgOppgaveService(
         rapid.publish(
             key = steg0.forespoerselId,
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to steg0.forespoerselId.toJson(),
@@ -145,7 +145,7 @@ class HentDataTilSakOgOppgaveService(
         mapOf(
             Log.klasse(this@HentDataTilSakOgOppgaveService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiver.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 
 data class EndrePaaminnelseMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val forespoersel: Forespoersel,
     val orgNavn: String,
@@ -48,7 +48,7 @@ class EndrePaaminnelseRiver(
 
             EndrePaaminnelseMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 forespoersel = Key.FORESPOERSEL.les(Forespoersel.serializer(), data),
                 orgNavn = Key.VIRKSOMHET.les(String.serializer(), data),
@@ -75,7 +75,7 @@ class EndrePaaminnelseRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke endre påminnelse på oppgave.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -89,7 +89,7 @@ class EndrePaaminnelseRiver(
         mapOf(
             Log.klasse(this@EndrePaaminnelseRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiver.kt
@@ -23,7 +23,7 @@ import java.util.UUID
 
 data class FerdigstillForespoerselSakMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -47,7 +47,7 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
             } else {
                 FerdigstillForespoerselSakMelding(
                     eventName = eventName,
-                    transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                    kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                     forespoerselId = Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, json) ?: Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 )
             }
@@ -63,7 +63,7 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_FERDIGSTILT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
     }
@@ -75,7 +75,7 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke ferdigstille sak og/eller oppgave for forespurt inntektmelding.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -89,7 +89,7 @@ class FerdigstillForespoerselSakOgOppgaveRiver(
         mapOf(
             Log.klasse(this@FerdigstillForespoerselSakOgOppgaveRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiver.kt
@@ -22,7 +22,7 @@ import java.util.UUID
 
 data class FjernPaaminnelseMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -39,7 +39,7 @@ class FjernPaaminnelseRiver(
         } else {
             FjernPaaminnelseMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.FORESPOERSEL_KASTET_TIL_INFOTRYGD, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, json),
             )
         }
@@ -60,7 +60,7 @@ class FjernPaaminnelseRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke fjerne påminnelse fra oppgave.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -74,7 +74,7 @@ class FjernPaaminnelseRiver(
         mapOf(
             Log.klasse(this@FjernPaaminnelseRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 
 data class OpprettForespoerselSakOgOppgaveMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val forespoersel: Forespoersel,
     val sykmeldt: Person,
@@ -51,7 +51,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
 
             OpprettForespoerselSakOgOppgaveMelding(
                 eventName = Key.EVENT_NAME.krev(EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED, EventName.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, data),
                 forespoersel = Key.FORESPOERSEL.les(Forespoersel.serializer(), data),
                 sykmeldt = Key.SYKMELDT.les(Person.serializer(), data),
@@ -88,7 +88,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETTET.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -105,7 +105,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke opprette sak og/eller oppgave for forespurt inntektmelding.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -119,7 +119,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
         mapOf(
             Log.klasse(this@OpprettForespoerselSakOgOppgaveRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 data class OpprettSelvbestemtSakMelding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val inntektsmelding: Inntektsmelding,
 )
@@ -48,7 +48,7 @@ class OpprettSelvbestemtSakRiver(
             OpprettSelvbestemtSakMelding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.OPPRETT_SELVBESTEMT_SAK, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 inntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
             )
@@ -69,7 +69,7 @@ class OpprettSelvbestemtSakRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -85,7 +85,7 @@ class OpprettSelvbestemtSakRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke lagre sak for selvbestemt inntektsmelding.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -100,7 +100,7 @@ class OpprettSelvbestemtSakRiver(
             Log.klasse(this@OpprettSelvbestemtSakRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.selvbestemtId(inntektsmelding.type.id),
         )
 }

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
@@ -26,7 +26,7 @@ import java.util.UUID
 
 data class UtgaattForespoerselMelding(
     val eventName: EventName,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
 )
 
@@ -47,7 +47,7 @@ class UtgaattForespoerselRiver(
                 // Forespørsler som ble forkastet nylig matcher her
                 UtgaattForespoerselMelding(
                     eventName = Key.EVENT_NAME.krev(EventName.FORESPOERSEL_FORKASTET, EventName.serializer(), json),
-                    transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                    kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                     forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, json),
                 )
             } else {
@@ -87,7 +87,7 @@ class UtgaattForespoerselRiver(
 
         return mapOf(
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_UTGAATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
     }
@@ -99,7 +99,7 @@ class UtgaattForespoerselRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke sette oppgave til utgått og/eller avbryte sak for forespurt inntektmelding.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -113,7 +113,7 @@ class UtgaattForespoerselRiver(
         mapOf(
             Log.klasse(this@UtgaattForespoerselRiver),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseServiceTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilPaaminnelseServiceTest.kt
@@ -54,7 +54,7 @@ class HentDataTilPaaminnelseServiceTest :
             testRapid.message(2).toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to HentDataTilPaaminnelseServiceMock.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to HentDataTilPaaminnelseServiceMock.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to HentDataTilPaaminnelseServiceMock.forespoerselId.toJson(),
@@ -88,14 +88,14 @@ class HentDataTilPaaminnelseServiceTest :
 
 private object HentDataTilPaaminnelseServiceMock {
     val forespoersel = mockForespoersel()
-    val transaksjonId: UUID = forespoersel.vedtaksperiodeId
+    val kontekstId: UUID = forespoersel.vedtaksperiodeId
     val forespoerselId: UUID = UUID.randomUUID()
     val orgnrMedNavn = mapOf(forespoersel.orgnr to "Kåre Conradis Kål og Kålrabi")
 
     fun steg0(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.MANUELL_ENDRE_PAAMINNELSE.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveServiceTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/HentDataTilSakOgOppgaveServiceTest.kt
@@ -57,7 +57,7 @@ class HentDataTilSakOgOppgaveServiceTest :
             testRapid.message(2).toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED.toJson(),
-                    Key.KONTEKST_ID to Mock.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to Mock.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to Mock.forespoerselId.toJson(),
@@ -97,7 +97,7 @@ class HentDataTilSakOgOppgaveServiceTest :
 private object Mock {
     const val SKAL_HA_PAAMINNELSE = true
     val forespoersel = mockForespoersel()
-    val transaksjonId: UUID = forespoersel.vedtaksperiodeId
+    val kontekstId: UUID = forespoersel.vedtaksperiodeId
     val forespoerselId: UUID = UUID.randomUUID()
     val orgnrMedNavn = mapOf(forespoersel.orgnr to "Kåre Conradis Kål og Kålrabi")
     val personer = listOf(forespoersel.fnr).associateWith { Person(it, "Kåre Conradi") }
@@ -105,7 +105,7 @@ private object Mock {
     fun steg0(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSEL_MOTTATT.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/EndrePaaminnelseRiverTest.kt
@@ -147,14 +147,14 @@ object EndrePaaminnelseMock {
 private fun forventetFail(innkommendeMelding: EndrePaaminnelseMelding): Fail =
     Fail(
         feilmelding = "Klarte ikke endre påminnelse på oppgave.",
-        kontekstId = innkommendeMelding.transaksjonId,
+        kontekstId = innkommendeMelding.kontekstId,
         utloesendeMelding = innkommendeMelding.toMap(),
     )
 
 private fun EndrePaaminnelseMelding.toMap() =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to
             mapOf(
                 Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -166,7 +166,7 @@ private fun EndrePaaminnelseMelding.toMap() =
 fun innkommendeEndrePaaminnelseMelding(): EndrePaaminnelseMelding =
     EndrePaaminnelseMelding(
         eventName = EventName.OPPGAVE_ENDRE_PAAMINNELSE_REQUESTED,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
         forespoersel = EndrePaaminnelseMock.forespoersel,
         orgNavn = EndrePaaminnelseMock.orgNavn,

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
@@ -281,27 +281,27 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 private fun innkommendeMelding(): FerdigstillForespoerselSakMelding =
     FerdigstillForespoerselSakMelding(
         eventName = EventName.FORESPOERSEL_BESVART,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
     )
 
 private fun forventetUtgaaendeMelding(innkommendeMelding: FerdigstillForespoerselSakMelding): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_FERDIGSTILT.toJson(),
-        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
         Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
     )
 
 private fun forventetFail(innkommendeMelding: FerdigstillForespoerselSakMelding): Fail =
     Fail(
         feilmelding = "Klarte ikke ferdigstille sak og/eller oppgave for forespurt inntektmelding.",
-        kontekstId = innkommendeMelding.transaksjonId,
+        kontekstId = innkommendeMelding.kontekstId,
         utloesendeMelding = innkommendeMelding.toMap(),
     )
 
 private fun FerdigstillForespoerselSakMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.FORESPOERSEL_ID to forespoerselId.toJson(),
     )

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FjernPaaminnelseRiverTest.kt
@@ -130,20 +130,20 @@ class FjernPaaminnelseRiverTest :
 private fun forventetFail(innkommendeMelding: FjernPaaminnelseMelding): Fail =
     Fail(
         feilmelding = "Klarte ikke fjerne påminnelse fra oppgave.",
-        kontekstId = innkommendeMelding.transaksjonId,
+        kontekstId = innkommendeMelding.kontekstId,
         utloesendeMelding = innkommendeMelding.toMap(),
     )
 
 private fun FjernPaaminnelseMelding.toMap() =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.FORESPOERSEL_ID to forespoerselId.toJson(),
     )
 
 fun innkommendeFjernPaaminnelseMelding(): FjernPaaminnelseMelding =
     FjernPaaminnelseMelding(
         eventName = EventName.FORESPOERSEL_KASTET_TIL_INFOTRYGD,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
     )

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
@@ -255,7 +255,7 @@ fun innkommendeOpprettForespoerselSakOgOppgaveMelding(): OpprettForespoerselSakO
     val forespoersel = mockForespoersel()
     return OpprettForespoerselSakOgOppgaveMelding(
         eventName = EventName.SAK_OG_OPPGAVE_OPPRETT_REQUESTED,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         forespoerselId = UUID.randomUUID(),
         sykmeldt = Person(forespoersel.fnr, "Peer Gynt"),
         orgNavn = "Peer Gynts Løgn og Bedrageri LTD",
@@ -267,7 +267,7 @@ fun innkommendeOpprettForespoerselSakOgOppgaveMelding(): OpprettForespoerselSakO
 private fun OpprettForespoerselSakOgOppgaveMelding.toMap() =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to
             mapOf(
                 Key.FORESPOERSEL_ID to forespoerselId.toJson(),
@@ -285,7 +285,7 @@ private fun forventetUtgaaendeMelding(
 ): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_OPPRETTET.toJson(),
-        Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
         Key.DATA to
             mapOf(
                 Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
@@ -297,6 +297,6 @@ private fun forventetUtgaaendeMelding(
 private fun forventetFail(innkommendeMelding: OpprettForespoerselSakOgOppgaveMelding): Fail =
     Fail(
         feilmelding = "Klarte ikke opprette sak og/eller oppgave for forespurt inntektmelding.",
-        kontekstId = innkommendeMelding.transaksjonId,
+        kontekstId = innkommendeMelding.kontekstId,
         utloesendeMelding = innkommendeMelding.toMap(),
     )

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
@@ -55,7 +55,7 @@ class OpprettSelvbestemtSakRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -97,7 +97,7 @@ class OpprettSelvbestemtSakRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly
                 mapOf(
                     Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-                    Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+                    Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.SELVBESTEMT_INNTEKTSMELDING to innkommendeMelding.inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -158,7 +158,7 @@ private fun innkommendeMelding(): OpprettSelvbestemtSakMelding {
     return OpprettSelvbestemtSakMelding(
         eventName = EventName.SELVBESTEMT_IM_MOTTATT,
         behovType = BehovType.OPPRETT_SELVBESTEMT_SAK,
-        transaksjonId = UUID.randomUUID(),
+        kontekstId = UUID.randomUUID(),
         data =
             mapOf(
                 Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -171,14 +171,14 @@ private fun OpprettSelvbestemtSakMelding.toMap(): Map<Key, JsonElement> =
     mapOf(
         Key.EVENT_NAME to eventName.toJson(),
         Key.BEHOV to behovType.toJson(),
-        Key.KONTEKST_ID to transaksjonId.toJson(),
+        Key.KONTEKST_ID to kontekstId.toJson(),
         Key.DATA to data.toJson(),
     )
 
 private fun OpprettSelvbestemtSakMelding.toFail(): Fail =
     Fail(
         feilmelding = "Klarte ikke lagre sak for selvbestemt inntektsmelding.",
-        kontekstId = transaksjonId,
+        kontekstId = kontekstId,
         utloesendeMelding = toMap(),
     )
 

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
@@ -322,44 +322,44 @@ private object Mock {
     fun innkommendeMelding(): UtgaattForespoerselMelding =
         UtgaattForespoerselMelding(
             eventName = EventName.FORESPOERSEL_FORKASTET,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             forespoerselId = UUID.randomUUID(),
         )
 
     fun UtgaattForespoerselMelding.toMap(): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.FORESPOERSEL_ID to forespoerselId.toJson(),
         )
 
     fun forventetUtgaaendeMelding(innkommendeMelding: UtgaattForespoerselMelding): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.SAK_OG_OPPGAVE_UTGAATT.toJson(),
-            Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+            Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
             Key.FORESPOERSEL_ID to innkommendeMelding.forespoerselId.toJson(),
         )
 
     fun forventetFail(innkommendeMelding: UtgaattForespoerselMelding): Fail =
         Fail(
             feilmelding = "Klarte ikke sette oppgave til utgått og/eller avbryte sak for forespurt inntektmelding.",
-            kontekstId = innkommendeMelding.transaksjonId,
+            kontekstId = innkommendeMelding.kontekstId,
             utloesendeMelding = innkommendeMelding.toMap(),
         )
 
     fun forespoerselIkkeFunnetFail(): Fail {
         val eventName = EventName.TRENGER_REQUESTED
-        val transaksjonId = UUID.randomUUID()
+        val kontekstId = UUID.randomUUID()
         val forespoerselId = UUID.randomUUID()
 
         return Fail(
             feilmelding = "Klarte ikke hente forespørsel. Feilet med kode 'FORESPOERSEL_IKKE_FUNNET'.",
-            kontekstId = transaksjonId,
+            kontekstId = kontekstId,
             utloesendeMelding =
                 mapOf(
                     Key.EVENT_NAME to eventName.toJson(),
                     Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                    Key.KONTEKST_ID to transaksjonId.toJson(),
+                    Key.KONTEKST_ID to kontekstId.toJson(),
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to forespoerselId.toJson(),

--- a/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
+++ b/apps/pdl/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiver.kt
@@ -27,7 +27,7 @@ import java.util.UUID
 data class Melding(
     val eventName: EventName,
     val behovType: BehovType,
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val svarKafkaKey: KafkaKey,
     val fnrListe: Set<Fnr>,
@@ -48,7 +48,7 @@ class HentPersonerRiver(
             Melding(
                 eventName = Key.EVENT_NAME.les(EventName.serializer(), json),
                 behovType = Key.BEHOV.krev(BehovType.HENT_PERSONER, BehovType.serializer(), json),
-                transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, json),
+                kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 svarKafkaKey = Key.SVAR_KAFKA_KEY.les(KafkaKey.serializer(), data),
                 fnrListe = Key.FNR_LISTE.les(Fnr.serializer().set(), data),
@@ -74,7 +74,7 @@ class HentPersonerRiver(
 
         return mapOf(
             Key.EVENT_NAME to eventName.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 data
                     .plus(
@@ -90,7 +90,7 @@ class HentPersonerRiver(
         val fail =
             Fail(
                 feilmelding = "Klarte ikke hente personer fra PDL.",
-                kontekstId = transaksjonId,
+                kontekstId = kontekstId,
                 utloesendeMelding = json,
             )
 
@@ -105,7 +105,7 @@ class HentPersonerRiver(
             Log.klasse(this@HentPersonerRiver),
             Log.event(eventName),
             Log.behov(behovType),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 
     private fun hentPersoner(fnrListe: Set<Fnr>): List<Person> =

--- a/apps/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
+++ b/apps/pdl/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/pdl/HentPersonerRiverTest.kt
@@ -131,7 +131,7 @@ class HentPersonerRiverTest :
             val forventetFail =
                 Fail(
                     feilmelding = "Klarte ikke hente personer fra PDL.",
-                    kontekstId = innkommendeMelding.transaksjonId,
+                    kontekstId = innkommendeMelding.kontekstId,
                     utloesendeMelding = innkommendeJsonMap,
                 )
 
@@ -181,7 +181,7 @@ private object Mock {
         return Melding(
             eventName = EventName.TRENGER_REQUESTED,
             behovType = BehovType.HENT_PERSONER,
-            transaksjonId = UUID.randomUUID(),
+            kontekstId = UUID.randomUUID(),
             data =
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -196,7 +196,7 @@ private object Mock {
         mapOf(
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to behovType.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to data.toJson(),
         )
 
@@ -206,7 +206,7 @@ private object Mock {
     ): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to innkommendeMelding.eventName.toJson(),
-            Key.KONTEKST_ID to innkommendeMelding.transaksjonId.toJson(),
+            Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
             Key.DATA to
                 innkommendeMelding.data
                     .plus(

--- a/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
+++ b/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
@@ -23,7 +23,7 @@ import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val selvbestemtId: UUID,
 )
 
@@ -42,7 +42,7 @@ class HentSelvbestemtImService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             selvbestemtId = Key.SELVBESTEMT_ID.les(UuidSerializer, melding),
         )
 
@@ -60,7 +60,7 @@ class HentSelvbestemtImService(
                 key = steg0.selvbestemtId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_SELVBESTEMT_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -88,7 +88,7 @@ class HentSelvbestemtImService(
                 success = steg1.inntektsmelding.toJson(Inntektsmelding.serializer()),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+        redisStore.skrivResultat(steg0.kontekstId, resultJson)
     }
 
     override fun onError(
@@ -103,7 +103,7 @@ class HentSelvbestemtImService(
         mapOf(
             Log.klasse(this@HentSelvbestemtImService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.selvbestemtId(selvbestemtId),
         )
 }

--- a/apps/selvbestemt-hent-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-hent-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImServiceTest.kt
@@ -40,24 +40,24 @@ class HentSelvbestemtImServiceTest :
         }
 
         test("hent inntektsmelding") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
             testRapid.sendJson(
-                Mock.startMelding(transaksjonId),
+                Mock.startMelding(kontekstId),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.firstMessage().lesBehov() shouldBe BehovType.HENT_SELVBESTEMT_IM
 
             testRapid.sendJson(
-                Mock.dataMelding(transaksjonId),
+                Mock.dataMelding(kontekstId),
             )
 
             testRapid.inspektør.size shouldBeExactly 1
 
             verify {
                 mockRedisStore.skrivResultat(
-                    transaksjonId,
+                    kontekstId,
                     ResultJson(
                         success = Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
                     ),
@@ -97,20 +97,20 @@ private object Mock {
     private val selvbestemtId: UUID = UUID.randomUUID()
     val inntektsmelding = mockInntektsmeldingV1()
 
-    fun startMelding(transaksjonId: UUID): Map<Key, JsonElement> =
+    fun startMelding(kontekstId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.SELVBESTEMT_ID to selvbestemtId.toJson(),
                 ).toJson(),
         )
 
-    fun dataMelding(transaksjonId: UUID): Map<Key, JsonElement> =
+    fun dataMelding(kontekstId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.SELVBESTEMT_IM_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.SELVBESTEMT_ID to selvbestemtId.toJson(),

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -42,7 +42,7 @@ import java.time.LocalDateTime
 import java.util.UUID
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val skjema: SkjemaInntektsmeldingSelvbestemt,
     val avsenderFnr: Fnr,
     val mottatt: LocalDateTime,
@@ -80,7 +80,7 @@ class LagreSelvbestemtImService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmeldingSelvbestemt.serializer(), melding),
             avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), melding),
             mottatt = Key.MOTTATT.les(LocalDateTimeSerializer, melding),
@@ -136,7 +136,7 @@ class LagreSelvbestemtImService(
             key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -148,7 +148,7 @@ class LagreSelvbestemtImService(
             key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -164,7 +164,7 @@ class LagreSelvbestemtImService(
             key = steg0.skjema.sykmeldtFnr,
             Key.EVENT_NAME to eventName.toJson(),
             Key.BEHOV to BehovType.HENT_ARBEIDSFORHOLD.toJson(),
-            Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+            Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -207,7 +207,7 @@ class LagreSelvbestemtImService(
                         key = inntektsmelding.type.id,
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.LAGRE_SELVBESTEMT_IM.toJson(),
-                        Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -221,7 +221,7 @@ class LagreSelvbestemtImService(
                     logger.warn(feilmelding)
                     sikkerLogger.warn(feilmelding)
                     val resultJson = ResultJson(failure = feilmelding.toJson())
-                    redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+                    redisStore.skrivResultat(steg0.kontekstId, resultJson)
                 }
             }
         }
@@ -244,7 +244,7 @@ class LagreSelvbestemtImService(
                         key = steg2.inntektsmelding.type.id,
                         Key.EVENT_NAME to eventName.toJson(),
                         Key.BEHOV to BehovType.OPPRETT_SELVBESTEMT_SAK.toJson(),
-                        Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -273,14 +273,14 @@ class LagreSelvbestemtImService(
                         steg2.inntektsmelding.type.id
                             .toJson(),
                 )
-            redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+            redisStore.skrivResultat(steg0.kontekstId, resultJson)
 
             if (!steg2.erDuplikat) {
                 val publisert =
                     rapid.publish(
                         key = steg2.inntektsmelding.type.id,
                         Key.EVENT_NAME to EventName.SELVBESTEMT_IM_LAGRET.toJson(),
-                        Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                        Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                         Key.DATA to
                             mapOf(
                                 Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
@@ -304,7 +304,7 @@ class LagreSelvbestemtImService(
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             val utloesendeBehov = Key.BEHOV.lesOrNull(BehovType.serializer(), fail.utloesendeMelding)
             val datafeil =
@@ -353,7 +353,7 @@ class LagreSelvbestemtImService(
         mapOf(
             Log.klasse(this@LagreSelvbestemtImService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }
 

--- a/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
+++ b/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
@@ -39,7 +39,7 @@ class TilgangForespoerselService(
     override val eventName = EventName.TILGANG_FORESPOERSEL_REQUESTED
 
     data class Steg0(
-        val transaksjonId: UUID,
+        val kontekstId: UUID,
         val forespoerselId: UUID,
         val avsenderFnr: Fnr,
     )
@@ -54,7 +54,7 @@ class TilgangForespoerselService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
             avsenderFnr = Key.FNR.les(Fnr.serializer(), melding),
         )
@@ -78,7 +78,7 @@ class TilgangForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -103,7 +103,7 @@ class TilgangForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -132,7 +132,7 @@ class TilgangForespoerselService(
                 success = steg2.tilgang.toJson(Tilgang.serializer()),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, tilgang)
+        redisStore.skrivResultat(steg0.kontekstId, tilgang)
 
         sikkerLogger.info("$eventName fullført.")
     }
@@ -144,7 +144,7 @@ class TilgangForespoerselService(
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             val tilgangResultat =
                 ResultJson(
@@ -161,7 +161,7 @@ class TilgangForespoerselService(
         mapOf(
             Log.klasse(this@TilgangForespoerselService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 }

--- a/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
+++ b/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
@@ -35,7 +35,7 @@ class TilgangOrgService(
     override val eventName = EventName.TILGANG_ORG_REQUESTED
 
     data class Steg0(
-        val transaksjonId: UUID,
+        val kontekstId: UUID,
         val orgnr: Orgnr,
         val fnr: Fnr,
     )
@@ -46,7 +46,7 @@ class TilgangOrgService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             orgnr = Key.ORGNR_UNDERENHET.les(Orgnr.serializer(), melding),
             fnr = Key.FNR.les(Fnr.serializer(), melding),
         )
@@ -65,7 +65,7 @@ class TilgangOrgService(
                 key = steg0.fnr,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.TILGANGSKONTROLL.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     data
                         .plus(
@@ -93,7 +93,7 @@ class TilgangOrgService(
                 success = steg1.tilgang.toJson(Tilgang.serializer()),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, resultat)
+        redisStore.skrivResultat(steg0.kontekstId, resultat)
 
         sikkerLogger.info("$eventName fullført.")
     }
@@ -105,7 +105,7 @@ class TilgangOrgService(
         MdcUtils.withLogFields(
             Log.klasse(this),
             Log.event(eventName),
-            Log.transaksjonId(fail.kontekstId),
+            Log.kontekstId(fail.kontekstId),
         ) {
             val resultat =
                 ResultJson(
@@ -122,6 +122,6 @@ class TilgangOrgService(
         mapOf(
             Log.klasse(this@TilgangOrgService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 }

--- a/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
+++ b/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
@@ -1,7 +1,6 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.trengerservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -40,7 +39,7 @@ private const val UKJENT_NAVN = "Ukjent navn"
 private const val UKJENT_VIRKSOMHET = "Ukjent virksomhet"
 
 data class Steg0(
-    val transaksjonId: UUID,
+    val kontekstId: UUID,
     val forespoerselId: UUID,
     val avsenderFnr: Fnr,
 )
@@ -71,7 +70,7 @@ class HentForespoerselService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             forespoerselId = Key.FORESPOERSEL_ID.les(UuidSerializer, melding),
             avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), melding),
         )
@@ -113,7 +112,7 @@ class HentForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_TRENGER_IM.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.FORESPOERSEL_ID to steg0.forespoerselId.toJson(),
@@ -134,7 +133,7 @@ class HentForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -147,7 +146,7 @@ class HentForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_PERSONER.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -164,7 +163,7 @@ class HentForespoerselService(
                 key = steg0.forespoerselId,
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_INNTEKT.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
@@ -186,7 +185,7 @@ class HentForespoerselService(
             val avsenderNavn = steg2.personer[steg0.avsenderFnr]?.navn ?: UKJENT_NAVN
             val orgNavn = steg2.orgnrMedNavn[steg1.forespoersel.orgnr] ?: UKJENT_VIRKSOMHET
 
-            val feil = redisStore.lesAlleFeil(steg0.transaksjonId)
+            val feil = redisStore.lesAlleFeil(steg0.kontekstId)
 
             val resultJson =
                 ResultJson(
@@ -201,7 +200,7 @@ class HentForespoerselService(
                         ).toJson(HentForespoerselResultat.serializer()),
                 )
 
-            redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+            redisStore.skrivResultat(steg0.kontekstId, resultJson)
         }
     }
 
@@ -265,7 +264,7 @@ class HentForespoerselService(
         mapOf(
             Log.klasse(this@HentForespoerselService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
             Log.forespoerselId(forespoerselId),
         )
 

--- a/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
+++ b/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
@@ -35,7 +35,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
     override val eventName = EventName.FORESPOERSLER_REQUESTED
 
     data class Steg0(
-        val transaksjonId: UUID,
+        val kontekstId: UUID,
         val vedtaksperiodeIdListe: List<UUID>,
     )
 
@@ -45,7 +45,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
 
     override fun lesSteg0(melding: Map<Key, JsonElement>): Steg0 =
         Steg0(
-            transaksjonId = Key.KONTEKST_ID.les(UuidSerializer, melding),
+            kontekstId = Key.KONTEKST_ID.les(UuidSerializer, melding),
             vedtaksperiodeIdListe = Key.VEDTAKSPERIODE_ID_LISTE.les(UuidSerializer.list(), melding),
         )
 
@@ -63,7 +63,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
                 key = UUID.randomUUID(),
                 Key.EVENT_NAME to eventName.toJson(),
                 Key.BEHOV to BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE.toJson(),
-                Key.KONTEKST_ID to steg0.transaksjonId.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
                         Key.VEDTAKSPERIODE_ID_LISTE to steg0.vedtaksperiodeIdListe.toJson(UuidSerializer),
@@ -81,7 +81,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
                 success = steg1.forespoersler.toJson(MapSerializer(UuidSerializer, Forespoersel.serializer())),
             )
 
-        redisStore.skrivResultat(steg0.transaksjonId, resultJson)
+        redisStore.skrivResultat(steg0.kontekstId, resultJson)
     }
 
     override fun onError(
@@ -102,7 +102,7 @@ class HentForespoerslerForVedtaksperiodeIdListeService(
         mapOf(
             Log.klasse(this@HentForespoerslerForVedtaksperiodeIdListeService),
             Log.event(eventName),
-            Log.transaksjonId(transaksjonId),
+            Log.kontekstId(kontekstId),
         )
 
     private fun loggBehovPublisert(

--- a/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeServiceTest.kt
+++ b/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeServiceTest.kt
@@ -43,20 +43,20 @@ class HentForespoerslerForVedtaksperiodeIdListeServiceTest :
         }
 
         test("forespørsler hentes og svar sendes ut på redis") {
-            val transaksjonId = UUID.randomUUID()
+            val kontekstId = UUID.randomUUID()
 
-            testRapid.sendJson(MockHent.steg0(transaksjonId))
+            testRapid.sendJson(MockHent.steg0(kontekstId))
 
             testRapid.inspektør.size shouldBeExactly 1
             testRapid.message(0).lesBehov() shouldBe BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE
 
-            testRapid.sendJson(MockHent.steg1(transaksjonId))
+            testRapid.sendJson(MockHent.steg1(kontekstId))
 
             testRapid.inspektør.size shouldBeExactly 1
 
             verify {
                 mockRedisStore.skrivResultat(
-                    transaksjonId,
+                    kontekstId,
                     ResultJson(
                         success = forespoersler.toJson(MapSerializer(UuidSerializer, Forespoersel.serializer())),
                     ),
@@ -102,20 +102,20 @@ private object MockHent {
             forespoerselId2 to mockForespoersel().copy(vedtaksperiodeId = vedtaksperiodeId2),
         )
 
-    fun steg0(transaksjonId: UUID): Map<Key, JsonElement> =
+    fun steg0(kontekstId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.VEDTAKSPERIODE_ID_LISTE to vedtaksperiodeIdListe.toJson(UuidSerializer),
                 ).toJson(),
         )
 
-    fun steg1(transaksjonId: UUID): Map<Key, JsonElement> =
+    fun steg1(kontekstId: UUID): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.FORESPOERSLER_REQUESTED.toJson(),
-            Key.KONTEKST_ID to transaksjonId.toJson(),
+            Key.KONTEKST_ID to kontekstId.toJson(),
             Key.DATA to
                 mapOf(
                     Key.VEDTAKSPERIODE_ID_LISTE to vedtaksperiodeIdListe.toJson(UuidSerializer),

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-# Plugin versions
+# Plugin  versions
 kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 kotlin.code.style=official
 
-# Plugin  versions
+# Plugin versions
 kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 


### PR DESCRIPTION
Tenkte først at dette kunne gjøres litt om litt, etterhvert som man rørte på ulike filer, men da synes jeg alltid at diffen var forstyrrende for den faktiske hensikten til PR-en. Det blir dermed en giga-PR med alle linjer på en gang.

Det er ikke brukt find-and-replace her, men heller renaming-funksjonen for variabel-/funksjonsnavn. I tillegg er et håndfull kommentarer endret manuelt. Funksjonelt sett er det ingen endringer.