### PR TITLE
Logg til Grafana Loki

### DIFF
--- a/config/nais.yml
+++ b/config/nais.yml
@@ -43,6 +43,9 @@ spec:
   secureLogs:
     enabled: true
   observability:
+    logging:
+      destinations:
+        - id: loki
     autoInstrumentation:
       enabled: true
       runtime: java


### PR DESCRIPTION
Vi skal etter hvert gå over til å ha loggene våre hos Grafana Loki. Setter opp nå slik at vi kan bli mer kjent med hvordan det fungerer før vi må bytte.

Satt opp i følge https://docs.nais.io/observability/logging/how-to/loki/index.html.