### PR TITLE
Fiks PDF viser ikke begrunnelse når ingen agp

### DIFF
--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -7,7 +7,7 @@ interface IKey
 
 @Serializable(KeySerializer::class)
 enum class Key : IKey {
-    // Predefinerte fra rapids-and-rivers biblioteket
+    // Predefinerte fra rapids-and-rivers-biblioteket
     EVENT_NAME,
     BEHOV,
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -7,7 +7,7 @@ interface IKey
 
 @Serializable(KeySerializer::class)
 enum class Key : IKey {
-    // Predefinerte fra rapids-and-rivers-biblioteket
+    // Predefinerte fra rapids-and-rivers  biblioteket
     EVENT_NAME,
     BEHOV,
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Key.kt
@@ -7,7 +7,7 @@ interface IKey
 
 @Serializable(KeySerializer::class)
 enum class Key : IKey {
-    // Predefinerte fra rapids-and-rivers-biblioteket
+    // Predefinerte fra rapids-and-rivers biblioteket
     EVENT_NAME,
     BEHOV,
 

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -294,7 +294,6 @@ class PdfDokument(
             addLabel("Utbetalt under arbeidsgiverperiode", redusertLoennIAgp.beloep.tilNorskFormat() + " kr")
         }
 
-
         addLabel("Betaler arbeidsgiver lønn under hele eller deler av sykefraværet?", (refusjon != null).tilNorskFormat())
         if (refusjon != null) {
             // Ja - tre ekstra spørsmål

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -287,12 +287,13 @@ class PdfDokument(
 
         if (arbeidsgiverperioder.isNotEmpty()) {
             addLabel("Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?", (redusertLoennIAgp == null).tilNorskFormat())
-            if (redusertLoennIAgp != null) {
-                // Redusert lønn i AGP - to ekstra spørsmål
-                addLabel("Begrunnelse", redusertLoennIAgp.begrunnelse.tilTekst())
-                addLabel("Utbetalt under arbeidsgiverperiode", redusertLoennIAgp.beloep.tilNorskFormat() + " kr")
-            }
         }
+        if (redusertLoennIAgp != null) {
+            // Redusert lønn i AGP - to ekstra spørsmål
+            addLabel("Begrunnelse", redusertLoennIAgp.begrunnelse.tilTekst())
+            addLabel("Utbetalt under arbeidsgiverperiode", redusertLoennIAgp.beloep.tilNorskFormat() + " kr")
+        }
+
 
         addLabel("Betaler arbeidsgiver lønn under hele eller deler av sykefraværet?", (refusjon != null).tilNorskFormat())
         if (refusjon != null) {

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -285,9 +285,12 @@ class PdfDokument(
 
         addSection("Refusjon")
 
-        if (arbeidsgiverperioder.isNotEmpty()) {
+        if (arbeidsgiverperioder.isEmpty()) {
+            addLabel("Ingen arbeidsgiverperiode")
+        } else {
             addLabel("Betaler arbeidsgiver full lønn til arbeidstaker i arbeidsgiverperioden?", (redusertLoennIAgp == null).tilNorskFormat())
         }
+
         if (redusertLoennIAgp != null) {
             // Redusert lønn i AGP - to ekstra spørsmål
             addLabel("Begrunnelse", redusertLoennIAgp.begrunnelse.tilTekst())

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -335,8 +335,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
-//        val file = File.createTempFile(title, ".pdf")
+//        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -231,7 +231,7 @@ class PdfDokumentTest {
         val medAgp = im
         val agpErNull = im.copy(agp = null)
         val agpHarTomPeriodeListe = im.copy(agp = Arbeidsgiverperiode(emptyList(), emptyList(), null))
-        val agptHarTomPeriodeListeMedBegrunnelse =
+        val agpHarTomPeriodeListeMedBegrunnelse =
             im.copy(
                 agp =
                     Arbeidsgiverperiode(
@@ -248,7 +248,7 @@ class PdfDokumentTest {
             "med_arbeidsgiverperiode" to medAgp,
             "med_arbeidsgiverperiode_lik_null" to agpErNull,
             "med_ingen_arbeidsgiver_perioder" to agpHarTomPeriodeListe,
-            "med_ingen_arbeidsgiver_perioder_og_begrunnelse" to agptHarTomPeriodeListeMedBegrunnelse,
+            "med_ingen_arbeidsgiver_perioder_og_begrunnelse" to agpHarTomPeriodeListeMedBegrunnelse,
         ).forEach { (filNavn, im) ->
             writePDF(filNavn, im)
         }
@@ -258,9 +258,9 @@ class PdfDokumentTest {
         pdfTekstFraIm(medAgp) shouldContain pdfAgpRelevantTekst
         pdfTekstFraIm(agpErNull) shouldNotContain pdfAgpRelevantTekst
         pdfTekstFraIm(agpHarTomPeriodeListe) shouldNotContain pdfAgpRelevantTekst
-        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldNotContain pdfAgpRelevantTekst
-        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldContain "Ingen arbeidsgiverperiode"
-        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldContain RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering.tilTekst()
+        pdfTekstFraIm(agpHarTomPeriodeListeMedBegrunnelse) shouldNotContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agpHarTomPeriodeListeMedBegrunnelse) shouldContain "Ingen arbeidsgiverperiode"
+        pdfTekstFraIm(agpHarTomPeriodeListeMedBegrunnelse) shouldContain RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering.tilTekst()
     }
 
     @Test

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -259,6 +259,7 @@ class PdfDokumentTest {
         pdfTekstFraIm(agpErNull) shouldNotContain pdfAgpRelevantTekst
         pdfTekstFraIm(agpHarTomPeriodeListe) shouldNotContain pdfAgpRelevantTekst
         pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldNotContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldContain "Ingen arbeidsgiverperiode"
         pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldContain RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering.tilTekst()
     }
 
@@ -334,8 +335,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-//        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
-        val file = File.createTempFile(title, ".pdf")
+        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+//        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -231,11 +231,24 @@ class PdfDokumentTest {
         val medAgp = im
         val agpErNull = im.copy(agp = null)
         val agpHarTomPeriodeListe = im.copy(agp = Arbeidsgiverperiode(emptyList(), emptyList(), null))
+        val agptHarTomPeriodeListeMedBegrunnelse =
+            im.copy(
+                agp =
+                    Arbeidsgiverperiode(
+                        emptyList(),
+                        emptyList(),
+                        RedusertLoennIAgp(
+                            beloep = 0.0,
+                            begrunnelse = RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering,
+                        ),
+                    ),
+            )
 
         mapOf(
             "med_arbeidsgiverperiode" to medAgp,
             "med_arbeidsgiverperiode_lik_null" to agpErNull,
             "med_ingen_arbeidsgiver_perioder" to agpHarTomPeriodeListe,
+            "med_ingen_arbeidsgiver_perioder_og_begrunnelse" to agptHarTomPeriodeListeMedBegrunnelse,
         ).forEach { (filNavn, im) ->
             writePDF(filNavn, im)
         }
@@ -245,6 +258,8 @@ class PdfDokumentTest {
         pdfTekstFraIm(medAgp) shouldContain pdfAgpRelevantTekst
         pdfTekstFraIm(agpErNull) shouldNotContain pdfAgpRelevantTekst
         pdfTekstFraIm(agpHarTomPeriodeListe) shouldNotContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldNotContain pdfAgpRelevantTekst
+        pdfTekstFraIm(agptHarTomPeriodeListeMedBegrunnelse) shouldContain RedusertLoennIAgp.Begrunnelse.FerieEllerAvspasering.tilTekst()
     }
 
     @Test


### PR DESCRIPTION
PDFen i gosys viser ikke begrunnelser for redusert lønn i AGP om det ikke er noen AGP i inntektsmeldingen.

Denne PRen fikser dette.