### PR TITLE
Oppdater selvbestemt IM som prosessert etter distribusjon

### DIFF
--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/App.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/App.kt
@@ -62,5 +62,5 @@ fun RapidsConnection.createDbRivers(
         LagreSelvbestemtImRiver(selvbestemtImRepo).connect(this)
 
         logger.info("Starter ${OppdaterImSomProsessertRiver::class.simpleName}...")
-        OppdaterImSomProsessertRiver(imRepo).connect(this)
+        OppdaterImSomProsessertRiver(imRepo, selvbestemtImRepo).connect(this)
     }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepo.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepo.kt
@@ -13,6 +13,7 @@ import org.jetbrains.exposed.sql.insert
 import org.jetbrains.exposed.sql.selectAll
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
+import java.time.LocalDateTime
 import java.util.UUID
 
 class SelvbestemtImRepo(
@@ -70,6 +71,26 @@ class SelvbestemtImRepo(
             }
         } else {
             "Oppdaterte uventet antall ($antallOppdatert) rader med journalpost-ID '$journalpostId'.".also {
+                logger.error(it)
+                sikkerLogger.error(it)
+            }
+        }
+    }
+
+    fun oppdaterSomProsessert(inntektsmeldingId: UUID) {
+        val antallOppdatert =
+            transaction(db) {
+                SelvbestemtInntektsmeldingEntitet.update(
+                    where = {
+                        SelvbestemtInntektsmeldingEntitet.inntektsmeldingId eq inntektsmeldingId
+                    },
+                ) {
+                    it[prosessert] = LocalDateTime.now()
+                }
+            }
+
+        if (antallOppdatert != 1) {
+            "Oppdaterte uventet antall ($antallOppdatert) rader under markering av inntektsmelding som prosessert.".also {
                 logger.error(it)
                 sikkerLogger.error(it)
             }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/SelvbestemtInntektsmeldingEntitet.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/SelvbestemtInntektsmeldingEntitet.kt
@@ -17,4 +17,5 @@ object SelvbestemtInntektsmeldingEntitet : Table("selvbestemt_inntektsmelding") 
         )
     val journalpostId = text("journalpost_id").nullable()
     val opprettet = datetime("opprettet")
+    val prosessert = datetime("prosessert").nullable()
 }


### PR DESCRIPTION
Oppdaterer selvbestemte inntektsmeldinger på samme måte som forespurte. Dette fikser også en feil der selvbestemte fører til forsøk på oppdatere forespurte som prosessert.