### PR TITLE
Bruk mer forklarende feltnavn for innkommende requester

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRequest.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRequest.kt
@@ -1,9 +1,13 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api.aktiveorgnr
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.JsonNames
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class AktiveOrgnrRequest(
+    @JsonNames("sykmeldtFnr")
     val identitetsnummer: Fnr,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRequest.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRequest.kt
@@ -2,12 +2,16 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.JsonNames
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.util.UUID
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class HentForespoerselRequest(
+    @JsonNames("forespoerselId")
     val uuid: UUID,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingResponse.kt
@@ -2,12 +2,18 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.api.innsending
 
+import kotlinx.serialization.EncodeDefault
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.util.UUID
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class InnsendingResponse(
     var uuid: UUID,
-)
+) {
+    @EncodeDefault
+    val forespoerselId: UUID = uuid
+}

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRequest.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRequest.kt
@@ -2,15 +2,19 @@
 
 package no.nav.helsearbeidsgiver.inntektsmelding.api.inntekt
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import kotlinx.serialization.json.JsonNames
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.time.LocalDate
 import java.util.UUID
 
 @Serializable
+@OptIn(ExperimentalSerializationApi::class)
 data class InntektRequest(
     val forespoerselId: UUID,
+    @JsonNames("inntektsdato")
     val skjaeringstidspunkt: LocalDate,
 )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -59,7 +59,9 @@ fun Route.kvittering(
 
         val forespoerselId =
             call.parameters["uuid"]
-                ?.let(::fjernLedendeSlash)
+                .let {
+                    it ?: call.parameters["forespoerselId"]
+                }?.let(::fjernLedendeSlash)
                 ?.runCatching(UUID::fromString)
                 ?.getOrNull()
 


### PR DESCRIPTION
Tanken er å innføre endringene på en bakoverkompatibelt måte, og så fjerne de gamle etter frontend har blitt oppdatert.