### PR TITLE
strengere refusjonsendring dato-validering

### DIFF
--- a/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
+++ b/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
@@ -145,18 +145,18 @@ fun mockRefusjon(): Refusjon =
             listOf(
                 RefusjonEndring(
                     beloep = 140.9,
-                    startdato = 14.oktober,
+                    startdato = 1.november,
                 ),
                 RefusjonEndring(
                     beloep = 130.8,
-                    startdato = 18.oktober,
+                    startdato = 18.november,
                 ),
                 RefusjonEndring(
                     beloep = 120.7,
-                    startdato = 21.oktober,
+                    startdato = 21.november,
                 ),
             ),
-        sluttdato = 31.oktober,
+        sluttdato = 30.november,
     )
 
 fun mockInntektsmeldingGammeltFormat(): InntektsmeldingGammeltFormat = mockInntektsmeldingV1().convert()

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.9-SNAPSHOT
+hagDomeneInntektsmeldingVersion=0.1.9
 junitJupiterVersion=5.11.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.9.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.1.8
+hagDomeneInntektsmeldingVersion=0.1.9-SNAPSHOT
 junitJupiterVersion=5.11.3
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.9.0


### PR DESCRIPTION
Valider refusjon endringsdatoer (må være etter AGP der vi har dette, ellers sjekkes det mot inntektDato) 
Valideringen er allerede implementert på frontend

https://trello.com/c/pckSBdXy/405-hindre-ag-fra-%C3%A5-sende-refusjonsendringer-og-opph%C3%B8r-som-er-f%C3%B8r-eller-under-agp
