### PR TITLE
La producer feile ved problemer

### DIFF
--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -60,7 +60,7 @@ class DistribusjonRiver(
                     journalpostId = journalpostId,
                     inntektsmelding = inntektsmelding,
                 ),
-            ).getOrThrow()
+            )
 
         "Distribuerte IM med journalpost-ID '$journalpostId'.".also {
             logger.info(it)

--- a/apps/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
+++ b/apps/distribusjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiverTest.kt
@@ -5,13 +5,14 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.maps.shouldContainExactly
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.JournalfoertInntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
@@ -59,7 +60,7 @@ class DistribusjonRiverTest :
                         ),
                 ),
             ) { innkommendeMelding ->
-                every { mockProducer.send(any()) } returns Result.success(JsonNull)
+                every { mockProducer.send(any()) } just Runs
 
                 testRapid.sendJson(innkommendeMelding.toMap())
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/kafka/Producer.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/kafka/Producer.kt
@@ -20,27 +20,34 @@ class Producer(
     fun send(
         key: UUID,
         message: Map<Key, JsonElement>,
-    ): Result<JsonElement> = send(key.toString(), message.toJson())
+    ) {
+        send(key.toString(), message.toJson())
+    }
 
     fun send(
         key: Fnr,
         message: Map<Key, JsonElement>,
-    ): Result<JsonElement> = send(key.verdi, message.toJson())
+    ) {
+        send(key.verdi, message.toJson())
+    }
 
     @JvmName("sendWithMessagePriKey")
     fun send(
         key: UUID,
         message: Map<Pri.Key, JsonElement>,
-    ): Result<JsonElement> = send(key.toString(), message.toJson())
+    ) {
+        send(key.toString(), message.toJson())
+    }
 
     /** Brukes til distribusjon. */
-    fun send(inntektsmelding: JournalfoertInntektsmelding): Result<JsonElement> =
+    fun send(inntektsmelding: JournalfoertInntektsmelding) {
         send(
             key =
                 inntektsmelding.inntektsmelding.type.id
                     .toString(),
             message = inntektsmelding.toJson(JournalfoertInntektsmelding.serializer()),
         )
+    }
 
     fun close() {
         producer.close()
@@ -49,11 +56,12 @@ class Producer(
     private fun send(
         key: String,
         message: JsonElement,
-    ): Result<JsonElement> =
-        ProducerRecord(topic, key, message)
-            .runCatching {
-                producer.send(this).get()
-            }.map { message }
+    ) {
+        producer
+            .send(
+                ProducerRecord(topic, key, message),
+            ).get()
+    }
 }
 
 private fun Map<Pri.Key, JsonElement>.toJson(): JsonElement =

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/kafka/ProducerTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/kafka/ProducerTest.kt
@@ -1,8 +1,7 @@
 package no.nav.helsearbeidsgiver.felles.kafka
 
+import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FunSpec
-import io.kotest.matchers.booleans.shouldBeTrue
-import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
@@ -37,7 +36,7 @@ class ProducerTest :
 
         context("send<UUID, Map<Key, JsonElement>>") {
 
-            test("gir suksessobjekt ved sendt melding til kafka stream") {
+            test("sender melding til kafka stream") {
                 every { mockKafkaProducer.send(any()).get() } returns mockRecordMetadata()
 
                 val expectedKey = UUID.randomUUID()
@@ -47,10 +46,7 @@ class ProducerTest :
                         Key.FORESPOERSEL_ID to expectedKey.toJson(),
                     )
 
-                val result = producer.send(expectedKey, expectedMessage)
-
-                result.isSuccess.shouldBeTrue()
-                result.getOrNull() shouldBe expectedMessage.toJson()
+                producer.send(expectedKey, expectedMessage)
 
                 val expected =
                     ProducerRecord(
@@ -62,7 +58,7 @@ class ProducerTest :
                 verifySequence { mockKafkaProducer.send(expected) }
             }
 
-            test("gir feilobjekt ved feilet sending til kafka stream") {
+            test("kaster exception når sending til kafka stream feiler") {
                 val forespoerselId = UUID.randomUUID()
 
                 every { mockKafkaProducer.send(any()) } throws TimeoutException("too slow bro")
@@ -73,10 +69,9 @@ class ProducerTest :
                         Key.FORESPOERSEL_ID to forespoerselId.toJson(),
                     )
 
-                val result = producer.send(forespoerselId, expectedMessage)
-
-                result.isFailure.shouldBeTrue()
-                result.getOrNull() shouldBe null
+                shouldThrowExactly<TimeoutException> {
+                    producer.send(forespoerselId, expectedMessage)
+                }
 
                 verifySequence { mockKafkaProducer.send(any()) }
             }
@@ -84,7 +79,7 @@ class ProducerTest :
 
         context("send<Fnr, Map<Key, JsonElement>>") {
 
-            test("gir suksessobjekt ved sendt melding til kafka stream") {
+            test("sender melding til kafka stream") {
                 every { mockKafkaProducer.send(any()).get() } returns mockRecordMetadata()
 
                 val expectedKey = Fnr.genererGyldig()
@@ -94,10 +89,7 @@ class ProducerTest :
                         Key.SAK_ID to randomDigitString(7).toJson(),
                     )
 
-                val result = producer.send(expectedKey, expectedMessage)
-
-                result.isSuccess.shouldBeTrue()
-                result.getOrNull() shouldBe expectedMessage.toJson()
+                producer.send(expectedKey, expectedMessage)
 
                 val expected =
                     ProducerRecord(
@@ -109,7 +101,7 @@ class ProducerTest :
                 verifySequence { mockKafkaProducer.send(expected) }
             }
 
-            test("gir feilobjekt ved feilet sending til kafka stream") {
+            test("kaster exception når sending til kafka stream feiler") {
                 every { mockKafkaProducer.send(any()) } throws TimeoutException("too slow bro")
 
                 val expectedMessage =
@@ -118,10 +110,9 @@ class ProducerTest :
                         Key.SAK_ID to randomDigitString(11).toJson(),
                     )
 
-                val result = producer.send(Fnr.genererGyldig(), expectedMessage)
-
-                result.isFailure.shouldBeTrue()
-                result.getOrNull() shouldBe null
+                shouldThrowExactly<TimeoutException> {
+                    producer.send(Fnr.genererGyldig(), expectedMessage)
+                }
 
                 verifySequence { mockKafkaProducer.send(any()) }
             }
@@ -129,7 +120,7 @@ class ProducerTest :
 
         context("send<UUID, Map<Pri.Key, JsonElement>>") {
 
-            test("gir suksessobjekt ved sendt melding til kafka stream") {
+            test("sender melding til kafka stream") {
                 every { mockKafkaProducer.send(any()).get() } returns mockRecordMetadata()
 
                 val expectedKey = UUID.randomUUID()
@@ -139,10 +130,7 @@ class ProducerTest :
                         Pri.Key.BOOMERANG to "\uD83E\uDE83".toJson(),
                     )
 
-                val result = producer.send(expectedKey, expectedMessage)
-
-                result.isSuccess.shouldBeTrue()
-                result.getOrNull() shouldBe expectedMessage.toJson()
+                producer.send(expectedKey, expectedMessage)
 
                 val expected =
                     ProducerRecord(
@@ -154,7 +142,7 @@ class ProducerTest :
                 verifySequence { mockKafkaProducer.send(expected) }
             }
 
-            test("gir feilobjekt ved feilet sending til kafka stream") {
+            test("kaster exception når sending til kafka stream feiler") {
                 every { mockKafkaProducer.send(any()) } throws TimeoutException("too slow bro")
 
                 val expectedMessage =
@@ -163,10 +151,9 @@ class ProducerTest :
                         Pri.Key.BOOMERANG to "\uD83E\uDE83".toJson(),
                     )
 
-                val result = producer.send(UUID.randomUUID(), expectedMessage)
-
-                result.isFailure.shouldBeTrue()
-                result.getOrNull() shouldBe null
+                shouldThrowExactly<TimeoutException> {
+                    producer.send(UUID.randomUUID(), expectedMessage)
+                }
 
                 verifySequence { mockKafkaProducer.send(any()) }
             }
@@ -174,7 +161,7 @@ class ProducerTest :
 
         context("send<JournalfoertInntektsmelding>") {
 
-            test("gir suksessobjekt ved sendt melding til kafka stream") {
+            test("sender melding til kafka stream") {
                 every { mockKafkaProducer.send(any()).get() } returns mockRecordMetadata()
 
                 val inntektsmelding =
@@ -183,10 +170,7 @@ class ProducerTest :
                         inntektsmelding = mockInntektsmeldingV1(),
                     )
 
-                val result = producer.send(inntektsmelding)
-
-                result.isSuccess.shouldBeTrue()
-                result.getOrNull() shouldBe inntektsmelding.toJson(JournalfoertInntektsmelding.serializer())
+                producer.send(inntektsmelding)
 
                 val expected =
                     ProducerRecord(
@@ -199,7 +183,7 @@ class ProducerTest :
                 verifySequence { mockKafkaProducer.send(expected) }
             }
 
-            test("gir feilobjekt ved feilet sending til kafka stream") {
+            test("kaster exception når sending til kafka stream feiler") {
                 every { mockKafkaProducer.send(any()) } throws TimeoutException("too slow bro")
 
                 val inntektsmelding =
@@ -208,10 +192,9 @@ class ProducerTest :
                         inntektsmelding = mockInntektsmeldingV1(),
                     )
 
-                val result = producer.send(inntektsmelding)
-
-                result.isFailure.shouldBeTrue()
-                result.getOrNull() shouldBe null
+                shouldThrowExactly<TimeoutException> {
+                    producer.send(inntektsmelding)
+                }
 
                 verifySequence { mockKafkaProducer.send(any()) }
             }

--- a/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
+++ b/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiver.kt
@@ -50,19 +50,20 @@ class MarkerForespoerselBesvartRiver(
         logger.info("Mottok melding om ${EventName.INNTEKTSMELDING_MOTTATT}.")
         sikkerLogger.info("Mottok melding:\n${json.toPretty()}.")
 
-        val publisert =
-            producer
-                .send(
-                    key = forespoerselId,
-                    message =
-                        mapOf(
-                            Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_BESVART_SIMBA.toJson(Pri.NotisType.serializer()),
-                            Pri.Key.FORESPOERSEL_ID to forespoerselId.toJson(),
-                        ),
-                ).getOrThrow()
+        producer
+            .send(
+                key = forespoerselId,
+                message =
+                    mapOf(
+                        Pri.Key.NOTIS to Pri.NotisType.FORESPOERSEL_BESVART_SIMBA.toJson(Pri.NotisType.serializer()),
+                        Pri.Key.FORESPOERSEL_ID to forespoerselId.toJson(),
+                    ),
+            )
 
-        logger.info("Publiserte melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_BESVART_SIMBA}.")
-        sikkerLogger.info("Publiserte melding på pri-topic:\n${publisert.toPretty()}")
+        "Publiserte melding på pri-topic om ${Pri.NotisType.FORESPOERSEL_BESVART_SIMBA}.".also {
+            logger.info(it)
+            sikkerLogger.info(it)
+        }
 
         return null
     }

--- a/apps/forespoersel-marker-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiverTest.kt
+++ b/apps/forespoersel-marker-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/MarkerForespoerselBesvartRiverTest.kt
@@ -4,13 +4,14 @@ import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.datatest.withData
 import io.kotest.matchers.ints.shouldBeExactly
+import io.mockk.Runs
 import io.mockk.clearAllMocks
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -37,7 +38,7 @@ class MarkerForespoerselBesvartRiverTest :
 
         test("Ved event om mottatt inntektsmelding på rapid-topic publiseres notis om å markere forespørsel som besvart på pri-topic") {
             // Må bare returnere en Result med gyldig JSON
-            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } returns Result.success(JsonNull)
+            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } just Runs
 
             val expectedForespoerselId = UUID.randomUUID()
 

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiver.kt
@@ -17,7 +17,6 @@ import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.json.toPretty
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
@@ -69,13 +68,12 @@ class HentForespoerslerForVedtaksperiodeIdListeRiver(
                                 Key.DATA to data.toJson(),
                             ).toJson(),
                     ),
-            ).onSuccess {
-                logger.info("Publiserte melding på pri-topic om ${Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE}.")
-                sikkerLogger.info("Publiserte melding på pri-topic:\n${it.toPretty()}")
-            }.onFailure {
-                logger.warn("Klarte ikke publiserte melding på pri-topic om ${Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE}.")
-                sikkerLogger.warn("Klarte ikke publiserte melding på pri-topic om ${Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE}.")
-            }
+            )
+
+        "Publiserte melding på pri-topic om ${Pri.BehovType.HENT_FORESPOERSLER_FOR_VEDTAKSPERIODE_ID_LISTE}.".also {
+            logger.info(it)
+            sikkerLogger.info(it)
+        }
 
         return null
     }

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiver.kt
@@ -16,7 +16,6 @@ import no.nav.helsearbeidsgiver.felles.rapidsrivers.river.ObjectRiver
 import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
-import no.nav.helsearbeidsgiver.utils.json.toPretty
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
@@ -67,13 +66,12 @@ class TrengerForespoerselRiver(
                                 Key.DATA to data.toJson(),
                             ).toJson(),
                     ),
-            ).onSuccess {
-                logger.info("Publiserte melding på pri-topic om ${Pri.BehovType.TRENGER_FORESPØRSEL}.")
-                sikkerLogger.info("Publiserte melding på pri-topic:\n${it.toPretty()}")
-            }.onFailure {
-                logger.warn("Klarte ikke publiserte melding på pri-topic om ${Pri.BehovType.TRENGER_FORESPØRSEL}.")
-                sikkerLogger.warn("Klarte ikke publiserte melding på pri-topic om ${Pri.BehovType.TRENGER_FORESPØRSEL}.")
-            }
+            )
+
+        "Publiserte melding på pri-topic om ${Pri.BehovType.TRENGER_FORESPØRSEL}.".also {
+            logger.info(it)
+            sikkerLogger.info(it)
+        }
 
         return null
     }

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/HentForespoerslerForVedtaksperiodeIdListeRiverTest.kt
@@ -3,11 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.helsebro
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -28,7 +29,7 @@ class HentForespoerslerForVedtaksperiodeIdListeRiverTest :
 
         test("Ved behov om forespørsler på rapid-topic publiseres behov om forespørsler på pri-topic") {
             // Må bare returnere en Result med gyldig JSON
-            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } returns Result.success(JsonNull)
+            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } just Runs
 
             val expectedEvent = EventName.FORESPOERSLER_REQUESTED
             val expectedKontekstId = UUID.randomUUID()

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiverTest.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/TrengerForespoerselRiverTest.kt
@@ -3,11 +3,12 @@ package no.nav.helsearbeidsgiver.inntektsmelding.helsebro
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.ints.shouldBeExactly
+import io.mockk.Runs
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -27,7 +28,7 @@ class TrengerForespoerselRiverTest :
 
         test("Ved behov om forespørsel på rapid-topic publiseres behov om forespørsel på pri-topic") {
             // Må bare returnere en Result med gyldig JSON
-            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } returns Result.success(JsonNull)
+            every { mockProducer.send(any(), any<Map<Pri.Key, JsonElement>>()) } just Runs
 
             val expectedEvent = EventName.INNTEKT_REQUESTED
             val expectedKontekstId = UUID.randomUUID()

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -7,10 +7,8 @@ import io.kotest.matchers.maps.shouldContainKey
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
-import io.mockk.every
 import io.mockk.verify
 import kotlinx.serialization.builtins.serializer
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.dokarkiv.domene.OpprettOgFerdigstillResponse
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
@@ -55,8 +53,6 @@ class InnsendingIT : EndToEndTest() {
             forespoerselId = Mock.forespoerselId,
             forespoerselSvar = Mock.forespoerselSvar,
         )
-
-        every { producer.send(any()) } returns Result.success(JsonNull)
 
         coEvery {
             dokarkivClient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -9,11 +9,9 @@ import io.kotest.matchers.maps.shouldContainAll
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
-import io.mockk.every
 import kotlinx.serialization.builtins.MapSerializer
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonNull
 import no.nav.helsearbeidsgiver.aareg.Ansettelsesperiode
 import no.nav.helsearbeidsgiver.aareg.Arbeidsgiver
 import no.nav.helsearbeidsgiver.aareg.Opplysningspliktig
@@ -76,7 +74,6 @@ class LagreSelvbestemtIT : EndToEndTest() {
                 aarsakInnsending = AarsakInnsending.Ny,
             )
 
-        every { producer.send(any()) } returns Result.success(JsonNull)
         coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Mock.virksomhet)
         coEvery { pdlKlient.personBolk(any()) } returns Mock.personer
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforhold
@@ -198,7 +195,6 @@ class LagreSelvbestemtIT : EndToEndTest() {
     fun `endret inntektsmelding lagres og prosesseres, men uten opprettelse av sak`() {
         val kontekstId: UUID = UUID.randomUUID()
 
-        every { producer.send(any()) } returns Result.success(JsonNull)
         coEvery { brregClient.hentVirksomheter(any()) } returns listOf(Mock.virksomhet)
         coEvery { pdlKlient.personBolk(any()) } returns Mock.personer
         coEvery { aaregClient.hentArbeidsforhold(any(), any()) } returns Mock.arbeidsforhold

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/utils/EndToEndTest.kt
@@ -13,7 +13,6 @@ import io.mockk.slot
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 import no.nav.hag.utils.bakgrunnsjobb.PostgresBakgrunnsjobbRepository
 import no.nav.helsearbeidsgiver.aareg.AaregClient
 import no.nav.helsearbeidsgiver.altinn.Altinn3M2MClient
@@ -162,9 +161,9 @@ abstract class EndToEndTest : ContainerTest() {
 
     val altinnClient = mockk<Altinn3M2MClient>()
     val pdlKlient = mockk<PdlClient>()
-    val producer = mockk<Producer>()
     val spinnKlient = mockk<SpinnKlient>()
 
+    val producer = mockk<Producer>(relaxed = true)
     val aaregClient = mockk<AaregClient>(relaxed = true)
     val agNotifikasjonKlient = mockk<ArbeidsgiverNotifikasjonKlient>(relaxed = true)
     val brregClient = mockk<BrregClient>(relaxed = true)
@@ -294,8 +293,6 @@ abstract class EndToEndTest : ContainerTest() {
                         ).toJson(ForespoerselSvar.serializer()),
                 )
             }
-
-            Result.success(JsonObject(emptyMap()))
         }
     }
 
@@ -325,8 +322,6 @@ abstract class EndToEndTest : ContainerTest() {
                         ).toJson(ForespoerselListeSvar.serializer()),
                 )
             }
-
-            Result.success(JsonObject(emptyMap()))
         }
     }
 


### PR DESCRIPTION
Fjerner en innebygget catch av exceptions i producer. Den har tidligere vært brukt til å ignorere feil i flyter som involverer brukere og dermed er lette å gjeninitiere. Nå er producer sentral i den asynkrone delen av Simba, og da synes jeg den innebygde catchen ble litt for skummel, da man fort kan bruke den feil og svelge viktige exceptions.