### PR TITLE
Bruk større cache for tilgangskall

### DIFF
--- a/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/App.kt
+++ b/apps/altinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/altinn/App.kt
@@ -32,5 +32,5 @@ private fun createAltinnClient(): Altinn3M2MClient =
         baseUrl = Env.altinnTilgangerBaseUrl,
         serviceCode = Env.serviceCode,
         getToken = AuthClient().tokenGetter(IdentityProvider.AZURE_AD, Env.altinnScope),
-        cacheConfig = CacheConfig(60.minutes, 100),
+        cacheConfig = CacheConfig(60.minutes, 5000),
     )

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/App.kt
@@ -84,7 +84,7 @@ fun Application.apiModule(
     val tilgangskontroll =
         Tilgangskontroll(
             producer,
-            LocalCache(LocalCache.Config(60.minutes, 1000)),
+            LocalCache(LocalCache.Config(60.minutes, 5000)),
             redisConnection,
         )
 


### PR DESCRIPTION
Dette gjør cachen nyttigere, da det er mindre sannsynlighet for å kaste ut brukbare elementer.