### PR TITLE
Fjern utdatert felt fra forespoersel

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -173,7 +173,6 @@ private object Mock {
             forespurtData = mockForespurtData(),
             erBesvart = false,
             vedtaksperiodeId = UUID.randomUUID(),
-            opprettetUpresisIkkeBruk = 31.mars,
         )
 
     private val inntekt =

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -23,7 +23,6 @@ data class Forespoersel(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
-    val opprettetUpresisIkkeBruk: LocalDate,
 ) {
     fun forslagBestemmendeFravaersdag(): LocalDate {
         val forslag = bestemmendeFravaersdager[orgnr]

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -23,7 +23,6 @@ data class ForespoerselFraBro(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
-    val opprettetUpresisIkkeBruk: LocalDate,
 ) {
     fun toForespoersel(): Forespoersel =
         Forespoersel(
@@ -35,6 +34,5 @@ data class ForespoerselFraBro(
             bestemmendeFravaersdager = bestemmendeFravaersdager,
             forespurtData = forespurtData,
             erBesvart = erBesvart,
-            opprettetUpresisIkkeBruk = opprettetUpresisIkkeBruk,
         )
 }

--- a/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
+++ b/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
@@ -28,7 +28,6 @@ fun mockForespoersel(): Forespoersel {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
-        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 

--- a/apps/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
+++ b/apps/forespoersel-mottatt/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmottatt/ForespoerselMottattRiverTest.kt
@@ -91,6 +91,5 @@ object Mock {
             bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
             forespurtData = mockForespurtData(),
             erBesvart = false,
-            opprettetUpresisIkkeBruk = 17.januar,
         )
 }

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -41,7 +41,6 @@ fun mockForespoerselListeSvarMedSuksess(): ForespoerselListeSvar {
                     bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
                     forespurtData = mockForespurtData(),
                     erBesvart = false,
-                    opprettetUpresisIkkeBruk = 17.januar,
                 ),
             ),
         boomerang = mockBoomerang(),
@@ -75,7 +74,6 @@ fun mockForespoerselSvarSuksess(forespoerselId: UUID): ForespoerselFraBro {
         bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
         forespurtData = mockForespurtData(),
         erBesvart = false,
-        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -310,7 +310,6 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
-                opprettetUpresisIkkeBruk = 2.august,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
@@ -22,7 +22,6 @@ import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
@@ -141,7 +140,6 @@ class ForespoerselMottattIT : EndToEndTest() {
                 bestemmendeFravaersdager = emptyMap(),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
-                opprettetUpresisIkkeBruk = 10.februar,
             )
         val sakId = UUID.randomUUID().toString()
         val oppgaveId = UUID.randomUUID().toString()

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -207,7 +207,6 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
-                opprettetUpresisIkkeBruk = 17.juli,
             )
 
         val forespoerselSvar =
@@ -221,7 +220,6 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = forespoersel.bestemmendeFravaersdager,
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
-                opprettetUpresisIkkeBruk = forespoersel.opprettetUpresisIkkeBruk,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -197,7 +197,6 @@ class InnsendingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 17.mars),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
-                opprettetUpresisIkkeBruk = 19.mars,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
@@ -25,7 +25,6 @@ fun mockForespoerselSvarSuksess(): ForespoerselFraBro {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
-        opprettetUpresisIkkeBruk = 17.januar,
     )
 }
 
@@ -48,7 +47,6 @@ fun mockForespoerselListeSvarResultat(
                 ),
             forespurtData = mockForespurtData(),
             erBesvart = false,
-            opprettetUpresisIkkeBruk = 17.januar,
         )
     return listOf(forespoersel, forespoersel.copy(vedtaksperiodeId = vedtaksperiodeId2))
 }


### PR DESCRIPTION
Dette feltet ble sendt til frontend for å kunne aktivere spørreskjema etter purring.