### PR TITLE
Enabler auditlog på databaser

### DIFF
--- a/apps/db/build.gradle.kts
+++ b/apps/db/build.gradle.kts
@@ -1,5 +1,4 @@
 dependencies {
     implementation(project(":felles-db-exposed"))
-
     testImplementation(testFixtures(project(":felles-db-exposed")))
 }

--- a/apps/feil-behandler/build.gradle.kts
+++ b/apps/feil-behandler/build.gradle.kts
@@ -11,6 +11,5 @@ dependencies {
     implementation("no.nav.helsearbeidsgiver:hag-bakgrunnsjobb:$bakgrunnsjobbVersion")
 
     runtimeOnly("org.postgresql:postgresql:$postgresqlVersion")
-
     testImplementation("org.testcontainers:postgresql:$testcontainersPostgresqlVersion")
 }

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -71,8 +71,12 @@ spec:
             users:
               - name: {{ database.user }}
             {{/if}}
-        {{#if database.logicalDecoding}}
         flags:
+          - name: cloudsql.enable_pgaudit
+            value: "true"
+          - name: pgaudit.log
+            value: 'write'
+        {{#if database.logicalDecoding}}
           - name: cloudsql.logical_decoding
             value: "on"
         {{/if}}


### PR DESCRIPTION
Enabler flagget i både dev og prod pga litt tuklete konfig. 
Det vil uansett også måtte enables manuelt av Nais-teamet i tillegg til disse flaggene, 
og det vil ikke være noe problem om det evt skrus på i dev også, uansett.
Måtte også touche noen filer i respektive apper, for å trigge deploy. 
