### PR TITLE
Legger til støtte for IM type Fisker og UtenArbeidsforhold

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -318,6 +318,24 @@ private fun Inntektsmelding.Type.hardcodedJson(): String =
             }
             """
 
+        is Inntektsmelding.Type.Fisker ->
+            """
+            {
+                "type": "Fisker",
+                "id": "$id",
+                "avsenderSystem": ${this.avsenderSystem.hardcodedJson()}
+            }
+            """
+
+        is Inntektsmelding.Type.UtenArbeidsforhold ->
+            """
+            {
+                "type": "UtenArbeidsforhold",
+                "id": "$id",
+                "avsenderSystem": ${this.avsenderSystem.hardcodedJson()}
+            }
+            """
+
         is Inntektsmelding.Type.ForespurtEkstern ->
             """
             {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreJournalpostIdRiver.kt
@@ -66,7 +66,7 @@ class LagreJournalpostIdRiver(
                 }
             }
 
-            is Inntektsmelding.Type.Selvbestemt -> {
+            is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold -> {
                 selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
             }
         }
@@ -107,7 +107,10 @@ class LagreJournalpostIdRiver(
             Log.inntektsmeldingId(inntektsmelding.id),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> Log.forespoerselId(inntektsmelding.type.id)
-                is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)
+                is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
+                    Log.selvbestemtId(
+                        inntektsmelding.type.id,
+                    )
             },
         )
 }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/OppdaterImSomProsessertRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/OppdaterImSomProsessertRiver.kt
@@ -47,7 +47,7 @@ class OppdaterImSomProsessertRiver(
         when (inntektsmelding.type) {
             is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern ->
                 imRepo.oppdaterSomProsessert(inntektsmelding.id)
-            is Inntektsmelding.Type.Selvbestemt ->
+            is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
                 selvbestemtImRepo.oppdaterSomProsessert(inntektsmelding.id)
         }
 
@@ -79,7 +79,10 @@ class OppdaterImSomProsessertRiver(
             Log.inntektsmeldingId(inntektsmelding.id),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> Log.forespoerselId(inntektsmelding.type.id)
-                is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)
+                is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
+                    Log.selvbestemtId(
+                        inntektsmelding.type.id,
+                    )
             },
         )
 }

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/OppdaterImSomProsessertRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/OppdaterImSomProsessertRiverTest.kt
@@ -63,7 +63,7 @@ class OppdaterImSomProsessertRiverTest :
                             is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern ->
                                 mockImRepo.oppdaterSomProsessert(innkommendeMelding.inntektsmelding.id)
 
-                            is Inntektsmelding.Type.Selvbestemt ->
+                            is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
                                 mockSelvbestemtImRepo.oppdaterSomProsessert(innkommendeMelding.inntektsmelding.id)
                         }
                     }
@@ -93,7 +93,7 @@ class OppdaterImSomProsessertRiverTest :
                             is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern ->
                                 mockImRepo.oppdaterSomProsessert(innkommendeMelding.inntektsmelding.id)
 
-                            is Inntektsmelding.Type.Selvbestemt ->
+                            is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
                                 mockSelvbestemtImRepo.oppdaterSomProsessert(innkommendeMelding.inntektsmelding.id)
                         }
                     }

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/DistribusjonRiver.kt
@@ -100,7 +100,10 @@ class DistribusjonRiver(
             Log.inntektsmeldingId(inntektsmelding.id),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> Log.forespoerselId(inntektsmelding.type.id)
-                is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)
+                is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
+                    Log.selvbestemtId(
+                        inntektsmelding.type.id,
+                    )
             },
         )
 }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/JournalfoerImRiver.kt
@@ -109,7 +109,10 @@ class JournalfoerImRiver(
             Log.inntektsmeldingId(inntektsmelding.id),
             when (inntektsmelding.type) {
                 is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> Log.forespoerselId(inntektsmelding.type.id)
-                is Inntektsmelding.Type.Selvbestemt -> Log.selvbestemtId(inntektsmelding.type.id)
+                is Inntektsmelding.Type.Selvbestemt, is Inntektsmelding.Type.Fisker, is Inntektsmelding.Type.UtenArbeidsforhold ->
+                    Log.selvbestemtId(
+                        inntektsmelding.type.id,
+                    )
             },
         )
 

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -201,7 +201,9 @@ class LagreSelvbestemtImService(
                     .plus(steg0.skjema.sykmeldingsperioder)
             val erAktivtArbeidsforhold = sykeperioder.aktivtArbeidsforholdIPeriode(steg1.arbeidsforhold)
 
-            if (erAktivtArbeidsforhold) {
+            val harIngenArbeidsforhold = inntektsmelding.type is Inntektsmelding.Type.Fisker || inntektsmelding.type is Inntektsmelding.Type.UtenArbeidsforhold
+
+            if (erAktivtArbeidsforhold || harIngenArbeidsforhold) {
                 rapid
                     .publish(
                         key = inntektsmelding.type.id,

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/ArbeidsforholdInnenforPeriodeKtTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/ArbeidsforholdInnenforPeriodeKtTest.kt
@@ -97,4 +97,13 @@ class ArbeidsforholdInnenforPeriodeKtTest :
                 ),
             ).aktivtArbeidsforholdIPeriode(AaregTestData.avsluttetArbeidsforholdListe) shouldBe false
         }
+
+        test("Periode er empty list") {
+            listOf(
+                Periode(
+                    LocalDate.of(2021, 5, 15),
+                    LocalDate.of(2021, 5, 18),
+                ),
+            ).aktivtArbeidsforholdIPeriode(emptyList()) shouldBe false
+        }
     })

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -124,8 +124,12 @@ class LagreSelvbestemtImServiceTest :
 
                 val type = it.lesInntektsmelding().type
                 when (type) {
-                    is Inntektsmelding.Type.Forespurt, is Inntektsmelding.Type.ForespurtEkstern -> fail("Feil type: $type")
                     is Inntektsmelding.Type.Selvbestemt -> type.id shouldNotBe nyInntektsmelding.type.id
+
+                    else ->
+                        fail(
+                            "Feil type: $type",
+                        )
                 }
             }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.0.21
 kotlinterVersion=4.4.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.3.3
+hagDomeneInntektsmeldingVersion=0.3.4-SNAPSHOT
 junitJupiterVersion=5.12.1
 kotestVersion=5.9.1
 kotlinCoroutinesVersion=1.10.1


### PR DESCRIPTION
I denne PRen brukes IM domene modell snapshot som har 2 nye typer: `fisker` og `utenArbeidsforhold`

Har ikke koblet opp til et API endepukt så er ikke mulig å teste i dev enda.

Eneste nye logikken så langt er i [LagreSelvbestemtImService.kt](https://github.com/navikt/helsearbeidsgiver-inntektsmelding/compare/fisker-selvbestemt?expand=1#diff-2a30fdd1cf30eb3cc4defaebaca159b60350d698e7bb4ef39413a4eed6be8a39):
`val harIngenArbeidsforhold = inntektsmelding.type is Inntektsmelding.Type.Fisker || inntektsmelding.type is Inntektsmelding.Type.UtenArbeidsforhold`

Om variabelen harIngenArbeidshold er true ignorerer vi om `sykeperioder.aktivtArbeidsforholdIPeriode(steg1.arbeidsforhold)` er `false`

___________
Alle de andre endringene kommer fra å utfylle when(inntektsmelding.type) og tester