### PR TITLE
Lagre inntektsmelding-ID i database

### DIFF
--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -1,14 +1,15 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.db
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convert
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convertAgp
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convertInntekt
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.LagretInntektsmelding
 import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 import no.nav.helsearbeidsgiver.felles.utils.konverterEndringAarsakTilListe
+import no.nav.helsearbeidsgiver.inntektsmelding.db.domene.InntektsmeldingGammeltFormat
+import no.nav.helsearbeidsgiver.inntektsmelding.db.domene.convert
+import no.nav.helsearbeidsgiver.inntektsmelding.db.domene.convertAgp
+import no.nav.helsearbeidsgiver.inntektsmelding.db.domene.convertInntekt
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
@@ -34,43 +35,49 @@ class InntektsmeldingRepository(
             transaction(db) {
                 InntektsmeldingEntitet
                     .select(
-                        InntektsmeldingEntitet.dokument,
                         InntektsmeldingEntitet.skjema,
+                        InntektsmeldingEntitet.dokument,
                         InntektsmeldingEntitet.eksternInntektsmelding,
                         InntektsmeldingEntitet.innsendt,
+                        InntektsmeldingEntitet.avsenderNavn,
                     ).where { InntektsmeldingEntitet.forespoerselId eq forespoerselId.toString() }
                     .orderBy(InntektsmeldingEntitet.innsendt, SortOrder.DESC)
                     .limit(1)
                     .map {
-                        Quadruple(
-                            it[InntektsmeldingEntitet.dokument],
+                        InntektsmeldingResult(
                             it[InntektsmeldingEntitet.skjema],
+                            it[InntektsmeldingEntitet.dokument],
                             it[InntektsmeldingEntitet.eksternInntektsmelding],
                             it[InntektsmeldingEntitet.innsendt],
+                            it[InntektsmeldingEntitet.avsenderNavn],
                         )
                     }
             }.firstOrNull()
                 ?.let { result ->
-                    val inntektsmelding = result.first
-                    val skjema = result.second
-                    val eksternInntektsmelding = result.third
-                    val mottatt = result.fourth
-
                     when {
-                        skjema != null -> LagretInntektsmelding.Skjema(inntektsmelding?.innsenderNavn, skjema.konverterEndringAarsakTilListe(), mottatt)
-                        inntektsmelding != null -> {
+                        result.skjema != null ->
+                            LagretInntektsmelding.Skjema(
+                                avsenderNavn = result.avsenderNavn ?: result.inntektsmeldingGammeltFormat?.innsenderNavn,
+                                skjema = result.skjema.konverterEndringAarsakTilListe(),
+                                mottatt = result.mottatt,
+                            )
+                        result.inntektsmeldingGammeltFormat != null -> {
                             val bakoverkompatibeltSkjema =
                                 SkjemaInntektsmelding(
                                     forespoerselId = forespoerselId,
-                                    avsenderTlf = inntektsmelding.telefonnummer.orEmpty(),
-                                    agp = inntektsmelding.convertAgp(),
-                                    inntekt = inntektsmelding.convertInntekt(),
-                                    refusjon = inntektsmelding.refusjon.convert(),
+                                    avsenderTlf = result.inntektsmeldingGammeltFormat.telefonnummer.orEmpty(),
+                                    agp = result.inntektsmeldingGammeltFormat.convertAgp(),
+                                    inntekt = result.inntektsmeldingGammeltFormat.convertInntekt(),
+                                    refusjon = result.inntektsmeldingGammeltFormat.refusjon.convert(),
                                 )
 
-                            LagretInntektsmelding.Skjema(inntektsmelding.innsenderNavn, bakoverkompatibeltSkjema, mottatt)
+                            LagretInntektsmelding.Skjema(
+                                avsenderNavn = result.inntektsmeldingGammeltFormat.innsenderNavn,
+                                skjema = bakoverkompatibeltSkjema,
+                                mottatt = result.mottatt,
+                            )
                         }
-                        eksternInntektsmelding != null -> LagretInntektsmelding.Ekstern(eksternInntektsmelding)
+                        result.eksternInntektsmelding != null -> LagretInntektsmelding.Ekstern(result.eksternInntektsmelding)
                         else -> null
                     }
                 }
@@ -150,30 +157,29 @@ class InntektsmeldingRepository(
         }
 
     fun oppdaterMedBeriketDokument(
-        forespoerselId: UUID,
         innsendingId: Long,
-        inntektsmeldingDokument: Inntektsmelding,
+        inntektsmelding: Inntektsmelding,
     ) {
         val antallOppdatert =
-            Metrics.dbInntektsmelding.recordTime(InntektsmeldingRepository::oppdaterMedBeriketDokument) {
-                transaction(db) {
-                    InntektsmeldingEntitet.update(
-                        where = {
-                            InntektsmeldingEntitet.id eq innsendingId
-                        },
-                    ) {
-                        it[dokument] = inntektsmeldingDokument
-                    }
+            transaction(db) {
+                InntektsmeldingEntitet.update(
+                    where = {
+                        InntektsmeldingEntitet.id eq innsendingId
+                    },
+                ) {
+                    it[inntektsmeldingId] = inntektsmelding.id
+                    it[dokument] = inntektsmelding.convert()
+                    it[avsenderNavn] = inntektsmelding.avsender.navn
                 }
             }
 
         if (antallOppdatert == 1) {
-            "Lagret inntektsmelding for forespørsel-ID $forespoerselId i database.".also {
+            "Lagret inntektsmelding for forespørsel-ID ${inntektsmelding.type.id} i database.".also {
                 logger.info(it)
                 sikkerLogger.info(it)
             }
         } else {
-            "Oppdaterte uventet antall ($antallOppdatert) rader ved lagring av inntektsmelding med forespørsel-ID $forespoerselId.".also {
+            "Oppdaterte uventet antall ($antallOppdatert) rader ved lagring av inntektsmelding med forespørsel-ID ${inntektsmelding.type.id}.".also {
                 logger.error(it)
                 sikkerLogger.error(it)
             }
@@ -181,11 +187,12 @@ class InntektsmeldingRepository(
     }
 }
 
-private class Quadruple<A, B, C, D>(
-    val first: A,
-    val second: B,
-    val third: C,
-    val fourth: D,
+private class InntektsmeldingResult(
+    val skjema: SkjemaInntektsmelding?,
+    val inntektsmeldingGammeltFormat: InntektsmeldingGammeltFormat?,
+    val eksternInntektsmelding: EksternInntektsmelding?,
+    val mottatt: LocalDateTime,
+    val avsenderNavn: String?,
 )
 
 private fun hentNyesteImQuery(forespoerselId: UUID): Query =

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertGammeltFormatUtils.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertGammeltFormatUtils.kt
@@ -1,0 +1,108 @@
+@file:Suppress("DEPRECATION")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.InntektEndringAarsak
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStilling
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStillingsprosent
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Nyansatt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permisjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.bestemmendeFravaersdag
+
+fun InntektsmeldingGammeltFormat.convertAgp(): Arbeidsgiverperiode? =
+    if (arbeidsgiverperioder.isEmpty()) {
+        null
+    } else {
+        Arbeidsgiverperiode(
+            perioder = arbeidsgiverperioder,
+            egenmeldinger = egenmeldingsperioder,
+            redusertLoennIAgp = fullLønnIArbeidsgiverPerioden?.convert(),
+        )
+    }
+
+fun InntektsmeldingGammeltFormat.convertInntekt(): Inntekt? =
+    if (inntekt == null) {
+        null
+    } else {
+        Inntekt(
+            beloep = inntekt.beregnetInntekt,
+            inntektsdato =
+                inntektsdato
+                    ?: bestemmendeFraværsdag
+                    ?: bestemmendeFravaersdag(
+                        arbeidsgiverperioder = arbeidsgiverperioder,
+                        sykefravaersperioder = fraværsperioder,
+                    ),
+            naturalytelser = naturalytelser?.map { it.convert() }.orEmpty(),
+            endringAarsak = inntekt.endringÅrsak?.convert(),
+            endringAarsaker = listOfNotNull(inntekt.endringÅrsak?.convert()),
+        )
+    }
+
+fun RefusjonGammeltFormat.convert(): Refusjon? =
+    // (refusjonPrMnd == null) bør ikke skje, men deprecated nullable-kode åpner for ugyldige data.
+    if (!utbetalerHeleEllerDeler || refusjonPrMnd == null) {
+        null
+    } else {
+        Refusjon(
+            beloepPerMaaned = refusjonPrMnd,
+            endringer = refusjonEndringer?.mapNotNull { it.convert() }.orEmpty(),
+            sluttdato = refusjonOpphører,
+        )
+    }
+
+fun BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.convert(): RedusertLoennIAgp.Begrunnelse = RedusertLoennIAgp.Begrunnelse.valueOf(name)
+
+fun NaturalytelseGammeltFormat.convert(): Naturalytelse =
+    Naturalytelse(
+        naturalytelse = naturalytelse.name.let(Naturalytelse.Kode::valueOf),
+        verdiBeloep = beløp,
+        sluttdato = dato,
+    )
+
+fun InntektEndringAarsakGammeltFormat.convert(): InntektEndringAarsak =
+    when (this) {
+        is BonusGammeltFormat -> Bonus
+        is FeilregistrertGammeltFormat -> Feilregistrert
+        is FerieGammeltFormat -> Ferie(ferier = liste)
+        is FerietrekkGammeltFormat -> Ferietrekk
+        is NyansattGammeltFormat -> Nyansatt
+        is NyStillingGammeltFormat -> NyStilling(gjelderFra = gjelderFra)
+        is NyStillingsprosentGammeltFormat -> NyStillingsprosent(gjelderFra = gjelderFra)
+        is PermisjonGammeltFormat -> Permisjon(permisjoner = liste)
+        is PermitteringGammeltFormat -> Permittering(permitteringer = liste)
+        is SykefravaerGammeltFormat -> Sykefravaer(sykefravaer = liste)
+        is TariffendringGammeltFormat -> Tariffendring(gjelderFra = gjelderFra, bleKjent = bleKjent)
+        is VarigLonnsendringGammeltFormat -> VarigLoennsendring(gjelderFra = gjelderFra)
+    }
+
+private fun FullLoennIAgpGammeltFormat.convert(): RedusertLoennIAgp? =
+    if (utbetalerFullLønn || utbetalt == null || begrunnelse == null) {
+        null
+    } else {
+        RedusertLoennIAgp(
+            beloep = utbetalt,
+            begrunnelse = begrunnelse.convert(),
+        )
+    }
+
+private fun RefusjonEndringGammeltFormat.convert(): RefusjonEndring? =
+    if (beløp == null || dato == null) {
+        null
+    } else {
+        RefusjonEndring(beløp, dato)
+    }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertNyttFormatUtils.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertNyttFormatUtils.kt
@@ -1,0 +1,112 @@
+@file:Suppress("DEPRECATION")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.InntektEndringAarsak
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStilling
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStillingsprosent
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Nyansatt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permisjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
+import no.nav.helsearbeidsgiver.utils.pipe.orDefault
+
+fun Inntektsmelding.convert(): InntektsmeldingGammeltFormat =
+    InntektsmeldingGammeltFormat(
+        vedtaksperiodeId = vedtaksperiodeId,
+        orgnrUnderenhet = avsender.orgnr.verdi,
+        identitetsnummer = sykmeldt.fnr.verdi,
+        fraværsperioder = sykmeldingsperioder,
+        egenmeldingsperioder = agp?.egenmeldinger.orEmpty(),
+        arbeidsgiverperioder = agp?.perioder.orEmpty(),
+        fullLønnIArbeidsgiverPerioden =
+            agp?.redusertLoennIAgp?.convert().orDefault(
+                FullLoennIAgpGammeltFormat(
+                    utbetalerFullLønn = true,
+                    begrunnelse = null,
+                    utbetalt = null,
+                ),
+            ),
+        inntekt = inntekt?.convert(),
+        inntektsdato = inntekt?.inntektsdato,
+        bestemmendeFraværsdag = null,
+        naturalytelser = inntekt?.naturalytelser?.map { it.convert() }.orEmpty(),
+        refusjon =
+            refusjon?.convert().orDefault(
+                RefusjonGammeltFormat(
+                    utbetalerHeleEllerDeler = false,
+                    refusjonPrMnd = null,
+                    refusjonOpphører = null,
+                    refusjonEndringer = null,
+                ),
+            ),
+        innsenderNavn = avsender.navn,
+        telefonnummer = avsender.tlf,
+    )
+
+fun Inntekt.convert(): InntektGammeltFormat =
+    InntektGammeltFormat(
+        bekreftet = true,
+        beregnetInntekt = beloep,
+        endringÅrsak = endringAarsak?.convert(),
+        manueltKorrigert = endringAarsak != null || endringAarsaker?.isNotEmpty() == true,
+    )
+
+fun Refusjon.convert(): RefusjonGammeltFormat =
+    RefusjonGammeltFormat(
+        utbetalerHeleEllerDeler = true,
+        refusjonPrMnd = beloepPerMaaned,
+        refusjonOpphører = sluttdato,
+        refusjonEndringer = endringer.map { it.convert() },
+    )
+
+private fun InntektEndringAarsak.convert(): InntektEndringAarsakGammeltFormat =
+    when (this) {
+        is Bonus -> BonusGammeltFormat()
+        is Feilregistrert -> FeilregistrertGammeltFormat
+        is Ferie -> FerieGammeltFormat(liste = ferier)
+        is Ferietrekk -> FerietrekkGammeltFormat
+        is Nyansatt -> NyansattGammeltFormat
+        is NyStilling -> NyStillingGammeltFormat(gjelderFra = gjelderFra)
+        is NyStillingsprosent -> NyStillingsprosentGammeltFormat(gjelderFra = gjelderFra)
+        is Permisjon -> PermisjonGammeltFormat(liste = permisjoner)
+        is Permittering -> PermitteringGammeltFormat(liste = permitteringer)
+        is Sykefravaer -> SykefravaerGammeltFormat(liste = sykefravaer)
+        is Tariffendring -> TariffendringGammeltFormat(gjelderFra = gjelderFra, bleKjent = bleKjent)
+        is VarigLoennsendring -> VarigLonnsendringGammeltFormat(gjelderFra = gjelderFra)
+    }
+
+private fun RedusertLoennIAgp.convert(): FullLoennIAgpGammeltFormat =
+    FullLoennIAgpGammeltFormat(
+        utbetalerFullLønn = false,
+        begrunnelse = begrunnelse.convert(),
+        utbetalt = beloep,
+    )
+
+private fun RedusertLoennIAgp.Begrunnelse.convert(): BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat =
+    BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.valueOf(name)
+
+private fun RefusjonEndring.convert(): RefusjonEndringGammeltFormat =
+    RefusjonEndringGammeltFormat(
+        beløp = beloep,
+        dato = startdato,
+    )
+
+private fun Naturalytelse.convert(): NaturalytelseGammeltFormat =
+    NaturalytelseGammeltFormat(
+        naturalytelse = naturalytelse.name.let(NaturalytelseKodeGammeltFormat::valueOf),
+        dato = sluttdato,
+        beløp = verdiBeloep,
+    )

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/FullLoennIAgpGammeltFormat.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/FullLoennIAgpGammeltFormat.kt
@@ -1,0 +1,34 @@
+@file:Suppress("DEPRECATION")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import kotlinx.serialization.Serializable
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class FullLoennIAgpGammeltFormat(
+    val utbetalerFullLønn: Boolean,
+    val begrunnelse: BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat? = null,
+    val utbetalt: Double? = null,
+)
+
+/** Bruker UpperCamelCase for å matche kodeverkverdier. */
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+enum class BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat {
+    ArbeidOpphoert,
+    BeskjedGittForSent,
+    BetvilerArbeidsufoerhet,
+    FerieEllerAvspasering,
+    FiskerMedHyre,
+    FravaerUtenGyldigGrunn,
+    IkkeFravaer,
+    IkkeFullStillingsandel,
+    IkkeLoenn,
+    LovligFravaer,
+    ManglerOpptjening,
+    Permittering,
+    Saerregler,
+    StreikEllerLockout,
+    TidligereVirksomhet,
+}

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/InntektGammeltFormat.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/InntektGammeltFormat.kt
@@ -1,0 +1,108 @@
+@file:Suppress("DEPRECATION")
+@file:UseSerializers(LocalDateSerializer::class)
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import kotlinx.serialization.ExperimentalSerializationApi
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.JsonClassDiscriminator
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import java.time.LocalDate
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class InntektGammeltFormat(
+    val bekreftet: Boolean,
+    val beregnetInntekt: Double,
+    val endringÅrsak: InntektEndringAarsakGammeltFormat? = null,
+    val manueltKorrigert: Boolean,
+)
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@OptIn(ExperimentalSerializationApi::class)
+@JsonClassDiscriminator("typpe")
+sealed class InntektEndringAarsakGammeltFormat
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Bonus")
+data class BonusGammeltFormat(
+    val aarligBonus: Double? = null,
+    val datoForBonus: LocalDate? = null,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Feilregistrert")
+data object FeilregistrertGammeltFormat : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Ferie")
+data class FerieGammeltFormat(
+    val liste: List<Periode>,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Ferietrekk")
+data object FerietrekkGammeltFormat : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Nyansatt")
+data object NyansattGammeltFormat : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("NyStilling")
+data class NyStillingGammeltFormat(
+    val gjelderFra: LocalDate,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("NyStillingsprosent")
+data class NyStillingsprosentGammeltFormat(
+    val gjelderFra: LocalDate,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Permisjon")
+data class PermisjonGammeltFormat(
+    val liste: List<Periode>,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Permittering")
+data class PermitteringGammeltFormat(
+    val liste: List<Periode>,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Sykefravaer")
+data class SykefravaerGammeltFormat(
+    val liste: List<Periode>,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("Tariffendring")
+data class TariffendringGammeltFormat(
+    val gjelderFra: LocalDate,
+    val bleKjent: LocalDate,
+) : InntektEndringAarsakGammeltFormat()
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+@SerialName("VarigLonnsendring")
+data class VarigLonnsendringGammeltFormat(
+    val gjelderFra: LocalDate,
+) : InntektEndringAarsakGammeltFormat()

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/InntektsmeldingGammeltFormat.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/InntektsmeldingGammeltFormat.kt
@@ -1,0 +1,40 @@
+@file:Suppress("DEPRECATION")
+@file:UseSerializers(LocalDateSerializer::class, UuidSerializer::class)
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
+import java.time.LocalDate
+import java.util.UUID
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class InntektsmeldingGammeltFormat(
+    val vedtaksperiodeId: UUID? = null,
+    val orgnrUnderenhet: String,
+    val identitetsnummer: String,
+    val fraværsperioder: List<Periode>,
+    val egenmeldingsperioder: List<Periode>,
+    val arbeidsgiverperioder: List<Periode>,
+    val fullLønnIArbeidsgiverPerioden: FullLoennIAgpGammeltFormat? = null,
+    val inntekt: InntektGammeltFormat? = null,
+    val inntektsdato: LocalDate? = null,
+    val bestemmendeFraværsdag: LocalDate? = null,
+    val naturalytelser: List<NaturalytelseGammeltFormat>? = null,
+    val refusjon: RefusjonGammeltFormat,
+    val innsenderNavn: String? = null,
+    val telefonnummer: String? = null,
+)
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+enum class AarsakInnsendingGammeltFormat(
+    val value: String,
+) {
+    NY("Ny"),
+    ENDRING("Endring"),
+}

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/NaturalytelseGammeltFormat.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/NaturalytelseGammeltFormat.kt
@@ -1,0 +1,41 @@
+@file:Suppress("DEPRECATION")
+@file:UseSerializers(LocalDateSerializer::class)
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import java.time.LocalDate
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class NaturalytelseGammeltFormat(
+    val naturalytelse: NaturalytelseKodeGammeltFormat,
+    val dato: LocalDate,
+    val beløp: Double,
+)
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+enum class NaturalytelseKodeGammeltFormat {
+    AKSJERGRUNNFONDSBEVISTILUNDERKURS,
+    ANNET,
+    BEDRIFTSBARNEHAGEPLASS,
+    BESOEKSREISERHJEMMETANNET,
+    BIL,
+    BOLIG,
+    ELEKTRONISKKOMMUNIKASJON,
+    FRITRANSPORT,
+    INNBETALINGTILUTENLANDSKPENSJONSORDNING,
+    KOSTBESPARELSEIHJEMMET,
+    KOSTDAGER,
+    KOSTDOEGN,
+    LOSJI,
+    OPSJONER,
+    RENTEFORDELLAAN,
+    SKATTEPLIKTIGDELFORSIKRINGER,
+    TILSKUDDBARNEHAGEPLASS,
+    YRKEBILTJENESTLIGBEHOVKILOMETER,
+    YRKEBILTJENESTLIGBEHOVLISTEPRIS,
+}

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/RefusjonGammeltFormat.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/RefusjonGammeltFormat.kt
@@ -1,0 +1,25 @@
+@file:Suppress("DEPRECATION")
+@file:UseSerializers(LocalDateSerializer::class)
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import java.time.LocalDate
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class RefusjonGammeltFormat(
+    val utbetalerHeleEllerDeler: Boolean,
+    val refusjonPrMnd: Double? = null,
+    val refusjonOpphører: LocalDate? = null,
+    val refusjonEndringer: List<RefusjonEndringGammeltFormat>? = null,
+)
+
+@Deprecated("Kun brukt for å lese gamle databaserader.")
+@Serializable
+data class RefusjonEndringGammeltFormat(
+    val beløp: Double? = null,
+    val dato: LocalDate? = null,
+)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -2,7 +2,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.db.river
 
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -56,9 +55,7 @@ class LagreImRiver(
     override fun LagreImMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
-        val inntektsmeldingGammeltFormat = inntektsmelding.convert()
-
-        imRepo.oppdaterMedBeriketDokument(inntektsmelding.type.id, innsendingId, inntektsmeldingGammeltFormat)
+        imRepo.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
         sikkerLogger.info("Lagret inntektsmelding.")
 
         return mapOf(

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
@@ -1,8 +1,8 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.db.tabell
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
+import no.nav.helsearbeidsgiver.inntektsmelding.db.domene.InntektsmeldingGammeltFormat
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig
 import org.jetbrains.exposed.sql.Table
 import org.jetbrains.exposed.sql.javatime.datetime
@@ -13,12 +13,13 @@ object InntektsmeldingEntitet : Table("inntektsmelding") {
         long("id").autoIncrement(
             idSeqName = "inntektsmelding_id_seq",
         )
+    val inntektsmeldingId = uuid("inntektsmelding_id").nullable()
     val forespoerselId = varchar(name = "forespoersel_id", length = 40)
     val dokument =
-        jsonb<Inntektsmelding>(
+        jsonb<InntektsmeldingGammeltFormat>(
             name = "dokument",
             jsonConfig = jsonConfig,
-            kSerializer = Inntektsmelding.serializer(),
+            kSerializer = InntektsmeldingGammeltFormat.serializer(),
         ).nullable()
     val eksternInntektsmelding =
         jsonb<EksternInntektsmelding>(
@@ -33,6 +34,8 @@ object InntektsmeldingEntitet : Table("inntektsmelding") {
             kSerializer = SkjemaInntektsmelding.serializer(),
         ).nullable()
     val innsendt = datetime("innsendt")
+    val avsenderNavn = text("avsender_navn").nullable()
     val journalpostId = varchar("journalpostid", 30).nullable()
+
     override val primaryKey = PrimaryKey(id, name = "id")
 }

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/domene/ConvertTest.kt
@@ -1,0 +1,300 @@
+@file:Suppress("DEPRECATION")
+
+package no.nav.helsearbeidsgiver.inntektsmelding.db.domene
+
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.equals.shouldBeEqual
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStilling
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.NyStillingsprosent
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Nyansatt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permisjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
+import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
+import no.nav.helsearbeidsgiver.utils.test.date.januar
+import no.nav.helsearbeidsgiver.utils.test.date.oktober
+import no.nav.helsearbeidsgiver.utils.test.date.september
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.time.LocalDate
+import java.util.UUID
+
+class ConvertTest :
+    FunSpec({
+
+        val foersteJanuar2023 = LocalDate.of(2023, 1, 1)
+        val inntektsmeldingId = UUID.randomUUID()
+        val forespurtType =
+            Inntektsmelding.Type.Forespurt(
+                id = UUID.randomUUID(),
+            )
+
+        test("convertInntekt") {
+            val im = lagGammelInntektsmelding()
+            val nyInntekt = im.convertInntekt()
+            nyInntekt shouldNotBe null
+            val gammelInntekt = im.inntekt
+            nyInntekt?.beloep shouldBe gammelInntekt?.beregnetInntekt
+        }
+
+        test("convertEndringAarsak") {
+            BonusGammeltFormat(1.0, LocalDate.EPOCH).convert() shouldBe Bonus
+            BonusGammeltFormat(null, null).convert() shouldBe Bonus
+            FeilregistrertGammeltFormat.convert() shouldBe Feilregistrert
+            FerieGammeltFormat(lagPeriode()).convert() shouldBe Ferie(lagPeriode())
+            FerietrekkGammeltFormat.convert() shouldBe Ferietrekk
+            NyansattGammeltFormat.convert() shouldBe Nyansatt
+            NyStillingGammeltFormat(foersteJanuar2023).convert() shouldBe NyStilling(foersteJanuar2023)
+            NyStillingsprosentGammeltFormat(foersteJanuar2023).convert() shouldBe NyStillingsprosent(foersteJanuar2023)
+            PermisjonGammeltFormat(lagPeriode()).convert() shouldBe Permisjon(lagPeriode())
+            PermitteringGammeltFormat(lagPeriode()).convert() shouldBe Permittering(lagPeriode())
+            SykefravaerGammeltFormat(lagPeriode()).convert() shouldBe Sykefravaer(lagPeriode())
+            TariffendringGammeltFormat(foersteJanuar2023, foersteJanuar2023).convert() shouldBe
+                Tariffendring(
+                    foersteJanuar2023,
+                    foersteJanuar2023,
+                )
+            VarigLonnsendringGammeltFormat(foersteJanuar2023).convert() shouldBe VarigLoennsendring(foersteJanuar2023)
+        }
+
+        test("Naturalytelse-convert") {
+            val belop = 10.0
+            val gamleYtelser =
+                NaturalytelseKodeGammeltFormat.entries
+                    .map {
+                        NaturalytelseGammeltFormat(it, foersteJanuar2023, belop)
+                    }.toList()
+            val nyeYtelser =
+                Naturalytelse.Kode.entries
+                    .map {
+                        Naturalytelse(it, belop, foersteJanuar2023)
+                    }.toList()
+            gamleYtelser.map { it.convert() } shouldBeEqual nyeYtelser
+        }
+
+        test("FullLoennIArbeidsgiverPerioden-convert") {
+            val utbetalt = 10000.0
+            val imMedReduksjon =
+                lagGammelInntektsmelding().copy(
+                    fullLønnIArbeidsgiverPerioden =
+                        FullLoennIAgpGammeltFormat(
+                            false,
+                            BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.BetvilerArbeidsufoerhet,
+                            utbetalt,
+                        ),
+                )
+            val agp = imMedReduksjon.convertAgp()
+            agp?.redusertLoennIAgp?.beloep shouldBe utbetalt
+            agp?.redusertLoennIAgp?.begrunnelse shouldBe RedusertLoennIAgp.Begrunnelse.BetvilerArbeidsufoerhet
+        }
+
+        test("convertBegrunnelse") {
+            val gamleBegrunnelser = BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.entries.toList()
+            val nyeBegrunnelser = RedusertLoennIAgp.Begrunnelse.entries.toList()
+            gamleBegrunnelser.forEachIndexed { index, begrunnelse -> begrunnelse.convert() shouldBe nyeBegrunnelser[index] }
+        }
+
+        test("håndterer tomme lister og null-verdier") {
+            val im = lagGammelInntektsmeldingMedTommeOgNullVerdier()
+            im.convertAgp()
+            im.convertInntekt()
+            im.refusjon.convert()
+        }
+
+        test("konverter fra nytt til gammelt IM-format") {
+            val nyIM =
+                mockInntektsmeldingV1().copy(
+                    id = inntektsmeldingId,
+                    type = forespurtType,
+                )
+            val gammelIM = nyIM.convert()
+
+            gammelIM.vedtaksperiodeId shouldBe nyIM.vedtaksperiodeId
+            gammelIM.orgnrUnderenhet shouldBe nyIM.avsender.orgnr.verdi
+            gammelIM.identitetsnummer shouldBe nyIM.sykmeldt.fnr.verdi
+            gammelIM.fraværsperioder shouldBe nyIM.sykmeldingsperioder
+            gammelIM.egenmeldingsperioder shouldBe nyIM.agp?.egenmeldinger
+            gammelIM.arbeidsgiverperioder shouldBe nyIM.agp?.perioder
+            gammelIM.fullLønnIArbeidsgiverPerioden shouldBe
+                FullLoennIAgpGammeltFormat(
+                    false,
+                    begrunnelse = BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.FerieEllerAvspasering,
+                    utbetalt = 300.3,
+                )
+            gammelIM.inntekt shouldBe nyIM.inntekt?.convert()
+            gammelIM.inntektsdato shouldBe nyIM.inntekt?.inntektsdato
+            gammelIM.bestemmendeFraværsdag.shouldBeNull() // settes alltid til 'null'
+            gammelIM.naturalytelser shouldBe
+                listOf(
+                    NaturalytelseGammeltFormat(
+                        naturalytelse = NaturalytelseKodeGammeltFormat.BEDRIFTSBARNEHAGEPLASS,
+                        dato = 10.oktober,
+                        beløp = 52.5,
+                    ),
+                    NaturalytelseGammeltFormat(
+                        naturalytelse = NaturalytelseKodeGammeltFormat.BIL,
+                        dato = 12.oktober,
+                        beløp = 434.0,
+                    ),
+                )
+            gammelIM.refusjon shouldBe nyIM.refusjon?.convert()
+            gammelIM.innsenderNavn shouldBe nyIM.avsender.navn
+            gammelIM.telefonnummer shouldBe nyIM.avsender.tlf
+        }
+
+        test("konverter inntekt fra nytt til gammelt IM-format") {
+            val belop = 1000.0
+            val dato = LocalDate.of(2024, 1, 1)
+            val nyInntekt =
+                Inntekt(
+                    belop,
+                    dato,
+                    listOf(Naturalytelse(Naturalytelse.Kode.BEDRIFTSBARNEHAGEPLASS, belop, dato)),
+                    Feilregistrert,
+                    listOf(Feilregistrert),
+                )
+            val gammelInntekt = nyInntekt.convert()
+            gammelInntekt.beregnetInntekt shouldBe belop
+            gammelInntekt.endringÅrsak shouldBe FeilregistrertGammeltFormat
+            gammelInntekt.bekreftet shouldBe true
+            gammelInntekt.manueltKorrigert shouldBe true
+
+            val nyIM =
+                mockInntektsmeldingV1().copy(
+                    inntekt = nyInntekt,
+                )
+            val konvertert = nyIM.convert()
+            konvertert.naturalytelser shouldBe listOf(NaturalytelseGammeltFormat(NaturalytelseKodeGammeltFormat.BEDRIFTSBARNEHAGEPLASS, dato, belop))
+            konvertert.inntektsdato shouldBe dato
+            konvertert.inntekt?.beregnetInntekt shouldBe belop
+        }
+
+        test("konverter reduksjon til V0") {
+            val belop = 333.33
+            val periode = listOf(10.september til 20.september)
+            val egenmeldinger = listOf(10.september til 12.september)
+
+            val nyIM =
+                mockInntektsmeldingV1().copy(
+                    agp =
+                        Arbeidsgiverperiode(
+                            periode,
+                            egenmeldinger,
+                            RedusertLoennIAgp(belop, RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering),
+                        ),
+                )
+
+            val konvertert = nyIM.convert()
+            konvertert.fullLønnIArbeidsgiverPerioden?.begrunnelse shouldBe BegrunnelseIngenEllerRedusertUtbetalingKodeGammeltFormat.FerieEllerAvspasering
+            konvertert.fullLønnIArbeidsgiverPerioden?.utbetalerFullLønn shouldBe false
+            konvertert.fullLønnIArbeidsgiverPerioden?.utbetalt shouldBe belop
+            konvertert.arbeidsgiverperioder shouldBe periode
+            konvertert.egenmeldingsperioder shouldBe egenmeldinger
+        }
+
+        test("konverter null-verdi for fullLønnIAGP") {
+            val orginal =
+                lagGammelInntektsmeldingMedTommeOgNullVerdier().copy(
+                    fullLønnIArbeidsgiverPerioden = null,
+                )
+
+            val nyIM =
+                mockInntektsmeldingV1().copy(
+                    agp = orginal.convertAgp(),
+                )
+
+            val konvertert = nyIM.convert()
+            konvertert.fullLønnIArbeidsgiverPerioden?.begrunnelse shouldBe null
+            konvertert.fullLønnIArbeidsgiverPerioden?.utbetalerFullLønn shouldBe true
+            konvertert.fullLønnIArbeidsgiverPerioden?.utbetalt shouldBe null
+        }
+
+        test("konverter refusjon til V0") {
+            val belop = 123.45
+            val dato1 = LocalDate.of(2023, 2, 2)
+            val dato2 = LocalDate.of(2023, 2, 2)
+            val refusjon = Refusjon(belop, listOf(RefusjonEndring(belop, dato1)), dato2)
+            val gammelRefusjon = refusjon.convert()
+            gammelRefusjon.refusjonEndringer shouldBe listOf(RefusjonEndringGammeltFormat(belop, dato1))
+            gammelRefusjon.refusjonOpphører shouldBe dato2
+            gammelRefusjon.refusjonPrMnd shouldBe belop
+        }
+    })
+
+private fun lagPeriode(): List<Periode> {
+    val start = LocalDate.of(2023, 1, 1)
+    return List(3) { Periode(start.plusDays(it.toLong()), start.plusDays(it.toLong())) }
+}
+
+private fun lagGammelInntektsmeldingMedTommeOgNullVerdier(): InntektsmeldingGammeltFormat =
+    lagGammelInntektsmelding().copy(
+        fraværsperioder = listOf(1.januar til 1.januar),
+        egenmeldingsperioder = emptyList(),
+        arbeidsgiverperioder = emptyList(),
+        fullLønnIArbeidsgiverPerioden = null,
+        inntekt = null,
+        inntektsdato = null,
+        bestemmendeFraværsdag = null,
+        naturalytelser = null,
+        innsenderNavn = null,
+        telefonnummer = null,
+    )
+
+private fun lagGammelInntektsmelding(): InntektsmeldingGammeltFormat =
+    InntektsmeldingGammeltFormat(
+        orgnrUnderenhet = Orgnr.genererGyldig().verdi,
+        identitetsnummer = Fnr.genererGyldig().verdi,
+        egenmeldingsperioder =
+            listOf(
+                12.september til 13.september,
+            ),
+        fraværsperioder =
+            listOf(
+                14.september til 20.september,
+                28.september til 21.oktober,
+            ),
+        arbeidsgiverperioder =
+            listOf(
+                12.september til 20.september,
+                28.september til 4.oktober,
+            ),
+        inntektsdato = null,
+        inntekt =
+            InntektGammeltFormat(
+                bekreftet = true,
+                beregnetInntekt = 100.0,
+                endringÅrsak = null,
+                manueltKorrigert = false,
+            ),
+        fullLønnIArbeidsgiverPerioden = null,
+        refusjon =
+            RefusjonGammeltFormat(
+                utbetalerHeleEllerDeler = true,
+                refusjonPrMnd = 50.0,
+                refusjonOpphører = LocalDate.EPOCH,
+                refusjonEndringer = emptyList(),
+            ),
+        naturalytelser = null,
+        innsenderNavn = "innsender",
+        telefonnummer = "22222222",
+        vedtaksperiodeId = UUID.randomUUID(),
+    )

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiverTest.kt
@@ -14,7 +14,6 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -45,7 +44,7 @@ class LagreImRiverTest :
         }
 
         test("inntektsmelding lagres") {
-            every { mockImRepo.oppdaterMedBeriketDokument(any(), any(), any()) } just Runs
+            every { mockImRepo.oppdaterMedBeriketDokument(any(), any()) } just Runs
 
             val nyInntektsmelding = mockInntektsmeldingV1()
 
@@ -68,13 +67,13 @@ class LagreImRiverTest :
                 )
 
             verifySequence {
-                mockImRepo.oppdaterMedBeriketDokument(innkommendeMelding.inntektsmelding.type.id, innsendingId, nyInntektsmelding.convert())
+                mockImRepo.oppdaterMedBeriketDokument(innsendingId, nyInntektsmelding)
             }
         }
 
         test("håndterer at repo feiler") {
             every {
-                mockImRepo.oppdaterMedBeriketDokument(any(), any(), any())
+                mockImRepo.oppdaterMedBeriketDokument(any(), any())
             } throws RuntimeException("thank you, next")
 
             val innkommendeMelding = innkommendeMelding(innsendingId)
@@ -93,7 +92,7 @@ class LagreImRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
 
             verifySequence {
-                mockImRepo.oppdaterMedBeriketDokument(any(), any(), any())
+                mockImRepo.oppdaterMedBeriketDokument(any(), any())
             }
         }
 
@@ -114,7 +113,7 @@ class LagreImRiverTest :
                 testRapid.inspektør.size shouldBeExactly 0
 
                 verify(exactly = 0) {
-                    mockImRepo.oppdaterMedBeriketDokument(any(), any(), any())
+                    mockImRepo.oppdaterMedBeriketDokument(any(), any())
                 }
             }
         }

--- a/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
+++ b/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockInntektsmelding.kt
@@ -1,6 +1,5 @@
 package no.nav.helsearbeidsgiver.felles.test.mock
 
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.Utils.convert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
@@ -17,6 +16,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.domene.EksternInntektsmelding
+import no.nav.helsearbeidsgiver.felles.utils.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.test.date.kl
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.date.november
@@ -25,9 +25,7 @@ import no.nav.helsearbeidsgiver.utils.test.date.september
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
-import java.time.ZoneOffset
 import java.util.UUID
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.deprecated.Inntektsmelding as InntektsmeldingGammeltFormat
 
 fun mockSkjemaInntektsmelding(): SkjemaInntektsmelding {
     val inntektsmelding = mockInntektsmeldingV1()
@@ -86,7 +84,7 @@ fun mockInntektsmeldingV1(): Inntektsmelding =
         inntekt = mockInntekt(),
         refusjon = mockRefusjon(),
         aarsakInnsending = AarsakInnsending.Endring,
-        mottatt = 14.mars.kl(14, 41, 42, 0).atOffset(ZoneOffset.ofHours(1)),
+        mottatt = 14.mars.kl(14, 41, 42, 0).toOffsetDateTimeOslo(),
         vedtaksperiodeId = UUID.randomUUID(),
     )
 
@@ -158,8 +156,6 @@ fun mockRefusjon(): Refusjon =
             ),
         sluttdato = 30.november,
     )
-
-fun mockInntektsmeldingGammeltFormat(): InntektsmeldingGammeltFormat = mockInntektsmeldingV1().convert()
 
 fun mockEksternInntektsmelding(): EksternInntektsmelding =
     EksternInntektsmelding(

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -22,7 +22,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.test.json.lesBehov
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
-import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingGammeltFormat
+import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.bjarneBetjent
@@ -53,10 +53,10 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
 
     @Test
     fun `skal berike og lagre inntektsmeldinger`() {
-        val tidligereInntektsmelding = mockInntektsmeldingGammeltFormat()
+        val tidligereInntektsmelding = mockInntektsmeldingV1()
 
         val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema, 10.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(Mock.forespoerselId, innsendingId, tidligereInntektsmelding)
+        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
 
         coEvery {
             dokarkivClient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
@@ -168,10 +168,10 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
 
     @Test
     fun `skal opprette en bakgrunnsjobb som gjenopptar berikelsen av inntektsmeldingen senere dersom oppslaget mot pdl feiler`() {
-        val tidligereInntektsmelding = mockInntektsmeldingGammeltFormat()
+        val tidligereInntektsmelding = mockInntektsmeldingV1()
 
         val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema, 10.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(Mock.forespoerselId, innsendingId, tidligereInntektsmelding)
+        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
 
         coEvery {
             dokarkivClient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -19,7 +19,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.test.mock.mockForespurtData
-import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingGammeltFormat
+import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -44,10 +44,10 @@ class InnsendingServiceIT : EndToEndTest() {
     @Test
     fun `Test at innsending er mottatt`() {
         val kontekstId: UUID = UUID.randomUUID()
-        val tidligereInntektsmelding = mockInntektsmeldingGammeltFormat()
+        val tidligereInntektsmelding = mockInntektsmeldingV1()
 
         val innsendingId = imRepository.lagreInntektsmeldingSkjema(Mock.skjema, 9.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(Mock.skjema.forespoerselId, innsendingId, tidligereInntektsmelding)
+        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
 
         mockForespoerselSvarFraHelsebro(
             forespoerselId = Mock.skjema.forespoerselId,

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -10,7 +10,7 @@ import no.nav.helsearbeidsgiver.felles.json.toJson
 import no.nav.helsearbeidsgiver.felles.json.toMap
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.test.mock.mockEksternInntektsmelding
-import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingGammeltFormat
+import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.mock.mockForespoerselSvarSuksess
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
@@ -33,7 +33,7 @@ class KvitteringIT : EndToEndTest() {
     fun `skal hente data til kvittering`() {
         val kontekstId = UUID.randomUUID()
         val skjema = mockSkjemaInntektsmelding()
-        val inntektsmelding = mockInntektsmeldingGammeltFormat()
+        val inntektsmelding = mockInntektsmeldingV1()
         val mottatt = 3.desember.atStartOfDay()
 
         mockForespoerselSvarFraHelsebro(
@@ -45,7 +45,7 @@ class KvitteringIT : EndToEndTest() {
         )
 
         val innsendingId = imRepository.lagreInntektsmeldingSkjema(skjema, mottatt)
-        imRepository.oppdaterMedBeriketDokument(skjema.forespoerselId, innsendingId, inntektsmelding)
+        imRepository.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),
@@ -67,7 +67,7 @@ class KvitteringIT : EndToEndTest() {
                 success.shouldNotBeNull()
                 success.fromJson(LagretInntektsmelding.serializer()) shouldBe
                     LagretInntektsmelding.Skjema(
-                        avsenderNavn = inntektsmelding.innsenderNavn,
+                        avsenderNavn = inntektsmelding.avsender.navn,
                         skjema = skjema,
                         mottatt = mottatt,
                     )


### PR DESCRIPTION
Lagrer denne ID-en slik at vi kan bruke den i ettertid.

Sniker også med en del dataklasser og konverteringsfunksjoner, men disse er stort sett blåkopiert fra domenepakken. Disse klassene er nå kun brukt for å lese gamle databaserader, så de kan fjernes fra domenepakken etter denne PR-en.