### PR TITLE
Fiks sakoppdatering ved henting av forkastet forespørsel

### DIFF
--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiver.kt
@@ -52,7 +52,7 @@ class UtgaattForespoerselRiver(
                 )
             } else {
                 // Forespørsler som ble forkastet for lenge siden matcher her dersom noen prøver å hente dem
-                val eventName = Key.EVENT_NAME.krev(EventName.TRENGER_REQUESTED, EventName.serializer(), fail.utloesendeMelding)
+                val eventName = Key.EVENT_NAME.les(EventName.serializer(), fail.utloesendeMelding)
                 val behovType = Key.BEHOV.les(BehovType.serializer(), fail.utloesendeMelding)
 
                 if (


### PR DESCRIPTION
For lenge siden så ble forespørsel først hentet under `EventName.TRENGER_REQUESTED`. Nå er det andre, tidligere eventer som prøver å hente og feiler, så oppdaterer her for å reaktualisere denne.