### PR TITLE
Distribuer inntektsmeldinger med garantert rekkefølge

### DIFF
--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -112,8 +112,10 @@ class DistribusjonRiver(
             )
 
         val record =
-            ProducerRecord<String, String>(
+            ProducerRecord(
                 TOPIC_HELSEARBEIDSGIVER_INNTEKTSMELDING_EKSTERN,
+                journalfoertInntektsmelding.inntektsmelding.type.id
+                    .toString(),
                 journalfoertInntektsmelding.toJsonStr(JournalfoertInntektsmelding.serializer()),
             )
 


### PR DESCRIPTION
Uten en (god) nøkkel i `ProducerRecord` så kan vi ikke garantere rekkefølgen på meldinger som sendes på Kafka-strømmen. Denne har gått under radaren til nå, men ble avslørt da den nylig førte til en prodfeil der to IM-er hadde feil rekkefølge.