### PR TITLE
Støtte flere endringsÅrsaker array i XML ved å ta første element

### DIFF
--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
@@ -71,7 +71,7 @@ private fun Inntektsmelding.tilArbeidsforhold(): Arbeidsforhold =
     Arbeidsforhold().also { af ->
         af.beregnetInntekt =
             InntektXml().also {
-                // beholder bare foorste element og bevisst forkaster resten for å unngå endring i XML formatet
+                // beholder bare første element og bevisst forkaster resten for å unngå endring i XML formatet
                 it.aarsakVedEndring = inntekt?.endringAarsaker?.firstOrNull()?.tilTekst()
                 it.beloep = inntekt?.beloep?.toBigDecimal()
             }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
@@ -71,6 +71,7 @@ private fun Inntektsmelding.tilArbeidsforhold(): Arbeidsforhold =
     Arbeidsforhold().also { af ->
         af.beregnetInntekt =
             InntektXml().also {
+                // beholder bare foorste element og bevisst forkaster resten for å unngå endring i XML formatet
                 it.aarsakVedEndring = inntekt?.endringAarsaker?.firstOrNull()?.tilTekst()
                 it.beloep = inntekt?.beloep?.toBigDecimal()
             }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
@@ -71,7 +71,7 @@ private fun Inntektsmelding.tilArbeidsforhold(): Arbeidsforhold =
     Arbeidsforhold().also { af ->
         af.beregnetInntekt =
             InntektXml().also {
-                it.aarsakVedEndring = inntekt?.endringAarsak?.tilTekst()
+                it.aarsakVedEndring = inntekt?.endringAarsaker?.get(0)?.tilTekst()
                 it.beloep = inntekt?.beloep?.toBigDecimal()
             }
         af.foersteFravaersdag =

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmelding.kt
@@ -71,7 +71,7 @@ private fun Inntektsmelding.tilArbeidsforhold(): Arbeidsforhold =
     Arbeidsforhold().also { af ->
         af.beregnetInntekt =
             InntektXml().also {
-                it.aarsakVedEndring = inntekt?.endringAarsaker?.get(0)?.tilTekst()
+                it.aarsakVedEndring = inntekt?.endringAarsaker?.firstOrNull()?.tilTekst()
                 it.beloep = inntekt?.beloep?.toBigDecimal()
             }
         af.foersteFravaersdag =

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -62,6 +62,7 @@ class TilXmlInntektsmeldingTest {
                         inntektsdato = 20.oktober,
                         naturalytelser = emptyList(),
                         endringAarsak = null,
+                        endringAarsaker = emptyList(),
                     ),
             )
         val im = tilXmlInntektsmelding(inntektmeldingUtenAarsak)

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -23,7 +23,6 @@ class TilXmlInntektsmeldingTest {
     @Test
     fun `skal mappe inntektsmelding til xml-skjema`() {
         val im = mockInntektsmeldingV1()
-        val im2 = im.copy(inntekt = im.inntekt?.copy(endringAarsaker = null))
         val imXml = tilXmlInntektsmelding(im)
         val skjema = imXml.skjemainnhold
         Assertions.assertNotNull(skjema.aarsakTilInnsending)

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -48,6 +48,7 @@ class TilXmlInntektsmeldingTest {
         Assertions.assertEquals(2, skjema.opphoerAvNaturalytelseListe.size)
         Assertions.assertNotNull(skjema.avsendersystem.innsendingstidspunkt)
         Assertions.assertNotNull(skjema.arbeidsforhold.beregnetInntekt.aarsakVedEndring)
+        Assertions.assertEquals(im.inntekt?.endringAarsaker!![0].tilTekst(), skjema.arbeidsforhold.beregnetInntekt.aarsakVedEndring)
         println(xmlMapper().writeValueAsString(imXml))
     }
 

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -23,6 +23,7 @@ class TilXmlInntektsmeldingTest {
     @Test
     fun `skal mappe inntektsmelding til xml-skjema`() {
         val im = mockInntektsmeldingV1()
+        val im2 = im.copy(inntekt = im.inntekt?.copy(endringAarsaker = null))
         val imXml = tilXmlInntektsmelding(im)
         val skjema = imXml.skjemainnhold
         Assertions.assertNotNull(skjema.aarsakTilInnsending)
@@ -48,7 +49,13 @@ class TilXmlInntektsmeldingTest {
         Assertions.assertEquals(2, skjema.opphoerAvNaturalytelseListe.size)
         Assertions.assertNotNull(skjema.avsendersystem.innsendingstidspunkt)
         Assertions.assertNotNull(skjema.arbeidsforhold.beregnetInntekt.aarsakVedEndring)
-        Assertions.assertEquals(im.inntekt?.endringAarsaker!![0].tilTekst(), skjema.arbeidsforhold.beregnetInntekt.aarsakVedEndring)
+        Assertions.assertEquals(
+            im.inntekt
+                ?.endringAarsaker
+                ?.firstOrNull()
+                ?.tilTekst(),
+            skjema.arbeidsforhold.beregnetInntekt.aarsakVedEndring,
+        )
         println(xmlMapper().writeValueAsString(imXml))
     }
 


### PR DESCRIPTION
En forenklet løsnining for å unngå at endring blir nødvending i programvare som leser XML filen.