### PR TITLE
Tar bort urelevant felt om IM ikke har AGP

### DIFF
--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -281,14 +281,17 @@ class PdfDokument(
     private fun addRefusjon() {
         val redusertLoennIAgp = inntektsmelding.agp?.redusertLoennIAgp
         val refusjon = inntektsmelding.refusjon
+        val arbeidsgiverperioder = inntektsmelding.agp?.perioder.orEmpty()
 
         addSection("Refusjon")
 
-        addLabel("Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?", (redusertLoennIAgp == null).tilNorskFormat())
-        if (redusertLoennIAgp != null) {
-            // Redusert lønn i AGP - to ekstra spørsmål
-            addLabel("Begrunnelse", redusertLoennIAgp.begrunnelse.tilTekst())
-            addLabel("Utbetalt under arbeidsgiverperiode", redusertLoennIAgp.beloep.tilNorskFormat() + " kr")
+        if (arbeidsgiverperioder.isNotEmpty()) {
+            addLabel("Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?", (redusertLoennIAgp == null).tilNorskFormat())
+            if (redusertLoennIAgp != null) {
+                // Redusert lønn i AGP - to ekstra spørsmål
+                addLabel("Begrunnelse", redusertLoennIAgp.begrunnelse.tilTekst())
+                addLabel("Utbetalt under arbeidsgiverperiode", redusertLoennIAgp.beloep.tilNorskFormat() + " kr")
+            }
         }
 
         addLabel("Betaler arbeidsgiver lønn under hele eller deler av sykefraværet?", (refusjon != null).tilNorskFormat())

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotContain
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
@@ -229,7 +230,7 @@ class PdfDokumentTest {
     fun `med ingen arbeidsgiverperiode`() {
         val medAgp = im
         val agpErNull = im.copy(agp = null)
-        val agpHarTomPeriodeListe = im.copy(agp = im.agp.shouldNotBeNull().copy(perioder = emptyList()))
+        val agpHarTomPeriodeListe = im.copy(agp = Arbeidsgiverperiode(emptyList(), emptyList(), null))
 
         mapOf(
             "med_arbeidsgiverperiode" to medAgp,

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
@@ -222,6 +223,27 @@ class PdfDokumentTest {
                     ),
             ),
         )
+    }
+
+    @Test
+    fun `med ingen arbeidsgiverperiode`() {
+        val medAgp = im
+        val agpErNull = im.copy(agp = null)
+        val agpHarTomPeriodeListe = im.copy(agp = im.agp.shouldNotBeNull().copy(perioder = emptyList()))
+
+        mapOf(
+            "med_arbeidsgiverperiode" to medAgp,
+            "med_arbeidsgiverperiode_lik_null" to agpErNull,
+            "med_ingen_arbeidsgiver_perioder" to agpHarTomPeriodeListe,
+        ).forEach { (filNavn, im) ->
+            writePDF(filNavn, im)
+        }
+
+        val pdfAgpRelevantTekst = "Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?"
+
+        pdfTekstFraIm(medAgp) shouldContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agpErNull) shouldNotContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agpHarTomPeriodeListe) shouldNotContain pdfAgpRelevantTekst
     }
 
     @Test


### PR DESCRIPTION
I dagens løsning inkluderer PDFen denne teksten selv om ingen arbeidsgiverperiode er definert:
```
Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?
JA
```

Denne PR endringen inkluderer bare teksten om `arbeidsgiverperioder.isNotEmpty()` 