### PR TITLE
Spinn-klient: Fiks retry ved timeout

### DIFF
--- a/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/MockSpinnKlient.kt
+++ b/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/MockSpinnKlient.kt
@@ -1,29 +1,54 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.brospinn
 
+import io.kotest.core.test.testCoroutineScheduler
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
+import io.ktor.client.plugins.HttpRequestRetry
 import io.ktor.http.ContentType
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.mockk.every
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import no.nav.helsearbeidsgiver.utils.test.mock.mockStatic
 
-fun mockSpinnKlient(
-    content: String,
-    status: HttpStatusCode,
-): SpinnKlient {
+@OptIn(ExperimentalStdlibApi::class, ExperimentalCoroutinesApi::class)
+fun mockSpinnKlient(vararg responses: Pair<HttpStatusCode, String>): SpinnKlient {
     val mockEngine =
-        MockEngine {
-            respond(
-                content = content,
-                status = status,
-                headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+        MockEngine.create {
+            reuseHandlers = false
+            requestHandlers.addAll(
+                responses.map { (status, content) ->
+                    {
+                        if (content == "timeout") {
+                            // Skrur den virtuelle klokka fremover, nok til at timeout forårsakes
+                            dispatcher.shouldNotBeNull().testCoroutineScheduler.advanceTimeBy(1)
+                        }
+                        respond(
+                            content = content,
+                            status = status,
+                            headers = headersOf(HttpHeaders.ContentType, ContentType.Application.Json.toString()),
+                        )
+                    }
+                },
             )
         }
 
-    val mockHttpClient = HttpClient(mockEngine) { configure() }
+    val mockHttpClient =
+        HttpClient(mockEngine) {
+            configure()
+
+            // Overstyr delay for å unngå at testene bruker lang tid
+            install(HttpRequestRetry) {
+                configureRetry()
+                constantDelay(
+                    millis = 1,
+                    randomizationMs = 1,
+                )
+            }
+        }
 
     return mockStatic(::createHttpClient) {
         every { createHttpClient() } returns mockHttpClient

--- a/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/SpinnKlientTest.kt
+++ b/apps/bro-spinn/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/SpinnKlientTest.kt
@@ -1,8 +1,10 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.brospinn
 
+import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.assertions.throwables.shouldThrowExactly
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
+import io.ktor.client.plugins.ServerResponseException
 import io.ktor.http.HttpStatusCode
 import no.nav.helsearbeidsgiver.utils.test.resource.readResource
 import no.nav.inntektsmeldingkontrakt.AvsenderSystem
@@ -14,18 +16,15 @@ class SpinnKlientTest :
         val expectedJson = "gyldigRespons.json".readResource()
         val expectedInntektsmelding = Jackson.fromJson(expectedJson)
 
-        test("Hvis inntektsmelding ikke finnes kastes feil") {
-            val spinnKlient = mockSpinnKlient("", HttpStatusCode.NotFound)
-            val exception =
-                shouldThrowExactly<SpinnApiException> {
-                    spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
-                }
-            exception.message shouldBe "$FIKK_SVAR_MED_RESPONSE_STATUS: ${HttpStatusCode.NotFound.value}"
+        test("Hvis inntektsmelding finnes returneres system navn") {
+            val spinnKlient = mockSpinnKlient(HttpStatusCode.OK to expectedJson)
+            val result = spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
+            result.avsenderSystemNavn shouldBe "NAV_NO"
         }
 
         test("Hvis inntektsmelding finnes men mangler avsenderSystemNavn kastes feil") {
             val responsData = Jackson.toJson(expectedInntektsmelding.copy(avsenderSystem = AvsenderSystem(null, null)))
-            val spinnKlient = mockSpinnKlient(responsData, HttpStatusCode.OK)
+            val spinnKlient = mockSpinnKlient(HttpStatusCode.OK to responsData)
 
             val exception =
                 shouldThrowExactly<SpinnApiException> {
@@ -33,9 +32,61 @@ class SpinnKlientTest :
                 }
             exception.message shouldBe MANGLER_AVSENDER
         }
-        test("Hvis inntektsmelding finnes returneres system navn") {
-            val spinnKlient = mockSpinnKlient(expectedJson, HttpStatusCode.OK)
-            val result = spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
-            result.avsenderSystemNavn shouldBe "NAV_NO"
+
+        test("feiler ved 4xx-feil") {
+            val spinnKlient = mockSpinnKlient(HttpStatusCode.NotFound to "")
+            val exception =
+                shouldThrowExactly<SpinnApiException> {
+                    spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
+                }
+            exception.message shouldBe "$FIKK_SVAR_MED_RESPONSE_STATUS: ${HttpStatusCode.NotFound.value}"
+        }
+
+        test("lykkes ved færre 5xx-feil enn max retries (5)") {
+            val spinnKlient =
+                mockSpinnKlient(
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.OK to expectedJson,
+                )
+
+            shouldNotThrowAny {
+                spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
+            }
+        }
+
+        test("feiler ved flere 5xx-feil enn max retries (5)") {
+            val spinnKlient =
+                mockSpinnKlient(
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                    HttpStatusCode.InternalServerError to "",
+                )
+
+            shouldThrowExactly<ServerResponseException> {
+                spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
+            }
+        }
+
+        test("kall feiler og prøver på nytt ved timeout") {
+            val spinnKlient =
+                mockSpinnKlient(
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to "timeout",
+                    HttpStatusCode.OK to expectedJson,
+                )
+
+            shouldNotThrowAny {
+                spinnKlient.hentEksternInntektsmelding(UUID.randomUUID())
+            }
         }
     })


### PR DESCRIPTION
Nåværende konfigurasjon støtter ikke retry ved timeouts ordentlig. 