### PR TITLE
Fjern utdatert responsfelt

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
@@ -4,7 +4,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
-import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.ForespurtData
@@ -26,11 +25,8 @@ data class HentForespoerselResponse(
     val bruttoinntekt: Double?,
     val tidligereinntekter: List<InntektPerMaaned>,
     val forespurtData: ForespurtData?,
-    val opprettetUpresisIkkeBruk: LocalDate,
     val erBesvart: Boolean,
     val feilReport: FeilReport? = null,
-    val success: JsonElement? = null,
-    val failure: JsonElement? = null,
 )
 
 @Deprecated("fjern når det ikke lenger brukes i frontend")

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -94,42 +94,35 @@ fun Route.hentForespoersel(
     }
 }
 
-private fun HentForespoerselResultat.toResponse(): HentForespoerselResponse {
-    val response =
-        HentForespoerselResponse(
-            navn = sykmeldtNavn,
-            innsenderNavn = avsenderNavn,
-            orgNavn = orgNavn,
-            identitetsnummer = forespoersel.fnr.verdi,
-            orgnrUnderenhet = forespoersel.orgnr.verdi,
-            fravaersperioder = forespoersel.sykmeldingsperioder,
-            egenmeldingsperioder = forespoersel.egenmeldingsperioder,
-            bestemmendeFravaersdag = forespoersel.forslagBestemmendeFravaersdag(),
-            eksternBestemmendeFravaersdag = forespoersel.eksternBestemmendeFravaersdag(),
-            bruttoinntekt = inntekt?.gjennomsnitt(),
-            tidligereinntekter = inntekt?.maanedOversikt.orEmpty(),
-            forespurtData = forespoersel.forespurtData,
-            opprettetUpresisIkkeBruk = forespoersel.opprettetUpresisIkkeBruk,
-            erBesvart = forespoersel.erBesvart,
-            feilReport =
-                if (feil.isEmpty()) {
-                    null
-                } else {
-                    FeilReport(
-                        feil =
-                            feil
-                                .map {
-                                    Feilmelding(
-                                        melding = it.value,
-                                        status = null,
-                                        datafelt = it.key,
-                                    )
-                                }.toMutableList(),
-                    )
-                },
-        )
-
-    return response.copy(
-        success = response.toJson(HentForespoerselResponse.serializer()),
+private fun HentForespoerselResultat.toResponse(): HentForespoerselResponse =
+    HentForespoerselResponse(
+        navn = sykmeldtNavn,
+        innsenderNavn = avsenderNavn,
+        orgNavn = orgNavn,
+        identitetsnummer = forespoersel.fnr.verdi,
+        orgnrUnderenhet = forespoersel.orgnr.verdi,
+        fravaersperioder = forespoersel.sykmeldingsperioder,
+        egenmeldingsperioder = forespoersel.egenmeldingsperioder,
+        bestemmendeFravaersdag = forespoersel.forslagBestemmendeFravaersdag(),
+        eksternBestemmendeFravaersdag = forespoersel.eksternBestemmendeFravaersdag(),
+        bruttoinntekt = inntekt?.gjennomsnitt(),
+        tidligereinntekter = inntekt?.maanedOversikt.orEmpty(),
+        forespurtData = forespoersel.forespurtData,
+        erBesvart = forespoersel.erBesvart,
+        feilReport =
+            if (feil.isEmpty()) {
+                null
+            } else {
+                FeilReport(
+                    feil =
+                        feil
+                            .map {
+                                Feilmelding(
+                                    melding = it.value,
+                                    status = null,
+                                    datafelt = it.key,
+                                )
+                            }.toMutableList(),
+                )
+            },
     )
-}

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -240,24 +240,7 @@ private object Mock {
             "bruttoinntekt": ${inntekt.gjennomsnitt()},
             "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
             "forespurtData": ${forespoersel.forespurtData.hardcodedJson()},
-            "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
-            "erBesvart": ${forespoersel.erBesvart},
-            "success": {
-                "navn": "Ola Normann",
-                "orgNavn": "Norge AS",
-                "innsenderNavn": "Arbeidsgiver",
-                "identitetsnummer": "${forespoersel.fnr}",
-                "orgnrUnderenhet": "${forespoersel.orgnr}",
-                "fravaersperioder": [${forespoersel.sykmeldingsperioder.joinToString(transform = Periode::hardcodedJson)}],
-                "egenmeldingsperioder": [${forespoersel.egenmeldingsperioder.joinToString(transform = Periode::hardcodedJson)}],
-                "bestemmendeFravaersdag": "${forespoersel.forslagBestemmendeFravaersdag()}",
-                "eksternBestemmendeFravaersdag": ${forespoersel.eksternBestemmendeFravaersdag().jsonStrOrNull()},
-                "bruttoinntekt": ${inntekt.gjennomsnitt()},
-                "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
-                "forespurtData": ${forespoersel.forespurtData.hardcodedJson()},
-                "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
-                "erBesvart": ${forespoersel.erBesvart}
-            }
+            "erBesvart": ${forespoersel.erBesvart}
         }
         """.removeJsonWhitespace()
 
@@ -276,24 +259,7 @@ private object Mock {
             "bruttoinntekt": ${inntekt.gjennomsnitt()},
             "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
             "forespurtData": ${mockForespurtDataMedForrigeInntekt().hardcodedJson()},
-            "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
-            "erBesvart": ${forespoersel.erBesvart},
-            "success": {
-                "navn": "Ola Normann",
-                "orgNavn": "Norge AS",
-                "innsenderNavn": "Arbeidsgiver",
-                "identitetsnummer": "${forespoersel.fnr}",
-                "orgnrUnderenhet": "${forespoersel.orgnr}",
-                "fravaersperioder": [${forespoersel.sykmeldingsperioder.joinToString(transform = Periode::hardcodedJson)}],
-                "egenmeldingsperioder": [${forespoersel.egenmeldingsperioder.joinToString(transform = Periode::hardcodedJson)}],
-                "bestemmendeFravaersdag": "${forespoersel.forslagBestemmendeFravaersdag()}",
-                "eksternBestemmendeFravaersdag": ${forespoersel.eksternBestemmendeFravaersdag().jsonStrOrNull()},
-                "bruttoinntekt": ${inntekt.gjennomsnitt()},
-                "tidligereinntekter": [${inntekt.maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}],
-                "forespurtData": ${mockForespurtDataMedForrigeInntekt().hardcodedJson()},
-                "opprettetUpresisIkkeBruk": "${forespoersel.opprettetUpresisIkkeBruk}",
-                "erBesvart": ${forespoersel.erBesvart}
-            }
+            "erBesvart": ${forespoersel.erBesvart}
         }
         """.removeJsonWhitespace()
 }


### PR DESCRIPTION
Fjerner `opprettetUpresisIkkeBruk`, som ikke lenger er i bruk.

Fjerner også `success` og `failure`, som aldri ble tatt i bruk, og som er utdatert som løsning.