### PR TITLE
Bruk inntektsmelding-ID som journalføringsreferanse

### DIFF
--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/metrics/Metrics.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/metrics/Metrics.kt
@@ -28,8 +28,6 @@ object Metrics {
 
     val brregRequest = requestMetric("Brreg")
 
-    val dokArkivRequest = requestMetric("DokArkiv")
-
     val inntektRequest = requestMetric("Inntekt")
 
     val forespoerslerBesvartFraSpleis = counterMetric("forespoersler besvart fra Spleis")

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
@@ -8,14 +8,10 @@ import no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument.PdfDokument
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument.transformToXML
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import java.util.Base64
-import java.util.UUID
 
 private val base64 = Base64.getEncoder()
 
-fun tilDokumenter(
-    uuid: UUID,
-    inntektsmelding: Inntektsmelding,
-): List<Dokument> =
+fun tilDokumenter(inntektsmelding: Inntektsmelding): List<Dokument> =
     listOf(
         Dokument(
             tittel = inntektsmelding.tilDokumentbeskrivelse(),
@@ -27,7 +23,7 @@ fun tilDokumenter(
                         filtype = "XML",
                         fysiskDokument = transformToXML(inntektsmelding).toByteArray().encode(),
                         variantFormat = "ORIGINAL",
-                        filnavn = "ari-$uuid.xml",
+                        filnavn = "ari-${inntektsmelding.id}.xml",
                     ),
 //                DokumentVariant(
 //                    filtype = "JSON",
@@ -35,13 +31,13 @@ fun tilDokumenter(
 //                        .toByteArray()
 //                        .encode(),
 //                    variantFormat = "ARKIV",
-//                    filnavn = "ari-$uuid.json"
+//                    filnavn = "ari-${inntektsmelding.id}.json"
 //                ),
                     DokumentVariant(
                         filtype = "PDFA",
                         fysiskDokument = PdfDokument(inntektsmelding).export().encode(),
                         variantFormat = "ARKIV",
-                        filnavn = "ari-$uuid.pdf",
+                        filnavn = "ari-${inntektsmelding.id}.pdf",
                     ),
                 ),
         ),

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiverTest.kt
@@ -12,7 +12,6 @@ import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.coVerifySequence
 import io.mockk.mockk
-import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.dokarkiv.DokArkivClient
 import no.nav.helsearbeidsgiver.dokarkiv.domene.DokumentVariant
@@ -50,16 +49,20 @@ class JournalfoerImRiverTest :
         }
 
         context("oppretter journalpost og publiserer melding for å lagre journalpost-ID") {
-            test("forespurt inntektsmelding") {
+            withData(
+                mapOf(
+                    "forespurt inntektsmelding" to Pair(EventName.INNTEKTSMELDING_MOTTATT, Key.INNTEKTSMELDING),
+                    "selvbestemt inntektsmelding" to Pair(EventName.SELVBESTEMT_IM_LAGRET, Key.SELVBESTEMT_INNTEKTSMELDING),
+                ),
+            ) { (innkommendeEvent, inntektsmeldingKey) ->
                 val journalpostId = randomDigitString(6)
-
-                val innkommendeMelding = Mock.innkommendeMelding(EventName.INNTEKTSMELDING_MOTTATT, Mock.inntektsmelding)
+                val innkommendeMelding = Mock.innkommendeMelding(innkommendeEvent, Mock.inntektsmelding)
 
                 coEvery {
                     mockDokArkivKlient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
                 } returns Mock.opprettOgFerdigstillResponse(journalpostId)
 
-                testRapid.sendJson(innkommendeMelding.toMap())
+                testRapid.sendJson(innkommendeMelding.toMap(inntektsmeldingKey))
 
                 testRapid.inspektør.size shouldBeExactly 1
 
@@ -86,52 +89,8 @@ class JournalfoerImRiverTest :
                                 it shouldHaveSize 1
                                 it.first().dokumentVarianter.map(DokumentVariant::filtype) shouldContainExactly listOf("XML", "PDFA")
                             },
-                        eksternReferanseId = "ARI-${innkommendeMelding.kontekstId}",
-                        callId = "callId_${innkommendeMelding.kontekstId}",
-                    )
-                }
-            }
-
-            test("selvbestemt inntektsmelding") {
-                val journalpostId = randomDigitString(8)
-
-                val innkommendeMelding = Mock.innkommendeMelding(EventName.SELVBESTEMT_IM_LAGRET, Mock.inntektsmelding)
-
-                coEvery {
-                    mockDokArkivKlient.opprettOgFerdigstillJournalpost(any(), any(), any(), any(), any(), any(), any())
-                } returns Mock.opprettOgFerdigstillResponse(journalpostId)
-
-                testRapid.sendJson(
-                    innkommendeMelding.toMap(Key.SELVBESTEMT_INNTEKTSMELDING),
-                )
-
-                testRapid.inspektør.size shouldBeExactly 1
-
-                testRapid.firstMessage().toMap() shouldContainExactly
-                    mapOf(
-                        Key.EVENT_NAME to EventName.INNTEKTSMELDING_JOURNALFOERT.toJson(),
-                        Key.KONTEKST_ID to innkommendeMelding.kontekstId.toJson(),
-                        Key.JOURNALPOST_ID to journalpostId.toJson(),
-                        Key.INNTEKTSMELDING to Mock.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                    )
-
-                coVerifySequence {
-                    mockDokArkivKlient.opprettOgFerdigstillJournalpost(
-                        tittel = "Inntektsmelding",
-                        gjelderPerson = GjelderPerson(Mock.inntektsmelding.sykmeldt.fnr.verdi),
-                        avsender =
-                            KlientAvsender.Organisasjon(
-                                orgnr = Mock.inntektsmelding.avsender.orgnr.verdi,
-                                navn = Mock.inntektsmelding.avsender.orgNavn,
-                            ),
-                        datoMottatt = LocalDate.now(),
-                        dokumenter =
-                            withArg {
-                                it shouldHaveSize 1
-                                it.first().dokumentVarianter.map(DokumentVariant::filtype) shouldContainExactly listOf("XML", "PDFA")
-                            },
-                        eksternReferanseId = "ARI-${innkommendeMelding.kontekstId}",
-                        callId = "callId_${innkommendeMelding.kontekstId}",
+                        eksternReferanseId = "ARI-${innkommendeMelding.inntektsmelding.id}",
+                        callId = "callId_${innkommendeMelding.inntektsmelding.id}",
                     )
                 }
             }

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
@@ -7,14 +7,13 @@ import no.nav.helsearbeidsgiver.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
-import java.util.UUID
 
 class TilDokumenterKtTest {
     @Test
     fun tilDokumenter() {
         val mockInntektsmelding = mockInntektsmeldingV1()
 
-        val dokumenter = tilDokumenter(UUID.randomUUID(), mockInntektsmelding)
+        val dokumenter = tilDokumenter(mockInntektsmelding)
 
         assertEquals(1, dokumenter.size)
         assertEquals(2, dokumenter[0].dokumentVarianter.size)


### PR DESCRIPTION
Dette vil gjøre det lettere å finne den ene fra den andre.