### PR TITLE
Bytt fra innsending-ID til inntektsmelding-ID ved lagring av journalpost-ID

### DIFF
--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -151,7 +151,7 @@ class InntektsmeldingRepository(
             }
         }
 
-    fun hentNyesteBerikedeInntektsmeldigId(forespoerselId: UUID): UUID? =
+    fun hentNyesteBerikedeInntektsmeldingId(forespoerselId: UUID): UUID? =
         transaction(db) {
             hentNyesteImQuery(forespoerselId)
                 .firstOrNull()

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImRiver.kt
@@ -27,7 +27,6 @@ data class LagreImMelding(
     val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val inntektsmelding: Inntektsmelding,
-    val innsendingId: Long,
 )
 
 class LagreImRiver(
@@ -48,14 +47,13 @@ class LagreImRiver(
                 kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 inntektsmelding = Key.INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
-                innsendingId = Key.INNSENDING_ID.les(Long.serializer(), data),
             )
         }
 
     override fun LagreImMelding.bestemNoekkel(): KafkaKey = KafkaKey(inntektsmelding.type.id)
 
     override fun LagreImMelding.haandter(json: Map<Key, JsonElement>): Map<Key, JsonElement> {
-        imRepo.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
+        imRepo.oppdaterMedBeriketDokument(inntektsmelding)
         sikkerLogger.info("Lagret inntektsmelding.")
 
         return mapOf(

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -58,8 +58,7 @@ class LagreImSkjemaRiver(
                 kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 forespoersel = Key.FORESPOERSEL_SVAR.les(Forespoersel.serializer(), data),
-                // TODO fjern default etter overgangsfase
-                inntektsmeldingId = Key.INNTEKTSMELDING_ID.lesOrNull(UuidSerializer, data) ?: UUID.randomUUID(),
+                inntektsmeldingId = Key.INNTEKTSMELDING_ID.les(UuidSerializer, data),
                 skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), data),
                 mottatt = Key.MOTTATT.les(LocalDateTimeSerializer, data),
                 innsending = Key.INNSENDING.lesOrNull(Innsending.serializer(), data),

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -57,7 +57,7 @@ class LagreJournalpostIdRiver(
             is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> {
                 imRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
 
-                if (imRepo.hentNyesteBerikedeInntektsmeldigId(inntektsmelding.type.id) != inntektsmelding.id) {
+                if (imRepo.hentNyesteBerikedeInntektsmeldingId(inntektsmelding.type.id) != inntektsmelding.id) {
                     "Inntektsmelding journalført, men ikke distribuert pga. nyere innsending.".also {
                         logger.info(it)
                         sikkerLogger.info(it)

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -67,7 +67,7 @@ class InntektsmeldingRepositoryTest :
             record.getOrNull(InntektsmeldingEntitet.skjema) shouldBe skjema
             record.getOrNull(InntektsmeldingEntitet.dokument) shouldBe inntektsmelding.convert()
 
-            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmelding.id
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldingId(skjema.forespoerselId) shouldBe inntektsmelding.id
         }
 
         test("skal lagre hvert innsendte skjema, men hente nyeste berikede inntektsmelding") {
@@ -86,10 +86,10 @@ class InntektsmeldingRepositoryTest :
             inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt.plusHours(6))
 
             inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId1))
-            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmeldingId1
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldingId(skjema.forespoerselId) shouldBe inntektsmeldingId1
 
             inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId2))
-            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmeldingId2
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldingId(skjema.forespoerselId) shouldBe inntektsmeldingId2
         }
 
         test("skal returnere im med gammelt inntekt-format ok") {

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.db
 import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldHaveSize
 import io.kotest.matchers.comparables.shouldBeLessThan
-import io.kotest.matchers.equals.shouldNotBeEqual
 import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
@@ -28,7 +27,6 @@ import org.jetbrains.exposed.sql.and
 import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
-import java.time.OffsetDateTime
 import java.util.UUID
 
 class TestRepo(
@@ -50,49 +48,48 @@ class InntektsmeldingRepositoryTest :
         val inntektsmeldingRepo = InntektsmeldingRepository(db)
         val testRepo = TestRepo(db)
 
-        test("skal lagre inntektsmeldingskjema og dokument") {
+        test("skal lagre inntektsmeldingskjema og inntektsmelding") {
             transaction {
                 InntektsmeldingEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
             val skjema = mockSkjemaInntektsmelding()
+            val mottatt = 9.desember.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
 
-            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, 9.desember.atStartOfDay())
-
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId, beriketDokument)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding)
 
             val record = testRepo.hentRecordFraInntektsmelding(skjema.forespoerselId).shouldNotBeNull()
 
             record.getOrNull(InntektsmeldingEntitet.journalpostId) shouldBe null
             record.getOrNull(InntektsmeldingEntitet.eksternInntektsmelding) shouldBe null
             record.getOrNull(InntektsmeldingEntitet.skjema) shouldBe skjema
-            record.getOrNull(InntektsmeldingEntitet.dokument) shouldBe beriketDokument.convert()
+            record.getOrNull(InntektsmeldingEntitet.dokument) shouldBe inntektsmelding.convert()
 
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmelding.id
         }
 
-        test("skal lagre hvert innsendte skjema med ny innsendingId, men hente nyeste berikede inntektsmelding") {
+        test("skal lagre hvert innsendte skjema, men hente nyeste berikede inntektsmelding") {
             transaction {
                 InntektsmeldingEntitet.selectAll().toList()
             }.shouldBeEmpty()
 
             val skjema = mockSkjemaInntektsmelding()
             val mottatt = 27.mars.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
+            val inntektsmeldingId1 = UUID.randomUUID()
+            val inntektsmeldingId2 = UUID.randomUUID()
 
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
             inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt.plusHours(6))
 
-            innsendingId1 shouldNotBeEqual innsendingId2
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId1))
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmeldingId1
 
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = OffsetDateTime.now())
-
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId2, beriketDokument.copy(id = UUID.randomUUID()))
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId2
-
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId1, beriketDokument.copy(id = UUID.randomUUID()))
-            inntektsmeldingRepo.hentNyesteBerikedeInnsendingId(skjema.forespoerselId) shouldBe innsendingId2
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId2))
+            inntektsmeldingRepo.hentNyesteBerikedeInntektsmeldigId(skjema.forespoerselId) shouldBe inntektsmeldingId2
         }
 
         test("skal returnere im med gammelt inntekt-format ok") {
@@ -101,11 +98,11 @@ class InntektsmeldingRepositoryTest :
             }.shouldBeEmpty()
 
             val skjema = mockSkjemaInntektsmelding()
-            val inntektsmelding = mockInntektsmeldingV1()
+            val mottatt = 9.desember.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
 
-            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, 9.desember.atStartOfDay())
-
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding)
 
             transaction {
                 InntektsmeldingEntitet
@@ -123,13 +120,13 @@ class InntektsmeldingRepositoryTest :
             }.shouldBeEmpty()
 
             val skjema = mockSkjemaInntektsmelding()
-            val journalpost1 = randomDigitString(7)
+            val mottatt = 9.desember.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
+            val journalpost = randomDigitString(7)
 
-            val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, 9.desember.atStartOfDay())
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId, beriketDokument)
-
-            inntektsmeldingRepo.oppdaterJournalpostId(innsendingId, journalpost1)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding)
+            inntektsmeldingRepo.oppdaterJournalpostId(inntektsmelding.id, journalpost)
 
             val record = testRepo.hentRecordFraInntektsmelding(skjema.forespoerselId)
 
@@ -141,18 +138,20 @@ class InntektsmeldingRepositoryTest :
 
         test("skal oppdatere im med journalpostId") {
             val skjema = mockSkjemaInntektsmelding()
-            val journalpostId = "jp-mollefonken-kjele"
             val mottatt = 16.mars.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
+            val inntektsmeldingId1 = UUID.randomUUID()
+            val inntektsmeldingId2 = UUID.randomUUID()
+            val journalpostId = randomDigitString(9)
 
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
 
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId1, beriketDokument.copy(id = UUID.randomUUID()))
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId2, beriketDokument.copy(id = UUID.randomUUID()))
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId1))
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId2))
 
             // Skal kun oppdatere den andre av de to inntektsmeldingene
-            inntektsmeldingRepo.oppdaterJournalpostId(innsendingId2, journalpostId)
+            inntektsmeldingRepo.oppdaterJournalpostId(inntektsmeldingId2, journalpostId)
 
             val resultat =
                 transaction(db) {
@@ -177,18 +176,20 @@ class InntektsmeldingRepositoryTest :
 
         test("skal oppdatere inntektsmelding med journalpostId selv om den allerede har dette") {
             val skjema = mockSkjemaInntektsmelding()
+            val mottatt = 5.mars.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
+            val inntektsmeldingId1 = UUID.randomUUID()
+            val inntektsmeldingId2 = UUID.randomUUID()
             val gammelJournalpostId = "jp-traust-gevir"
             val nyJournalpostId = "jp-gallant-badehette"
-            val mottatt = 5.mars.atStartOfDay()
 
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
-            val innsendingId2 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
 
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = OffsetDateTime.now())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId1, beriketDokument.copy(id = UUID.randomUUID()))
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId2, beriketDokument.copy(id = UUID.randomUUID()))
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId1))
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding.copy(id = inntektsmeldingId2))
 
-            inntektsmeldingRepo.oppdaterJournalpostId(innsendingId2, gammelJournalpostId)
+            inntektsmeldingRepo.oppdaterJournalpostId(inntektsmeldingId2, gammelJournalpostId)
 
             val resultatFoerNyJournalpostId =
                 transaction(db) {
@@ -211,7 +212,7 @@ class InntektsmeldingRepositoryTest :
             }
 
             // Oppdater journalpostId
-            inntektsmeldingRepo.oppdaterJournalpostId(innsendingId2, nyJournalpostId)
+            inntektsmeldingRepo.oppdaterJournalpostId(inntektsmeldingId2, nyJournalpostId)
 
             val resultsEtterNyJournalpostId =
                 transaction(db) {
@@ -237,15 +238,15 @@ class InntektsmeldingRepositoryTest :
         test("skal _ikke_ oppdatere journalpostId for ekstern inntektsmelding") {
             val skjema = mockSkjemaInntektsmelding()
             val mottatt = 9.desember.atStartOfDay()
+            val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
             val journalpostId = "jp-slem-fryser"
 
-            val innsendingId1 = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding)
 
-            val beriketDokument = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
-            inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId1, beriketDokument)
             inntektsmeldingRepo.lagreEksternInntektsmelding(skjema.forespoerselId, mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(1)))
 
-            inntektsmeldingRepo.oppdaterJournalpostId(innsendingId1, journalpostId)
+            inntektsmeldingRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
 
             val resultat =
                 transaction(db) {
@@ -311,12 +312,12 @@ class InntektsmeldingRepositoryTest :
 
             test("henter skjema (med inntektsmelding)") {
                 val skjema = mockSkjemaInntektsmelding()
-                // Bruk inntektsmelding som er ulikt skjema for å sjekke at hentet skjema ikke stammer fra inntektsmelding
-                val inntektsmelding = mockInntektsmeldingV1().copy(inntekt = null)
                 val mottatt = 9.desember.atStartOfDay()
+                // Bruk inntektsmelding som er ulikt skjema for å sjekke at hentet skjema ikke stammer fra inntektsmelding
+                val inntektsmelding = mockInntektsmeldingV1().copy(inntekt = null, mottatt = mottatt.toOffsetDateTimeOslo())
 
-                val innsendingId = inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
-                inntektsmeldingRepo.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+                inntektsmeldingRepo.oppdaterMedBeriketDokument(inntektsmelding)
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId)
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -50,7 +50,7 @@ class LagreJournalpostIdRiverTest :
                 val innkommendeMelding = Mock.innkommendeMelding()
 
                 every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
-                every { mockImRepo.hentNyesteBerikedeInntektsmeldigId(any()) } returns innkommendeMelding.inntektsmelding.id
+                every { mockImRepo.hentNyesteBerikedeInntektsmeldingId(any()) } returns innkommendeMelding.inntektsmelding.id
 
                 testRapid.sendJson(innkommendeMelding.toMap())
 
@@ -66,7 +66,7 @@ class LagreJournalpostIdRiverTest :
 
                 verifySequence {
                     mockImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmelding.id, innkommendeMelding.journalpostId)
-                    mockImRepo.hentNyesteBerikedeInntektsmeldigId(innkommendeMelding.inntektsmelding.type.id)
+                    mockImRepo.hentNyesteBerikedeInntektsmeldingId(innkommendeMelding.inntektsmelding.type.id)
                 }
                 verify(exactly = 0) {
                     mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -109,7 +109,7 @@ class LagreJournalpostIdRiverTest :
 
         test("journalpost-ID lagres i databasen, men blir ikke sendt videre fordi IM ikke er nyeste innsending") {
             every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
-            every { mockImRepo.hentNyesteBerikedeInntektsmeldigId(any()) } returns UUID.randomUUID()
+            every { mockImRepo.hentNyesteBerikedeInntektsmeldingId(any()) } returns UUID.randomUUID()
 
             val innkommendeMelding = Mock.innkommendeMelding()
 
@@ -119,7 +119,7 @@ class LagreJournalpostIdRiverTest :
 
             verifySequence {
                 mockImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmelding.id, innkommendeMelding.journalpostId)
-                mockImRepo.hentNyesteBerikedeInntektsmeldigId(innkommendeMelding.inntektsmelding.type.id)
+                mockImRepo.hentNyesteBerikedeInntektsmeldingId(innkommendeMelding.inntektsmelding.type.id)
             }
             verify(exactly = 0) {
                 mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiverTest.kt
@@ -12,7 +12,6 @@ import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
@@ -28,7 +27,6 @@ import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.firstMessage
 import no.nav.helsearbeidsgiver.felles.test.rapidsrivers.sendJson
 import no.nav.helsearbeidsgiver.inntektsmelding.db.InntektsmeldingRepository
 import no.nav.helsearbeidsgiver.inntektsmelding.db.SelvbestemtImRepo
-import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.INNSENDING_ID
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.Mock.toMap
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
@@ -49,10 +47,10 @@ class LagreJournalpostIdRiverTest :
 
         context("journalpost-ID lagres i databasen") {
             test("forespurt IM") {
-                every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
-                every { mockImRepo.hentNyesteBerikedeInnsendingId(any()) } returns INNSENDING_ID
-
                 val innkommendeMelding = Mock.innkommendeMelding()
+
+                every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
+                every { mockImRepo.hentNyesteBerikedeInntektsmeldigId(any()) } returns innkommendeMelding.inntektsmelding.id
 
                 testRapid.sendJson(innkommendeMelding.toMap())
 
@@ -67,8 +65,8 @@ class LagreJournalpostIdRiverTest :
                     )
 
                 verifySequence {
-                    mockImRepo.oppdaterJournalpostId(INNSENDING_ID, innkommendeMelding.journalpostId)
-                    mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmelding.type.id)
+                    mockImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmelding.id, innkommendeMelding.journalpostId)
+                    mockImRepo.hentNyesteBerikedeInntektsmeldigId(innkommendeMelding.inntektsmelding.type.id)
                 }
                 verify(exactly = 0) {
                     mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -88,11 +86,7 @@ class LagreJournalpostIdRiverTest :
                         ),
                     )
 
-                testRapid.sendJson(
-                    innkommendeMelding
-                        .toMap()
-                        .minus(Key.INNSENDING_ID),
-                )
+                testRapid.sendJson(innkommendeMelding.toMap())
 
                 testRapid.inspektør.size shouldBeExactly 1
 
@@ -115,7 +109,7 @@ class LagreJournalpostIdRiverTest :
 
         test("journalpost-ID lagres i databasen, men blir ikke sendt videre fordi IM ikke er nyeste innsending") {
             every { mockImRepo.oppdaterJournalpostId(any(), any()) } just Runs
-            every { mockImRepo.hentNyesteBerikedeInnsendingId(any()) } returns INNSENDING_ID + 1L
+            every { mockImRepo.hentNyesteBerikedeInntektsmeldigId(any()) } returns UUID.randomUUID()
 
             val innkommendeMelding = Mock.innkommendeMelding()
 
@@ -124,8 +118,8 @@ class LagreJournalpostIdRiverTest :
             testRapid.inspektør.size shouldBeExactly 0
 
             verifySequence {
-                mockImRepo.oppdaterJournalpostId(INNSENDING_ID, innkommendeMelding.journalpostId)
-                mockImRepo.hentNyesteBerikedeInnsendingId(innkommendeMelding.inntektsmelding.type.id)
+                mockImRepo.oppdaterJournalpostId(innkommendeMelding.inntektsmelding.id, innkommendeMelding.journalpostId)
+                mockImRepo.hentNyesteBerikedeInntektsmeldigId(innkommendeMelding.inntektsmelding.type.id)
             }
             verify(exactly = 0) {
                 mockSelvbestemtImRepo.oppdaterJournalpostId(any(), any())
@@ -220,15 +214,12 @@ class LagreJournalpostIdRiverTest :
     })
 
 private object Mock {
-    const val INNSENDING_ID = 1L
-
     fun innkommendeMelding(inntektsmelding: Inntektsmelding = mockInntektsmeldingV1()): LagreJournalpostIdMelding =
         LagreJournalpostIdMelding(
             eventName = EventName.INNTEKTSMELDING_JOURNALFOERT,
             kontekstId = UUID.randomUUID(),
             inntektsmelding = inntektsmelding,
             journalpostId = randomDigitString(10),
-            innsendingId = INNSENDING_ID,
         )
 
     fun LagreJournalpostIdMelding.toMap(): Map<Key, JsonElement> =
@@ -237,7 +228,6 @@ private object Mock {
             Key.KONTEKST_ID to kontekstId.toJson(),
             Key.JOURNALPOST_ID to journalpostId.toJson(),
             Key.INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-            Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
         )
 
     val fail = mockFail("I er et steinras og du skal falla med meg.", EventName.INNTEKTSMELDING_MOTTATT)

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -25,6 +25,8 @@ enum class Key : IKey {
     FORESPOERSEL_MAP,
     FORESPOERSEL_SVAR,
     INNSENDING,
+
+    // TODO fjern etter overgangsperiode
     INNSENDING_ID,
     INNTEKT,
     INNTEKTSDATO,

--- a/apps/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/InnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no.nav.helsearbeidsgiver.inntektsmelding.innsending/InnsendingServiceTest.kt
@@ -204,6 +204,7 @@ private object Mock {
     fun steg2(kontekstId: UUID): Map<Key, JsonElement> =
         steg1(kontekstId).plusData(
             mapOf(
+                Key.INNTEKTSMELDING_ID to UUID.randomUUID().toJson(),
                 Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
                 Key.INNSENDING_ID to INNSENDING_ID.toJson(Long.serializer()),
             ),

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -54,8 +54,8 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
     fun `skal berike og lagre inntektsmeldinger`() {
         val tidligereInntektsmelding = mockInntektsmeldingV1()
 
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(tidligereInntektsmelding.id, Mock.skjema, 10.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
+        imRepository.lagreInntektsmeldingSkjema(tidligereInntektsmelding.id, Mock.skjema, 10.desember.atStartOfDay())
+        imRepository.oppdaterMedBeriketDokument(tidligereInntektsmelding)
 
         coEvery {
             dokarkivClient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
@@ -76,7 +76,6 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                     Key.FORESPOERSEL_SVAR to Mock.forespoersel.toJson(Forespoersel.serializer()),
                     Key.INNTEKTSMELDING_ID to UUID.randomUUID().toJson(),
                     Key.SKJEMA_INNTEKTSMELDING to Mock.skjema.toJson(SkjemaInntektsmelding.serializer()),
-                    Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                     Key.MOTTATT to Mock.mottatt.toJson(),
                 ).toJson(),
         )
@@ -154,8 +153,8 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
     fun `skal opprette en bakgrunnsjobb som gjenopptar berikelsen av inntektsmeldingen senere dersom oppslaget mot pdl feiler`() {
         val tidligereInntektsmelding = mockInntektsmeldingV1()
 
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(tidligereInntektsmelding.id, Mock.skjema, 10.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
+        imRepository.lagreInntektsmeldingSkjema(tidligereInntektsmelding.id, Mock.skjema, 10.desember.atStartOfDay())
+        imRepository.oppdaterMedBeriketDokument(tidligereInntektsmelding)
 
         coEvery {
             dokarkivClient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
@@ -182,7 +181,6 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                     Key.FORESPOERSEL_SVAR to Mock.forespoersel.toJson(Forespoersel.serializer()),
                     Key.INNTEKTSMELDING_ID to UUID.randomUUID().toJson(),
                     Key.SKJEMA_INNTEKTSMELDING to Mock.skjema.toJson(SkjemaInntektsmelding.serializer()),
-                    Key.INNSENDING_ID to innsendingId.toJson(Long.serializer()),
                     Key.MOTTATT to Mock.mottatt.toJson(),
                 ).toJson(),
         )

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -46,8 +46,8 @@ class InnsendingServiceIT : EndToEndTest() {
         val kontekstId: UUID = UUID.randomUUID()
         val tidligereInntektsmelding = mockInntektsmeldingV1()
 
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(UUID.randomUUID(), Mock.skjema, 9.desember.atStartOfDay())
-        imRepository.oppdaterMedBeriketDokument(innsendingId, tidligereInntektsmelding)
+        imRepository.lagreInntektsmeldingSkjema(tidligereInntektsmelding.id, Mock.skjema, 9.desember.atStartOfDay())
+        imRepository.oppdaterMedBeriketDokument(tidligereInntektsmelding)
 
         mockForespoerselSvarFraHelsebro(
             forespoerselId = Mock.skjema.forespoerselId,

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -44,8 +44,8 @@ class KvitteringIT : EndToEndTest() {
                 ),
         )
 
-        val innsendingId = imRepository.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
-        imRepository.oppdaterMedBeriketDokument(innsendingId, inntektsmelding)
+        imRepository.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+        imRepository.oppdaterMedBeriketDokument(inntektsmelding)
 
         publish(
             Key.EVENT_NAME to EventName.KVITTERING_REQUESTED.toJson(),


### PR DESCRIPTION
Nå som inntektsmelding-ID finnes i databasen så kan den brukes til å sette journalpost-ID på korrekt rad, og innsending-ID kan fases ut. Sistnevnte må gjøres i flere steg, for å unngå in-flight problemer.