### PR TITLE
Forbedre respons mot frontend for henting av preutfyllingsinfo

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
@@ -1,45 +1,57 @@
-@file:UseSerializers(LocalDateSerializer::class)
+@file:UseSerializers(YearMonthSerializer::class, LocalDateSerializer::class)
 
 package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
-import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.ForespurtData
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
+import no.nav.helsearbeidsgiver.utils.json.serializer.YearMonthSerializer
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import java.time.LocalDate
+import java.time.YearMonth
 
 @Serializable
 data class HentForespoerselResponse(
+    val sykmeldt: Sykmeldt,
+    val avsender: Avsender,
+    val egenmeldingsperioder: List<Periode>,
+    val sykmeldingsperioder: List<Periode>,
+    val bestemmendeFravaersdag: LocalDate,
+    val eksternInntektsdato: LocalDate?,
+    val inntekt: Inntekt?,
+    val forespurtData: ForespurtData?,
+    val erBesvart: Boolean,
+    // TODO utdaterte felt, slett etter overgangsperiode i frontend
     val navn: String?,
     val orgNavn: String?,
     val innsenderNavn: String?,
     val identitetsnummer: String,
     val orgnrUnderenhet: String,
     val fravaersperioder: List<Periode>,
-    val egenmeldingsperioder: List<Periode>,
-    val bestemmendeFravaersdag: LocalDate,
     val eksternBestemmendeFravaersdag: LocalDate?,
     val bruttoinntekt: Double?,
     val tidligereinntekter: List<InntektPerMaaned>,
-    val forespurtData: ForespurtData?,
-    val erBesvart: Boolean,
-    val feilReport: FeilReport? = null,
 )
 
-@Deprecated("fjern når det ikke lenger brukes i frontend")
 @Serializable
-data class FeilReport(
-    val feil: MutableList<Feilmelding> = mutableListOf(),
+data class Sykmeldt(
+    val fnr: Fnr,
+    val navn: String?,
 )
 
-@Deprecated("fjern når det ikke lenger brukes i frontend")
 @Serializable
-data class Feilmelding(
-    val melding: String,
-    // TODO fjern når frontend ikke lenger bruker
-    val status: Int? = null,
-    val datafelt: Key? = null,
+data class Avsender(
+    val orgnr: Orgnr,
+    val orgNavn: String?,
+    val navn: String?,
+)
+
+@Serializable
+data class Inntekt(
+    val gjennomsnitt: Double,
+    val historikk: Map<YearMonth, Double?>,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektResponse.kt
@@ -1,10 +1,18 @@
+@file:UseSerializers(YearMonthSerializer::class)
+
 package no.nav.helsearbeidsgiver.inntektsmelding.api.inntekt
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
+import no.nav.helsearbeidsgiver.utils.json.serializer.YearMonthSerializer
+import java.time.YearMonth
 
 @Serializable
 data class InntektResponse(
+    val gjennomsnitt: Double,
+    val historikk: Map<YearMonth, Double?>,
+    // TODO utdaterte felt, slett etter overgangsperiode i frontend
     val bruttoinntekt: Double,
     val tidligereInntekter: List<InntektPerMaaned>,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
@@ -59,6 +59,11 @@ fun Route.inntektRoute(
             if (resultat != null) {
                 val response =
                     InntektResponse(
+                        gjennomsnitt = resultat.gjennomsnitt(),
+                        historikk =
+                            resultat.maanedOversikt.associate { inntektPerMaaned ->
+                                inntektPerMaaned.maaned to inntektPerMaaned.inntekt
+                            },
                         bruttoinntekt = resultat.gjennomsnitt(),
                         tidligereInntekter = resultat.maanedOversikt,
                     ).toJson(InntektResponse.serializer().nullable)

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtResponse.kt
@@ -1,10 +1,18 @@
+@file:UseSerializers(YearMonthSerializer::class)
+
 package no.nav.helsearbeidsgiver.inntektsmelding.api.inntektselvbestemt
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.felles.domene.InntektPerMaaned
+import no.nav.helsearbeidsgiver.utils.json.serializer.YearMonthSerializer
+import java.time.YearMonth
 
 @Serializable
 data class InntektSelvbestemtResponse(
+    val gjennomsnitt: Double,
+    val historikk: Map<YearMonth, Double?>,
+    // TODO utdaterte felt, slett etter overgangsperiode i frontend
     val bruttoinntekt: Double,
     val tidligereInntekter: List<InntektPerMaaned>,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
@@ -59,6 +59,11 @@ fun Route.inntektSelvbestemtRoute(
             if (resultat != null) {
                 val response =
                     InntektSelvbestemtResponse(
+                        gjennomsnitt = resultat.gjennomsnitt(),
+                        historikk =
+                            resultat.maanedOversikt.associate { inntektPerMaaned ->
+                                inntektPerMaaned.maaned to inntektPerMaaned.inntekt
+                            },
                         bruttoinntekt = resultat.gjennomsnitt(),
                         tidligereInntekter = resultat.maanedOversikt,
                     ).toJson(InntektSelvbestemtResponse.serializer().nullable)

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRouteKtTest.kt
@@ -62,8 +62,13 @@ class InntektRouteKtTest : ApiTest() {
                             ),
                         ),
                 )
-            val forvertentResponse =
+            val forventetResponse =
                 InntektResponse(
+                    gjennomsnitt = inntekt.gjennomsnitt(),
+                    historikk =
+                        inntekt.maanedOversikt.associate {
+                            it.maaned to it.inntekt
+                        },
                     bruttoinntekt = inntekt.gjennomsnitt(),
                     tidligereInntekter = inntekt.maanedOversikt,
                 )
@@ -80,7 +85,7 @@ class InntektRouteKtTest : ApiTest() {
             val response = post(path, request, InntektRequest.serializer())
 
             response.status shouldBe HttpStatusCode.OK
-            response.bodyAsText() shouldBe forvertentResponse.toJsonStr(InntektResponse.serializer())
+            response.bodyAsText() shouldBe forventetResponse.toJsonStr(InntektResponse.serializer())
 
             verifySequence {
                 mockProducer.send(

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
@@ -35,6 +35,7 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
+import java.time.YearMonth
 import java.util.UUID
 
 private const val PATH = Routes.PREFIX + Routes.INNTEKT_SELVBESTEMT
@@ -230,11 +231,15 @@ private object Mock {
 private fun Inntekt.hardcodedJson(): String =
     """
     {
+        "gjennomsnitt": ${gjennomsnitt()},
+        "historikk": {${maanedOversikt.map { it.maaned to it.inntekt }.joinToString(transform = Pair<YearMonth, Double?>::hardcodedJson)}},
         "bruttoinntekt": ${gjennomsnitt()},
         "tidligereInntekter": [${maanedOversikt.joinToString(transform = InntektPerMaaned::hardcodedJson)}]
 
     }
     """.removeJsonWhitespace()
+
+private fun Pair<YearMonth, Double?>.hardcodedJson(): String = "\"$first\": $second"
 
 private fun InntektPerMaaned.hardcodedJson(): String =
     """

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/MoneyUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/utils/MoneyUtils.kt
@@ -1,6 +1,17 @@
 package no.nav.helsearbeidsgiver.felles.utils
 
 import java.math.RoundingMode
+import java.time.YearMonth
+
+fun Map<YearMonth, Double?>.gjennomsnitt(): Double =
+    if (isEmpty()) {
+        0.0
+    } else {
+        values
+            .mapNotNull { it }
+            .sumMoney()
+            .divideMoney(this.size)
+    }
 
 /** Forhindrer avrundingsfeil. */
 fun List<Double>.sumMoney(): Double =

--- a/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/utils/MoneyUtilsKtTest.kt
+++ b/apps/felles/src/test/kotlin/no/nav/helsearbeidsgiver/felles/utils/MoneyUtilsKtTest.kt
@@ -1,12 +1,40 @@
 package no.nav.helsearbeidsgiver.felles.utils
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.data.Row2
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.utils.test.date.august
+import no.nav.helsearbeidsgiver.utils.test.date.juli
+import no.nav.helsearbeidsgiver.utils.test.date.juni
+import java.time.YearMonth
 
 class MoneyUtilsKtTest :
     FunSpec({
+        context(Map<YearMonth, Double?>::gjennomsnitt.name) {
+            withData(
+                nameFn = { (inntekt, expectedAverage) ->
+                    "(${inntekt.values.joinToString(separator = " + ")}) / ${inntekt.size} = $expectedAverage"
+                },
+                listOf<Row2<Map<YearMonth, Double?>, Double>>(
+                    // Average of A.values should be B
+                    row(emptyMap(), 0.0),
+                    row(mapOf(juni(2024) to null), 0.0),
+                    row(mapOf(juni(2024) to 0.0), 0.0),
+                    row(mapOf(juni(2024) to 97.0), 97.0),
+                    row(mapOf(juni(2024) to 55.0, juli(2024) to null), 27.5),
+                    row(mapOf(juni(2024) to 366.0, juli(2024) to 0.0), 183.0),
+                    row(mapOf(juni(2024) to 717.0, juli(2024) to 33.0), 375.0),
+                    row(mapOf(juni(2024) to 840.0, juli(2024) to 38.52, august(2024) to 80.155), 319.56),
+                    row(mapOf(juni(2024) to 505.23, juli(2024) to 114.333, august(2024) to 7.696), 209.09),
+                    row(mapOf(juni(2024) to 68.44, juli(2024) to 4298.59, august(2024) to 9000.99), 4456.01),
+                ),
+            ) { (inntekt, expectedAverage) ->
+                inntekt.gjennomsnitt() shouldBe expectedAverage
+            }
+        }
+
         context(List<Double>::sumMoney.name) {
             withData(
                 nameFn = { (addends, expectedSum) ->


### PR DESCRIPTION
Gjør responsen for preutfylling, og et par andre mindre endepunkter, mer enhetlig med resten av API-et mot frontend.