### PR TITLE
Legg til nye endepunkter med stiparametre

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
@@ -41,14 +41,16 @@ val sikkerLogger = sikkerLogger()
 object Routes {
     const val PREFIX = "/api/v1"
 
-    const val HENT_FORESPOERSEL = "/hent-forespoersel"
+    const val HENT_FORESPOERSEL_GAMMEL = "/hent-forespoersel"
+    const val HENT_FORESPOERSEL = "/hent-forespoersel/{forespoerselId}"
     const val HENT_FORESPOERSEL_ID_LISTE = "/hent-forespoersel-id-liste"
     const val INNTEKT = "/inntekt"
     const val INNTEKT_SELVBESTEMT = "/inntekt-selvbestemt"
     const val INNSENDING = "/inntektsmelding"
     const val SELVBESTEMT_INNTEKTSMELDING = "/selvbestemt-inntektsmelding"
     const val SELVBESTEMT_INNTEKTSMELDING_MED_ID = "$SELVBESTEMT_INNTEKTSMELDING/{selvbestemtId}"
-    const val KVITTERING = "/kvittering"
+    const val KVITTERING_GAMMEL = "/kvittering"
+    const val KVITTERING = "/kvittering/{forespoerselId}"
     const val AKTIVEORGNR = "/aktiveorgnr"
     const val TILGANG_ORGNR = "/tilgangorgnr/{orgnr}"
 }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
@@ -3,7 +3,6 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api
 import kotlinx.coroutines.delay
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID
 
 private const val MAX_RETRIES = 10
@@ -14,16 +13,11 @@ private val WAIT_MILLIS = List(MAX_RETRIES) { 100L * (1 + it) }
 class RedisPoller(
     private val redisStore: RedisStore,
 ) {
-    private val sikkerLogger = sikkerLogger()
-
     suspend fun hent(key: UUID): ResultJson {
         repeat(MAX_RETRIES) {
-            sikkerLogger.debug("Polling redis: $it time(s) for key $key")
-
             val result = redisStore.lesResultat(key)
 
             if (result != null) {
-                sikkerLogger.info("Hentet verdi for: '$key' = $result")
                 return result
             } else {
                 delay(WAIT_MILLIS.getOrNull(it) ?: WAIT_MILLIS_DEFAULT)
@@ -35,5 +29,5 @@ class RedisPoller(
 }
 
 class RedisPollerTimeoutException(
-    uuid: UUID,
-) : Exception("Brukte for lang tid på å svare ($uuid).")
+    key: UUID,
+) : Exception("Brukte for lang tid på å svare ($key).")

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
@@ -51,7 +51,7 @@ fun Route.aktiveOrgnrRoute(
                     respondNotFound("Fant ingen arbeidsforhold.", String.serializer())
                 } else {
                     val response = resultat.toResponse()
-                    call.respond(HttpStatusCode.Created, response.toJson(AktiveOrgnrResponse.serializer()))
+                    call.respond(HttpStatusCode.OK, response.toJson(AktiveOrgnrResponse.serializer()))
                 }
             } else {
                 val feilmelding = resultatJson.failure?.fromJson(String.serializer()) ?: Tekst.TEKNISK_FEIL_FORBIGAAENDE

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -2,10 +2,14 @@ package no.nav.helsearbeidsgiver.inntektsmelding.api.hentforespoersel
 
 import io.ktor.http.HttpStatusCode
 import io.ktor.server.routing.Route
+import io.ktor.server.routing.RoutingRequest
+import io.ktor.server.routing.get
 import io.ktor.server.routing.post
 import kotlinx.serialization.builtins.serializer
+import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
+import no.nav.helsearbeidsgiver.felles.Tekst
 import no.nav.helsearbeidsgiver.felles.domene.HentForespoerselResultat
 import no.nav.helsearbeidsgiver.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.felles.json.toJson
@@ -14,7 +18,7 @@ import no.nav.helsearbeidsgiver.felles.metrics.Metrics
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.utils.gjennomsnitt
+import no.nav.helsearbeidsgiver.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPollerTimeoutException
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
@@ -31,6 +35,8 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondForbidden
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondInternalServerError
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
@@ -41,7 +47,7 @@ fun Route.hentForespoersel(
 ) {
     val redisPoller = RedisStore(redisConnection, RedisPrefix.HentForespoersel).let(::RedisPoller)
 
-    post(Routes.HENT_FORESPOERSEL) {
+    post(Routes.HENT_FORESPOERSEL_GAMMEL) {
         val kontekstId = UUID.randomUUID()
 
         Metrics.hentForespoerselEndpoint.recordTime(Route::hentForespoersel) {
@@ -54,7 +60,7 @@ fun Route.hentForespoersel(
 
                     val arbeidsgiverFnr = call.request.lesFnrFraAuthToken()
 
-                    producer.sendRequestEvent(kontekstId, request, arbeidsgiverFnr)
+                    producer.sendRequestEvent(kontekstId, request.uuid, arbeidsgiverFnr)
 
                     val resultatJson = redisPoller.hent(kontekstId)
 
@@ -95,22 +101,119 @@ fun Route.hentForespoersel(
             }
         }
     }
+
+    get(Routes.HENT_FORESPOERSEL) {
+        val kontekstId = UUID.randomUUID()
+
+        val forespoerselId =
+            call.parameters["forespoerselId"]
+                ?.runCatching(UUID::fromString)
+                ?.getOrNull()
+
+        val (statusCode, response) =
+            if (forespoerselId == null) {
+                val feilmelding = "Ugyldig parameter: '${call.parameters["forespoerselId"]}'."
+
+                logger.error(feilmelding)
+                sikkerLogger.error(feilmelding)
+
+                HttpStatusCode.BadRequest to feilmelding.toJson()
+            } else {
+                MdcUtils.withLogFields(
+                    Log.apiRoute(Routes.HENT_FORESPOERSEL),
+                    Log.kontekstId(kontekstId),
+                    Log.forespoerselId(forespoerselId),
+                ) {
+                    hentForespoersel(
+                        tilgangskontroll = tilgangskontroll,
+                        producer = producer,
+                        redisPoller = redisPoller,
+                        request = call.request,
+                        kontekstId = kontekstId,
+                        forespoerselId = forespoerselId,
+                    )
+                }
+            }
+
+        respond(statusCode, response, JsonElement.serializer())
+    }
+}
+
+private suspend fun hentForespoersel(
+    tilgangskontroll: Tilgangskontroll,
+    producer: Producer,
+    redisPoller: RedisPoller,
+    request: RoutingRequest,
+    kontekstId: UUID,
+    forespoerselId: UUID,
+): Pair<HttpStatusCode, JsonElement> {
+    "Henter forespørsel.".also {
+        logger.info(it)
+        sikkerLogger.info(it)
+    }
+
+    try {
+        tilgangskontroll.validerTilgangTilForespoersel(request, forespoerselId)
+    } catch (_: ManglerAltinnRettigheterException) {
+        return HttpStatusCode.Forbidden to "Mangler rettigheter for organisasjon.".toJson()
+    }
+
+    val arbeidsgiverFnr = request.lesFnrFraAuthToken()
+
+    producer.sendRequestEvent(kontekstId, forespoerselId, arbeidsgiverFnr)
+
+    val resultatJson =
+        try {
+            redisPoller.hent(kontekstId)
+        } catch (_: RedisPollerTimeoutException) {
+            "Klarte ikke hente forespørsel pga. Redis-timeout.".also {
+                logger.info(it)
+                sikkerLogger.info(it)
+            }
+
+            return HttpStatusCode.InternalServerError to Tekst.REDIS_TIMEOUT_FEILMELDING.toJson()
+        }
+
+    val resultat = resultatJson.success?.fromJson(HentForespoerselResultat.serializer())
+
+    return if (resultat != null) {
+        val response = resultat.toResponse().toJson(HentForespoerselResponse.serializer())
+
+        "Forespørsel hentet OK.".also {
+            logger.info(it)
+            sikkerLogger.info("$it\n${response.toPretty()}")
+        }
+
+        HttpStatusCode.OK to response
+    } else {
+        val feilmelding =
+            resultatJson.failure
+                ?.fromJson(String.serializer())
+                ?: Tekst.TEKNISK_FEIL_FORBIGAAENDE
+
+        "Klarte ikke hente forespørsel.".also {
+            logger.info(it)
+            sikkerLogger.info("$it Feilmelding: '$feilmelding'.")
+        }
+
+        HttpStatusCode.InternalServerError to feilmelding.toJson()
+    }
 }
 
 private fun Producer.sendRequestEvent(
     kontekstId: UUID,
-    request: HentForespoerselRequest,
+    forespoerselId: UUID,
     arbeidsgiverFnr: Fnr,
 ) {
     send(
-        key = request.uuid,
+        key = forespoerselId,
         message =
             mapOf(
                 Key.EVENT_NAME to EventName.TRENGER_REQUESTED.toJson(),
                 Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
-                        Key.FORESPOERSEL_ID to request.uuid.toJson(),
+                        Key.FORESPOERSEL_ID to forespoerselId.toJson(),
                         Key.ARBEIDSGIVER_FNR to arbeidsgiverFnr.toJson(),
                     ).toJson(),
             ),

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -54,7 +54,7 @@ fun Route.kvittering(
 ) {
     val redisPoller = RedisStore(redisConnection, RedisPrefix.Kvittering).let(::RedisPoller)
 
-    get(Routes.KVITTERING) {
+    get(Routes.KVITTERING_GAMMEL) {
         val kontekstId = UUID.randomUUID()
 
         val forespoerselId =
@@ -109,6 +109,62 @@ fun Route.kvittering(
                     logger.error("Fikk timeout for forespørselId: $forespoerselId")
                     respondInternalServerError(RedisTimeoutResponse(forespoerselId), RedisTimeoutResponse.serializer())
                 }
+            }
+        }
+    }
+
+    get(Routes.KVITTERING) {
+        val kontekstId = UUID.randomUUID()
+
+        val forespoerselId =
+            call.parameters["forespoerselId"]
+                ?.runCatching(UUID::fromString)
+                ?.getOrNull()
+
+        if (forespoerselId == null) {
+            "Ugyldig parameter: ${call.parameters["uuid"]}".let {
+                logger.warn(it)
+                respondBadRequest(it, String.serializer())
+            }
+        } else {
+            logger.info("Henter data for forespørselId: $forespoerselId")
+            try {
+                tilgangskontroll.validerTilgangTilForespoersel(call.request, forespoerselId)
+
+                producer.sendRequestEvent(kontekstId, forespoerselId)
+                val resultatJson = redisPoller.hent(kontekstId)
+
+                val resultat = resultatJson.success?.fromJson(KvitteringResultat.serializer())
+                if (resultat != null) {
+                    sikkerLogger.info("Hentet kvittering for '$forespoerselId'.\n${resultatJson.success?.toPretty()}")
+
+                    when (val lagret = resultat.lagret) {
+                        is LagretInntektsmelding.Skjema -> {
+                            val skjemaResponse = lagResponse(resultat.forespoersel, resultat.sykmeldtNavn, resultat.orgNavn, lagret)
+                            respondOk(skjemaResponse, KvitteringResponse.serializer())
+                        }
+                        is LagretInntektsmelding.Ekstern -> {
+                            val eksternResponse = lagResponse(lagret)
+                            respondOk(eksternResponse, KvitteringResponse.serializer())
+                        }
+                        null ->
+                            respondNotFound("Kvittering ikke funnet for forespørselId: $forespoerselId", String.serializer())
+                    }
+                } else {
+                    val feilmelding = resultatJson.failure?.fromJson(String.serializer()) ?: Tekst.TEKNISK_FEIL_FORBIGAAENDE
+                    respondInternalServerError(feilmelding, String.serializer())
+                }
+            } catch (e: ManglerAltinnRettigheterException) {
+                respondForbidden("Du har ikke rettigheter for organisasjon.", String.serializer())
+            } catch (e: SerializationException) {
+                "Kunne ikke parse json-resultat for forespørselId: $forespoerselId".let {
+                    logger.error(it)
+                    sikkerLogger.error(it, e)
+                    respondInternalServerError(JsonErrorResponse(forespoerselId.toString()), JsonErrorResponse.serializer())
+                }
+            } catch (_: RedisPollerTimeoutException) {
+                logger.error("Fikk timeout for forespørselId: $forespoerselId")
+                respondInternalServerError(RedisTimeoutResponse(forespoerselId), RedisTimeoutResponse.serializer())
             }
         }
     }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/response/ErrorResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/response/ErrorResponse.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.UseSerializers
+import no.nav.helsearbeidsgiver.felles.Tekst
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import java.util.UUID
 
@@ -46,7 +47,7 @@ data class RedisTimeoutResponse(
     val inntektsmeldingTypeId: UUID? = null,
 ) {
     @EncodeDefault
-    val error = "Brukte for lang tid mot redis."
+    val error = Tekst.REDIS_TIMEOUT_FEILMELDING
 }
 
 @Serializable

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/AuthorizationTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/AuthorizationTest.kt
@@ -20,12 +20,14 @@ class AuthorizationTest : ApiTest() {
     fun `stopp uautoriserte kall mot API`() =
         testApi {
             listOf(
-                Routes.HENT_FORESPOERSEL to ::postUtenAuth,
+                Routes.HENT_FORESPOERSEL_GAMMEL to ::postUtenAuth,
+                Routes.HENT_FORESPOERSEL to ::getUtenAuth,
                 Routes.INNTEKT to ::postUtenAuth,
                 Routes.INNTEKT_SELVBESTEMT to ::postUtenAuth,
                 Routes.INNSENDING to ::postUtenAuth,
                 Routes.SELVBESTEMT_INNTEKTSMELDING to ::postUtenAuth,
                 Routes.SELVBESTEMT_INNTEKTSMELDING + "/0" to ::getUtenAuth,
+                Routes.KVITTERING_GAMMEL to ::getUtenAuth,
                 Routes.KVITTERING to ::getUtenAuth,
                 Routes.AKTIVEORGNR to ::postUtenAuth,
                 Routes.HENT_FORESPOERSEL_ID_LISTE to ::postUtenAuth,

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
@@ -51,7 +51,7 @@ class AktiveOrgnrRouteKtTest : ApiTest() {
 
             val response = post(path, requestBody.fromJson(AktiveOrgnrRequest.serializer()), AktiveOrgnrRequest.serializer())
 
-            assertEquals(HttpStatusCode.Created, response.status)
+            assertEquals(HttpStatusCode.OK, response.status)
             assertEquals(Mock.GYLDIG_AKTIVE_ORGNR_RESPONSE, response.bodyAsText())
 
             verifySequence {

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -188,7 +188,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `gir Forbidden-ikke hvis mangler tilgang`() =
+    fun `gir Forbidden-feil hvis mangler tilgang`() =
         testApi {
             coEvery { mockRedisConnection.get(any()) } returns ikkeTilgangResultat
 

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -11,7 +11,6 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
-import kotlinx.serialization.json.JsonObject
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.EventName
@@ -49,13 +48,12 @@ import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-import org.junit.jupiter.api.Assertions.assertNull
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.time.YearMonth
 import java.util.UUID
 
-private const val PATH = Routes.PREFIX + Routes.HENT_FORESPOERSEL
+private val pathMedId = Routes.PREFIX + Routes.HENT_FORESPOERSEL.replaceFirst("{forespoerselId}", UUID.randomUUID().toString())
 
 class HentForespoerselRouteKtTest : ApiTest() {
     @BeforeEach
@@ -64,7 +62,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
     }
 
     @Test
-    fun `skal returnere resultat og status CREATED`() =
+    fun `henter forespørsel`() =
         testApi {
             coEvery { mockRedisConnection.get(any()) } returnsMany
                 listOf(
@@ -73,9 +71,9 @@ class HentForespoerselRouteKtTest : ApiTest() {
                 )
 
             val forespoerselId = UUID.randomUUID()
-            val response = post(PATH, HentForespoerselRequest(forespoerselId), HentForespoerselRequest.serializer())
+            val response = get(pathMedId.substringBeforeLast("/") + "/$forespoerselId")
 
-            response.status shouldBe HttpStatusCode.Created
+            response.status shouldBe HttpStatusCode.OK
             response.bodyAsText() shouldBe Mock.resultat.tilResponseJson()
 
             verifySequence {
@@ -115,7 +113,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal returnere resultat og status CREATED med forespørsel bare inntekt`() =
+    fun `henter forespørsel med forslag til forrige inntekt`() =
         testApi {
             val resultatMedForrigeInntekt =
                 Mock.resultat
@@ -132,14 +130,14 @@ class HentForespoerselRouteKtTest : ApiTest() {
                     resultatMedForrigeInntekt.tilSuksessJson(),
                 )
 
-            val response = post(PATH, HentForespoerselRequest(UUID.randomUUID()), HentForespoerselRequest.serializer())
+            val response = get(pathMedId)
 
-            response.status shouldBe HttpStatusCode.Created
+            response.status shouldBe HttpStatusCode.OK
             response.bodyAsText() shouldBe resultatMedForrigeInntekt.tilResponseJson()
         }
 
     @Test
-    fun `skal returnere resultat og status CREATED med 'null' for verdier som ikke ble hentet`() =
+    fun `henter forespørsel med 'null' for verdier som ikke ble hentet`() =
         testApi {
             val resultatMedNullVerdier =
                 Mock.resultat
@@ -156,45 +154,33 @@ class HentForespoerselRouteKtTest : ApiTest() {
                     resultatMedNullVerdier.tilSuksessJson(),
                 )
 
-            val response = post(PATH, HentForespoerselRequest(UUID.randomUUID()), HentForespoerselRequest.serializer())
+            val response = get(pathMedId)
 
-            response.status shouldBe HttpStatusCode.Created
+            response.status shouldBe HttpStatusCode.OK
             response.bodyAsText() shouldBe resultatMedNullVerdier.tilResponseJson()
         }
 
     @Test
-    fun `skal returnere Internal server error hvis Redis timer ut`() =
+    fun `gir 500-feil hvis Redis timer ut`() =
         testApi {
             coEvery { mockRedisConnection.get(any()) } returns harTilgangResultat andThenThrows RedisPollerTimeoutException(UUID.randomUUID())
 
-            val response = post(PATH, HentForespoerselRequest(UUID.randomUUID()), HentForespoerselRequest.serializer())
+            val response = get(pathMedId)
 
             assertEquals(HttpStatusCode.InternalServerError, response.status)
         }
 
     @Test
-    fun `skal returnere 400-feil ved ugyldig request`() =
+    fun `gir 400-feil ved ugyldig forespørsel-ID`() =
         testApi {
-            val ugyldigRequest =
-                JsonObject(
-                    mapOf(
-                        HentForespoerselRequest::uuid.name to "ikke en uuid".toJson(),
-                    ),
-                )
-
-            val response = post(PATH, ugyldigRequest, JsonElement.serializer())
+            val response = get(pathMedId.substringBeforeLast("/") + "/ugyldig-forespoersel-id")
 
             assertEquals(HttpStatusCode.BadRequest, response.status)
             assertNotNull(response.bodyAsText())
 
-            val result = response.bodyAsText().fromJson(ResultJson.serializer())
+            val feilmelding = response.bodyAsText().fromJson(String.serializer())
 
-            assertNull(result.success)
-            assertNotNull(result.failure)
-
-            val feilmelding = result.failure!!.fromJson(String.serializer())
-
-            assertEquals("Mangler forespørsel-ID for å hente forespørsel.", feilmelding)
+            assertEquals("Ugyldig parameter: 'ugyldig-forespoersel-id'.", feilmelding)
 
             verify(exactly = 0) {
                 mockProducer.send(any<UUID>(), any<Map<Key, JsonElement>>())
@@ -202,11 +188,11 @@ class HentForespoerselRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal returnere Forbidden hvis feil ikke tilgang`() =
+    fun `gir Forbidden-ikke hvis mangler tilgang`() =
         testApi {
             coEvery { mockRedisConnection.get(any()) } returns ikkeTilgangResultat
 
-            val response = post(PATH, HentForespoerselRequest(UUID.randomUUID()), HentForespoerselRequest.serializer())
+            val response = get(pathMedId)
             assertEquals(HttpStatusCode.Forbidden, response.status)
 
             verify(exactly = 0) {
@@ -215,7 +201,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal returnere Forbidden hvis feil i Tilgangsresultet`() =
+    fun `gir Forbidden-feil hvis problemer under henting av tilgang`() =
         testApi {
             coEvery { mockRedisConnection.get(any()) } returns
                 ResultJson(
@@ -223,7 +209,7 @@ class HentForespoerselRouteKtTest : ApiTest() {
                 ).toJson()
                     .toString()
 
-            val response = post(PATH, HentForespoerselRequest(UUID.randomUUID()), HentForespoerselRequest.serializer())
+            val response = get(pathMedId)
             assertEquals(HttpStatusCode.Forbidden, response.status)
 
             verify(exactly = 0) {
@@ -276,7 +262,7 @@ private object Mock {
         )
 }
 
-private fun HentForespoerselResultat.tilSuksessJson() =
+private fun HentForespoerselResultat.tilSuksessJson(): String =
     ResultJson(
         success = toJson(HentForespoerselResultat.serializer()),
     ).toJson()

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -224,10 +224,10 @@ class HentSelvbestemtImRouteKtTest : ApiTest() {
     @Test
     fun `ugyldig ID i URL gir 400-feil`() =
         testApi {
-            val response = get("${pathUtenId}ikke-en-uuid")
+            val response = get("${pathUtenId}ugyldig-selvbestemt-id")
 
             response.status shouldBe HttpStatusCode.BadRequest
-            response.bodyAsText() shouldBe "\"Ugyldig parameter: 'ikke-en-uuid'\""
+            response.bodyAsText() shouldBe "\"Ugyldig parameter: 'ugyldig-selvbestemt-id'.\""
         }
 
     @Test

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
@@ -28,9 +28,9 @@ private const val PATH = Routes.PREFIX + Routes.KVITTERING
 
 class KvitteringRouteKtTest : ApiTest() {
     @Test
-    fun `skal ikke godta tom uuid`() =
+    fun `gir 400-feil ved manglende forespørsel-ID`() =
         testApi {
-            val response = get("$PATH?uuid=")
+            val response = get(PATH.substringBeforeLast("/"))
             assertEquals(HttpStatusCode.BadRequest, response.status)
 
             verify(exactly = 0) {
@@ -39,9 +39,9 @@ class KvitteringRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal ikke godta ugyldig uuid`() =
+    fun `gir 400-feil ved ugyldig forespørsel-ID`() =
         testApi {
-            val response = get("$PATH?uuid=ikke-en-uuid")
+            val response = get(PATH.substringBeforeLast("/") + "/ugyldig-forespoersel-id")
             assertEquals(HttpStatusCode.BadRequest, response.status)
 
             verify(exactly = 0) {
@@ -50,7 +50,7 @@ class KvitteringRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal godta gyldig uuid`() =
+    fun `skal godta gyldig forespørsel-ID`() =
         testApi {
             val forespoerselId = UUID.randomUUID()
 
@@ -63,7 +63,7 @@ class KvitteringRouteKtTest : ApiTest() {
                         .toString(),
                 )
 
-            val response = get(PATH + "?uuid=" + forespoerselId)
+            val response = get(PATH.replaceFirst("{forespoerselId}", forespoerselId.toString()))
 
             assertEquals(HttpStatusCode.OK, response.status)
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Tekst.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/Tekst.kt
@@ -3,4 +3,5 @@ package no.nav.helsearbeidsgiver.felles
 object Tekst {
     const val TEKNISK_FEIL_FORBIGAAENDE = "Teknisk feil, prøv igjen senere."
     const val UGYLDIG_REQUEST = "Ugyldig request."
+    const val REDIS_TIMEOUT_FEILMELDING = "Brukte for lang tid mot redis."
 }


### PR DESCRIPTION
Legger til to GET-endepunkt med stiparameter for å erstatte en POST og en GET med query-parameter. Fjerner erstattede endepunkt når frontend har byttet til nye.