### PR TITLE
Flere inntekt begrunnelser fylles når IM hentes fra databasen

### DIFF
--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -8,6 +8,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.LagretInntektsmelding
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
+import no.nav.helsearbeidsgiver.felles.utils.konverterEndringAarsakTilListe
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -56,7 +57,7 @@ class InntektsmeldingRepository(
                     val mottatt = result.fourth
 
                     when {
-                        skjema != null -> LagretInntektsmelding.Skjema(inntektsmelding?.innsenderNavn, skjema, mottatt)
+                        skjema != null -> LagretInntektsmelding.Skjema(inntektsmelding?.innsenderNavn, skjema.konverterEndringAarsakTilListe(), mottatt)
                         inntektsmelding != null -> {
                             val bakoverkompatibeltSkjema =
                                 SkjemaInntektsmelding(

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -82,6 +82,9 @@ class InntektsmeldingRepositoryTest :
             record.getOrNull(InntektsmeldingEntitet.dokument) shouldBe beriketDokument
 
             inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId
+
+//            val lagretInntektsmelding = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId).shouldBeInstanceOf<LagretInntektsmelding.Skjema>()
+//            lagretInntektsmelding.skjema.inntekt?.endringAarsaker shouldBe listOf(skjema.inntekt?.endringAarsak!!)
         }
 
         test("skal lagre hvert innsendte skjema med ny innsendingId, men hente nyeste berikede inntektsmelding") {
@@ -307,7 +310,9 @@ class InntektsmeldingRepositoryTest :
                 val skjema = mockSkjemaInntektsmelding()
                 val mottatt = 9.desember.atStartOfDay()
 
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjema, mottatt)
+                val skjemaUtenEndringsAarsaker = skjema.copy(inntekt = skjema.inntekt?.copy(endringAarsaker = emptyList()))
+
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(skjemaUtenEndringsAarsaker, mottatt)
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId)
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -82,9 +82,6 @@ class InntektsmeldingRepositoryTest :
             record.getOrNull(InntektsmeldingEntitet.dokument) shouldBe beriketDokument
 
             inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId
-
-//            val lagretInntektsmelding = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId).shouldBeInstanceOf<LagretInntektsmelding.Skjema>()
-//            lagretInntektsmelding.skjema.inntekt?.endringAarsaker shouldBe listOf(skjema.inntekt?.endringAarsak!!)
         }
 
         test("skal lagre hvert innsendte skjema med ny innsendingId, men hente nyeste berikede inntektsmelding") {

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/EndringsAarsakUtils.kt
@@ -4,13 +4,13 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 
 // midlertidlig duplisering for å støtte flere endringsÅrsaker
 fun SkjemaInntektsmelding.konverterEndringAarsakTilListe(): SkjemaInntektsmelding =
-    if (this.inntekt?.endringAarsaker != null) {
-        this
-    } else {
+    if (this.inntekt?.endringAarsaker.isNullOrEmpty()) {
         this.copy(
             inntekt =
                 this.inntekt?.copy(
                     endringAarsaker = listOfNotNull(this.inntekt?.endringAarsak),
                 ),
         )
+    } else {
+        this
     }


### PR DESCRIPTION
Inntekt endringsAarsaker array fylles om de ikke er definert i gamle dokumenter lagret i Simba databasen når de blir hentet.