### PR TITLE
Bruk inntektklient med cache, retry og timeout

### DIFF
--- a/apps/inntekt/gradle.properties
+++ b/apps/inntekt/gradle.properties
@@ -1,1 +1,1 @@
-inntektKlientVersion=0.5.0
+inntektKlientVersion=0.6.0

--- a/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/App.kt
+++ b/apps/inntekt/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntekt/App.kt
@@ -5,7 +5,9 @@ import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helsearbeidsgiver.felles.auth.AuthClient
 import no.nav.helsearbeidsgiver.felles.auth.IdentityProvider
 import no.nav.helsearbeidsgiver.inntekt.InntektKlient
+import no.nav.helsearbeidsgiver.utils.cache.LocalCache
 import no.nav.helsearbeidsgiver.utils.log.logger
+import kotlin.time.Duration.Companion.minutes
 
 private val logger = "helsearbeidsgiver-im-inntekt".logger()
 
@@ -24,5 +26,9 @@ fun RapidsConnection.createHentInntektRiver(inntektKlient: InntektKlient): Rapid
 
 fun createInntektKlient(): InntektKlient {
     val tokenGetter = AuthClient().tokenGetter(IdentityProvider.AZURE_AD, Env.inntektScope)
-    return InntektKlient(Env.inntektUrl, tokenGetter)
+    return InntektKlient(
+        baseUrl = Env.inntektUrl,
+        cacheConfig = LocalCache.Config(10.minutes, 1000),
+        getAccessToken = tokenGetter,
+    )
 }


### PR DESCRIPTION
Setter cachetid til 10 min for å gi mulighet til å treffe flere ganger utfylling av skjema, ved reinnlasting og endring av AGP. Dette er et av de tyngre kallene vi har, men vi vil heller ikke cache for lenge i tilfelle dataene endres.

Cachestørrelse basert på https://logs.adeo.no/app/r/s/Bfz0o.