### PR TITLE
Flere begrunnelser v1 - Oppdatert IM modell og PDF støtte

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -22,4 +22,7 @@ dependencies {
     testImplementation("io.ktor:ktor-client-core:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
+
+    //  midlertidlig for flere endringsaarsaker
+    testImplementation("io.kotest:kotest-assertions-json:5.8.0")
 }

--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -22,7 +22,4 @@ dependencies {
     testImplementation("io.ktor:ktor-client-core:$ktorVersion")
     testImplementation("io.ktor:ktor-server-test-host:$ktorVersion")
     testImplementation("no.nav.security:mock-oauth2-server:$mockOauth2ServerVersion")
-
-    //  midlertidlig for flere endringsaarsaker
-    testImplementation("io.kotest:kotest-assertions-json:5.8.0")
 }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -95,19 +95,6 @@ fun Route.innsending(
     }
 }
 
-// // midlertidlig duplisering for å støtte flere endringsÅrsaker
-// fun SkjemaInntektsmelding.fyllUtMangledeEndringsAarsaker(): SkjemaInntektsmelding {
-//    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
-//    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
-//    return if (verdiMangler) medEndringsAarsakerfyllt else this
-// }
-//
-// fun Inntektsmelding.fyllUtMangledeEndringsAarsaker(): Inntektsmelding {
-//    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
-//    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
-//    return if (verdiMangler) medEndringsAarsakerfyllt else this
-// }
-
 private suspend fun PipelineContext<Unit, ApplicationCall>.lesRequestOrNull(): SkjemaInntektsmelding? =
     call
         .receiveText()

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -15,7 +15,7 @@ import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.utils.fyllUtMangledeEndringsAarsaker
+import no.nav.helsearbeidsgiver.felles.utils.konverterEndringAarsakTilListe
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.Tilgangskontroll
@@ -119,7 +119,7 @@ private suspend fun PipelineContext<Unit, ApplicationCall>.lesRequestOrNull(): S
                         sikkerLogger.info("$it\n${json.toPretty()}")
                     }
                 }.fromJson(SkjemaInntektsmelding.serializer())
-                .fyllUtMangledeEndringsAarsaker()
+                .konverterEndringAarsakTilListe()
         }.getOrElse { error ->
             "Klarte ikke parse json for inntektsmeldingsskjema.".also {
                 logger.error(it)

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -79,8 +79,6 @@ class HentSelvbestemtImRouteKtTest : ApiTest() {
 
             val actualJson = response.bodyAsText()
 
-            println("expected vs actual json:")
-            println(actualJson)
             println(Mock.successResponseJson(expectedInntektsmelding))
 
             assertSoftly {

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -1,7 +1,5 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api.hentselvbestemtim
 
-import io.kotest.assertions.assertSoftly
-import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.ktor.client.statement.bodyAsText
@@ -78,12 +76,6 @@ class HentSelvbestemtImRouteKtTest : ApiTest() {
             val response = get(pathMedId)
 
             val actualJson = response.bodyAsText()
-
-            println(Mock.successResponseJson(expectedInntektsmelding))
-
-            assertSoftly {
-                actualJson shouldEqualJson Mock.successResponseJson(expectedInntektsmelding)
-            }
 
             response.status shouldBe HttpStatusCode.OK
             actualJson shouldBe Mock.successResponseJson(expectedInntektsmelding)

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -1,5 +1,7 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api.hentselvbestemtim
 
+import io.kotest.assertions.assertSoftly
+import io.kotest.assertions.json.shouldEqualJson
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldBeEmpty
 import io.ktor.client.statement.bodyAsText
@@ -76,6 +78,14 @@ class HentSelvbestemtImRouteKtTest : ApiTest() {
             val response = get(pathMedId)
 
             val actualJson = response.bodyAsText()
+
+            println("expected vs actual json:")
+            println(actualJson)
+            println(Mock.successResponseJson(expectedInntektsmelding))
+
+            assertSoftly {
+                actualJson shouldEqualJson Mock.successResponseJson(expectedInntektsmelding)
+            }
 
             response.status shouldBe HttpStatusCode.OK
             actualJson shouldBe Mock.successResponseJson(expectedInntektsmelding)
@@ -318,7 +328,8 @@ private fun Inntekt.hardcodedJson(): String =
         "beloep": $beloep,
         "inntektsdato": "$inntektsdato",
         "naturalytelser": [${naturalytelser.joinToString(transform = Naturalytelse::hardcodedJson)}],
-        "endringAarsak": ${endringAarsak?.hardcodedJson()}
+        "endringAarsak": ${endringAarsak?.hardcodedJson()},
+        "endringAarsaker": [${endringAarsak?.hardcodedJson()}]
     }
     """
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
@@ -1,0 +1,25 @@
+package no.nav.helsearbeidsgiver.felles.utils
+
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
+
+// midlertidlig duplisering for å støtte flere endringsÅrsaker
+fun SkjemaInntektsmelding.fyllUtMangledeEndringsAarsaker(): SkjemaInntektsmelding {
+    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
+    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
+    return if (verdiMangler) medEndringsAarsakerfyllt else this
+}
+
+fun Inntektsmelding.fyllUtMangledeEndringsAarsaker(): Inntektsmelding {
+    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
+    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
+    return if (verdiMangler) medEndringsAarsakerfyllt else this
+}
+
+// fun LagretInntektsmelding.fyllUtMangledeEndringsAarsaker(): LagretInntektsmelding {
+//
+//
+//    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
+//    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
+//    return if (verdiMangler) medEndringsAarsakerfyllt else this
+// }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.felles.utils
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 
 // midlertidlig duplisering for å støtte flere endringsÅrsaker
@@ -11,8 +10,7 @@ fun SkjemaInntektsmelding.konverterEndringAarsakTilListe(): SkjemaInntektsmeldin
         this.copy(
             inntekt =
                 this.inntekt?.copy(
-                    endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak, Bonus),
-                    endringAarsak = null,
+                    endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak),
                 ),
         )
     }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
@@ -1,25 +1,17 @@
 package no.nav.helsearbeidsgiver.felles.utils
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 
 // midlertidlig duplisering for å støtte flere endringsÅrsaker
-fun SkjemaInntektsmelding.fyllUtMangledeEndringsAarsaker(): SkjemaInntektsmelding {
-    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
-    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
-    return if (verdiMangler) medEndringsAarsakerfyllt else this
-}
-
-fun Inntektsmelding.fyllUtMangledeEndringsAarsaker(): Inntektsmelding {
-    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
-    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
-    return if (verdiMangler) medEndringsAarsakerfyllt else this
-}
-
-// fun LagretInntektsmelding.fyllUtMangledeEndringsAarsaker(): LagretInntektsmelding {
-//
-//
-//    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
-//    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
-//    return if (verdiMangler) medEndringsAarsakerfyllt else this
-// }
+fun SkjemaInntektsmelding.konverterEndringAarsakTilListe(): SkjemaInntektsmelding =
+    if (this.inntekt?.endringAarsaker != null) {
+        this
+    } else {
+        this.copy(
+            inntekt =
+                this.inntekt?.copy(
+                    endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak),
+                    endringAarsak = null,
+                ),
+        )
+    }

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
@@ -1,5 +1,6 @@
 package no.nav.helsearbeidsgiver.felles.utils
 
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 
 // midlertidlig duplisering for å støtte flere endringsÅrsaker
@@ -10,7 +11,7 @@ fun SkjemaInntektsmelding.konverterEndringAarsakTilListe(): SkjemaInntektsmeldin
         this.copy(
             inntekt =
                 this.inntekt?.copy(
-                    endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak),
+                    endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak, Bonus),
                     endringAarsak = null,
                 ),
         )

--- a/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
+++ b/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
@@ -130,6 +130,12 @@ fun mockInntekt(): Inntekt =
             NyStillingsprosent(
                 gjelderFra = 16.oktober,
             ),
+        endringAarsaker =
+            listOf(
+                NyStillingsprosent(
+                    gjelderFra = 16.oktober,
+                ),
+            ),
     )
 
 fun mockRefusjon(): Refusjon =

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -2,12 +2,12 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.*
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.InntektEndringAarsak
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStilling
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStillingsprosent

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -212,13 +212,7 @@ class PdfDokument(
                 }
 
             when (endringAarsak) {
-                is Bonus ->
-                    addLabel(forklaringEndring, endringAarsak.beskrivelse())
-                is Feilregistrert ->
-                    addLabel(forklaringEndring, endringAarsak.beskrivelse())
-                is Nyansatt ->
-                    addLabel(forklaringEndring, endringAarsak.beskrivelse())
-                is Ferietrekk ->
+                is Bonus, is Feilregistrert, is Nyansatt, is Ferietrekk ->
                     addLabel(forklaringEndring, endringAarsak.beskrivelse())
 
                 is Ferie ->
@@ -339,7 +333,7 @@ class PdfDokument(
     }
 }
 
-public fun InntektEndringAarsak.beskrivelse(): String =
+fun InntektEndringAarsak.beskrivelse(): String =
     when (this) {
         is Bonus -> "Bonus"
         is Feilregistrert -> "Mangelfull eller uriktig rapportering til A-ordningen"

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -18,6 +18,8 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
 import no.nav.helsearbeidsgiver.felles.utils.tilNorskFormat
+import no.nav.helsearbeidsgiver.inntektsmelding.joark.tilTekst
+import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 
 private const val FORKLARING_ENDRING = "Forklaring for endring"
 
@@ -197,21 +199,22 @@ class PdfDokument(
             "Registrert inntekt (per ${inntektsmelding.inntekt?.inntektsdato?.tilNorskFormat()})",
             "${inntektsmelding.inntekt?.beloep?.tilNorskFormat()} kr/måned",
         )
-        val endringAarsak = inntektsmelding.inntekt?.endringAarsak
-        when (endringAarsak) {
-            null -> return // trenger ikke sende inn årsak...
-            is Bonus -> addBonus()
-            is Feilregistrert -> addFeilregistrert()
-            is Ferie -> addFerie(endringAarsak)
-            is Ferietrekk -> addFerietrekk()
-            is NyStilling -> addNyStilling(endringAarsak)
-            is NyStillingsprosent -> addNyStillingsprosent(endringAarsak)
-            is Nyansatt -> addNyAnsatt()
-            is Permisjon -> addPermisjon(endringAarsak)
-            is Permittering -> addPermittering(endringAarsak)
-            is Sykefravaer -> addSykefravaer(endringAarsak)
-            is Tariffendring -> addTariffendring(endringAarsak)
-            is VarigLoennsendring -> addVarigLonnsendring(endringAarsak)
+        val endringAarsaker = inntektsmelding.inntekt?.endringAarsaker.orDefault(emptyList())
+        endringAarsaker.forEach { endringAarsak ->
+            when (endringAarsak) {
+                is Bonus -> addBonus()
+                is Feilregistrert -> addFeilregistrert()
+                is Ferie -> addFerie(endringAarsak)
+                is Ferietrekk -> addFerietrekk()
+                is NyStilling -> addNyStilling(endringAarsak)
+                is NyStillingsprosent -> addNyStillingsprosent(endringAarsak)
+                is Nyansatt -> addNyAnsatt()
+                is Permisjon -> addPermisjon(endringAarsak)
+                is Permittering -> addPermittering(endringAarsak)
+                is Sykefravaer -> addSykefravaer(endringAarsak)
+                is Tariffendring -> addTariffendring(endringAarsak)
+                is VarigLoennsendring -> addVarigLonnsendring(endringAarsak)
+            }
         }
     }
 
@@ -248,7 +251,7 @@ class PdfDokument(
     }
 
     private fun addTariffendring(tariffendring: Tariffendring) {
-        addLabel(FORKLARING_ENDRING, "Tariffendring")
+        addLabel("Forklaring for endring (2 av 2)", "Tariffendring")
         addLabel("Gjelder fra", tariffendring.gjelderFra.tilNorskFormat(), linefeed = false)
         addLabel("Ble kjent", tariffendring.bleKjent.tilNorskFormat(), kolonneTo)
     }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -2,7 +2,21 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.*
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStilling
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStillingsprosent
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Nyansatt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permisjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
 import no.nav.helsearbeidsgiver.felles.utils.tilNorskFormat
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -247,7 +247,7 @@ class PdfDokumentTest {
                         im.inntekt.shouldNotBeNull().copy(
                             beloep = 123.0,
                             endringAarsak = it.value,
-                            endringAarsaker = listOf(it.value, Tariffendring(dag, dag.plusDays(2))),
+                            endringAarsaker = listOf(it.value),
                         ),
                 ),
             )
@@ -269,8 +269,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
-//        val file = File.createTempFile(title, ".pdf")
+//        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -264,22 +264,8 @@ class PdfDokumentTest {
     }
 
     @Test
-    fun `med alle mulige parvise kombinasjoner av begrunnelser blir teksten lagt til`() {
-        endringAarsaker
-            .parviseKombinasjoner()
-            .map { it.tilIm() }
-            .forEach { im ->
-                im.inntekt?.endringAarsaker?.forEachIndexed { indeks, endring ->
-                    pdfTekstFraIm(im) shouldContain "Endringsårsak (${indeks + 1} av 2)\n${endring.beskrivelse()}"
-                }
-            }
-    }
-
-    private fun <E> List<E>.parviseKombinasjoner(): List<List<E>> = flatMapIndexed { i, foorste -> drop(i + 1).map { andre -> listOf(foorste, andre) } }
-
-    @Test
-    fun `med 2, 3, 4 og 5 begrunnelser blir teksten lagt til`() {
-        (2..5).forEach { n ->
+    fun `med 2, 3, 4, 5 eller 6 begrunnelser blir teksten lagt til`() {
+        (2..6).forEach { n ->
             endringAarsaker
                 .windowed(n, 1, partialWindows = false)
                 .map { it.tilIm() }

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -299,6 +299,7 @@ class PdfDokumentTest {
                 im.inntekt.shouldNotBeNull().copy(
                     beloep = 123.0,
                     endringAarsaker = this,
+                    endringAarsak = null,
                 ),
         )
 
@@ -312,8 +313,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
-//        val file = File.createTempFile(title, ".pdf")
+//        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -247,6 +247,7 @@ class PdfDokumentTest {
                         im.inntekt.shouldNotBeNull().copy(
                             beloep = 123.0,
                             endringAarsak = it.value,
+                            endringAarsaker = listOf(it.value, Tariffendring(dag, dag.plusDays(2))),
                         ),
                 ),
             )
@@ -258,6 +259,7 @@ class PdfDokumentTest {
                     im.inntekt.shouldNotBeNull().copy(
                         beloep = 123.0,
                         endringAarsak = null,
+                        endringAarsaker = emptyList(),
                     ),
             ),
         )
@@ -267,8 +269,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-        // val file = File(System.getProperty("user.home"), "/Desktop/$title.pdf")
-        val file = File.createTempFile(title, ".pdf")
+        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+//        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.7
+hagDomeneInntektsmeldingVersion=0.1.8-SNAPSHOT
 junitJupiterVersion=5.11.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.8-SNAPSHOT
+hagDomeneInntektsmeldingVersion=0.1.8
 junitJupiterVersion=5.11.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.9.0


### PR DESCRIPTION
Lager en draft da det blir mye kode å se på om hele funksjonen skulle vært klar for prod.

Funksjonen `Flere begrunnelser` legger til støtte for flere inntekt endring begrunnelser (`List<endringsAarsak>`)



For å støtte dette i prod beholder vi den gamle verdien slik at frontend ikke må endres og vi unngår inflight errors.

## Endringer:

**0:** I denen versjonen har jeg oppdatert IM modellen til `hagDomeneInntektsmeldingVersion=0.1.8-SNAPSHOT`
Denne beholder gamle endringsAarsak variabelen og legger til en nullable liste med deafult verdi `= null`
```kotlin
data class Inntekt(
    val beloep: Double,
    val inntektsdato: LocalDate,
    val naturalytelser: List<Naturalytelse>,
    val endringAarsak: InntektEndringAarsak?,
    val endringAarsaker: List<InntektEndringAarsak>? = null, // <-- lagt til denne
) {
```

**1:** Listen blir utfylt når vi serialiserer JSON til `Inntektsmelding` med en util funksjon 
(siden den blir satt til null om den ikke eksisterer i JSON)
```kotlin
// midlertidlig duplisering for å støtte flere endringsÅrsaker
fun SkjemaInntektsmelding.fyllUtMangledeEndringsAarsaker(): SkjemaInntektsmelding {
    val medEndringsAarsakerfyllt = this.copy(inntekt = this.inntekt?.copy(endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak)))
    val verdiMangler = this.inntekt?.endringAarsaker.isNullOrEmpty()
    return if (verdiMangler) medEndringsAarsakerfyllt else this
}
```

**3:** 
I PDFen så er det lagt til støtte for flere begrunnelser 
(snakket med Dag om å bytte til `Endingsårsak (1 av 2)` teksten)
```kotlin
val endringAarsaker = inntektsmelding.inntekt?.endringAarsaker.orDefault(emptyList())
val antall = endringAarsaker.size
endringAarsaker.forEachIndexed { indeks, endringAarsak ->

    forklaringEndring = FORKLARING_ENDRING + if (antall > 1) " (${indeks + 1} av $antall)" else ""
    when (endringAarsak) {
        is Bonus -> addBonus()
        is Feilregistrert -> addFeilregistrert()
        //....
    }
}
```
**PDF:**
![image](https://github.com/user-attachments/assets/5aad439d-78fa-489b-b3fb-c3744402447a)

