### PR TITLE
Legg til kolonne for inntektsmelding-ID i database

### DIFF
--- a/apps/db/src/main/resources/db/migration/V19__inntektsmelding_add_im_id.sql
+++ b/apps/db/src/main/resources/db/migration/V19__inntektsmelding_add_im_id.sql
@@ -1,0 +1,3 @@
+ALTER TABLE inntektsmelding
+    ADD COLUMN inntektsmelding_id UUID UNIQUE,
+    ADD COLUMN avsender_navn      TEXT;


### PR DESCRIPTION
`UNIQUE` skal også sørge for at kolonnen blir indeksert, som vi trenger når vi skal oppdatere radene med journalpost-ID.

Sniker med kolonne for avsendernavn også, som nå lagres i IM på gammelt format.