### PR TITLE
Arbeidsgivernotifikasjon: Fjern utdatert merkelapp

### DIFF
--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -24,9 +24,6 @@ private val sikkerLogger = sikkerLogger()
 
 object NotifikasjonTekst {
     const val MERKELAPP = "Inntektsmelding sykepenger"
-
-    @Deprecated("Bruk NotifikasjonTekst.MERKELAPP. Utdatert siden 21.05.2024.")
-    const val MERKELAPP_GAMMEL = "Inntektsmelding"
     const val OPPGAVE_TEKST = "Innsending av inntektsmelding"
     const val PAAMINNELSE_TITTEL = "Påminnelse – Vi mangler inntektsmelding for en av deres ansatte"
     const val STATUS_TEKST_UNDER_BEHANDLING = "Nav trenger inntektsmelding"
@@ -130,14 +127,6 @@ fun ArbeidsgiverNotifikasjonKlient.ferdigstillSak(
                 statusTekst = NotifikasjonTekst.STATUS_TEKST_FERDIG,
                 nyLenke = nyLenke,
             )
-        }.recoverCatching {
-            nyStatusSakByGrupperingsid(
-                grupperingsid = forespoerselId.toString(),
-                merkelapp = NotifikasjonTekst.MERKELAPP_GAMMEL,
-                status = SaksStatus.FERDIG,
-                statusTekst = NotifikasjonTekst.STATUS_TEKST_FERDIG,
-                nyLenke = nyLenke,
-            )
         }.onFailure { error ->
             loggWarnIkkeFunnetEllerThrow("Fant ikke sak under ferdigstilling.", error)
         }
@@ -153,14 +142,6 @@ fun ArbeidsgiverNotifikasjonKlient.avbrytSak(
             nyStatusSakByGrupperingsid(
                 grupperingsid = forespoerselId.toString(),
                 merkelapp = NotifikasjonTekst.MERKELAPP,
-                status = SaksStatus.FERDIG,
-                statusTekst = NotifikasjonTekst.STATUS_TEKST_AVBRUTT,
-                nyLenke = nyLenke,
-            )
-        }.recoverCatching {
-            nyStatusSakByGrupperingsid(
-                grupperingsid = forespoerselId.toString(),
-                merkelapp = NotifikasjonTekst.MERKELAPP_GAMMEL,
                 status = SaksStatus.FERDIG,
                 statusTekst = NotifikasjonTekst.STATUS_TEKST_AVBRUTT,
                 nyLenke = nyLenke,
@@ -223,12 +204,6 @@ fun ArbeidsgiverNotifikasjonKlient.ferdigstillOppgave(
                 merkelapp = NotifikasjonTekst.MERKELAPP,
                 nyLenke = lenke,
             )
-        }.recoverCatching {
-            oppgaveUtfoertByEksternIdV2(
-                eksternId = forespoerselId.toString(),
-                merkelapp = NotifikasjonTekst.MERKELAPP_GAMMEL,
-                nyLenke = lenke,
-            )
         }.onFailure { error ->
             loggWarnIkkeFunnetEllerThrow("Fant ikke oppgave under ferdigstilling.", error)
         }
@@ -244,12 +219,6 @@ fun ArbeidsgiverNotifikasjonKlient.settOppgaveUtgaatt(
             oppgaveUtgaattByEksternId(
                 eksternId = forespoerselId.toString(),
                 merkelapp = NotifikasjonTekst.MERKELAPP,
-                nyLenke = lenke,
-            )
-        }.recoverCatching {
-            oppgaveUtgaattByEksternId(
-                eksternId = forespoerselId.toString(),
-                merkelapp = NotifikasjonTekst.MERKELAPP_GAMMEL,
                 nyLenke = lenke,
             )
         }.onFailure { error ->

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/FerdigstillForespoerselSakOgOppgaveRiverTest.kt
@@ -82,63 +82,6 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
             }
         }
 
-        test("sak og oppgave med gammel merkelapp ferdigstilles") {
-            val innkommendeMelding = innkommendeMelding()
-
-            coEvery {
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), NotifikasjonTekst.MERKELAPP, any(), any(), any())
-            } throws SakEllerOppgaveFinnesIkkeException("'Tis but a scratch")
-
-            coEvery {
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), NotifikasjonTekst.MERKELAPP_GAMMEL, any(), any(), any())
-            } just Runs
-
-            coEvery {
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), NotifikasjonTekst.MERKELAPP, any())
-            } throws SakEllerOppgaveFinnesIkkeException("We are the knights who say 'Ni!'")
-
-            coEvery {
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), NotifikasjonTekst.MERKELAPP_GAMMEL, any())
-            } just Runs
-
-            testRapid.sendJson(innkommendeMelding.toMap())
-
-            testRapid.inspektør.size shouldBeExactly 1
-
-            testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding)
-
-            coVerifySequence {
-                // Feiler
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
-                    grupperingsid = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding sykepenger",
-                    status = SaksStatus.FERDIG,
-                    statusTekst = "Mottatt – Se kvittering eller korriger inntektsmelding",
-                    nyLenke = "$mockLinkUrl/im-dialog/kvittering/${innkommendeMelding.forespoerselId}",
-                )
-                // Feiler ikke
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
-                    grupperingsid = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding",
-                    status = SaksStatus.FERDIG,
-                    statusTekst = "Mottatt – Se kvittering eller korriger inntektsmelding",
-                    nyLenke = "$mockLinkUrl/im-dialog/kvittering/${innkommendeMelding.forespoerselId}",
-                )
-                // Feiler
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding sykepenger",
-                    nyLenke = "$mockLinkUrl/im-dialog/kvittering/${innkommendeMelding.forespoerselId}",
-                )
-                // Feiler ikke
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding",
-                    nyLenke = "$mockLinkUrl/im-dialog/kvittering/${innkommendeMelding.forespoerselId}",
-                )
-            }
-        }
-
         test("sak ferdigstilles selv om oppgave ikke finnes") {
             val innkommendeMelding = innkommendeMelding()
 
@@ -159,7 +102,6 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
                 mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding sykepenger", any())
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding", any())
             }
         }
 
@@ -182,7 +124,6 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding", any(), any(), any())
                 mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding sykepenger", any())
             }
         }
@@ -206,9 +147,7 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
 
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding", any(), any(), any())
                 mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding sykepenger", any())
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding", any())
             }
         }
 
@@ -226,7 +165,6 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding", any(), any(), any())
             }
         }
 
@@ -250,7 +188,6 @@ class FerdigstillForespoerselSakOgOppgaveRiverTest :
             coVerifySequence {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any())
                 mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding sykepenger", any())
-                mockAgNotifikasjonKlient.oppgaveUtfoertByEksternIdV2(any(), "Inntektsmelding", any())
             }
         }
 

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/UtgaattForespoerselRiverTest.kt
@@ -66,57 +66,10 @@ class UtgaattForespoerselRiverTest :
             }
         }
 
-        test("Hvis oppdatering av oppgave og sak feiler med SakEllerOppgaveFinnesIkkeException skal oppgaven og saken oppdateres med gammel merkelapp") {
-            coEvery {
-                mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId("Inntektsmelding sykepenger", any(), any())
-            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotikitasjonKlient")
-            coEvery {
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), "Inntektsmelding sykepenger", any(), any(), any(), any())
-            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotikitasjonKlient")
-
-            val innkommendeMelding = Mock.innkommendeMelding()
-
-            testRapid.sendJson(innkommendeMelding.toMap())
-
-            testRapid.inspektør.size shouldBeExactly 1
-            testRapid.firstMessage().toMap() shouldContainExactly Mock.forventetUtgaaendeMelding(innkommendeMelding)
-
-            coVerifySequence {
-                // Feiler
-                mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
-                    merkelapp = "Inntektsmelding sykepenger",
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
-                // Feiler ikke
-                mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
-                    merkelapp = "Inntektsmelding",
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
-                // Feiler
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
-                    grupperingsid = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding sykepenger",
-                    status = SaksStatus.FERDIG,
-                    statusTekst = "Avbrutt av Nav",
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
-                // Feiler ikke
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
-                    grupperingsid = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding",
-                    status = SaksStatus.FERDIG,
-                    statusTekst = "Avbrutt av Nav",
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
-            }
-        }
-
-        test("Hvis oppgaveUtgaattByEksternId med ny og gammel merkelapp feiler med SakEllerOppgaveFinnesIkkeException skal saken avbrytes likevel") {
+        test("Hvis oppgaveUtgaattByEksternId feiler med SakEllerOppgaveFinnesIkkeException skal saken avbrytes likevel") {
             coEvery {
                 mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(any(), any(), any())
-            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotikitasjonKlient")
+            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotifikasjonKlient")
 
             val innkommendeMelding = Mock.innkommendeMelding()
 
@@ -132,12 +85,6 @@ class UtgaattForespoerselRiverTest :
                     eksternId = innkommendeMelding.forespoerselId.toString(),
                     nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
                 )
-                // Feiler
-                mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
-                    merkelapp = "Inntektsmelding",
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
                 // Feiler ikke
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
                     grupperingsid = innkommendeMelding.forespoerselId.toString(),
@@ -149,10 +96,10 @@ class UtgaattForespoerselRiverTest :
             }
         }
 
-        test("Hvis avbrytSak med ny og gammel merkelapp feiler med SakEllerOppgaveFinnesIkkeException skal oppgaven settes til utgått likevel") {
+        test("Hvis avbrytSak feiler med SakEllerOppgaveFinnesIkkeException skal oppgaven settes til utgått likevel") {
             coEvery {
                 mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(any(), any(), any(), any(), any(), any())
-            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotikitasjonKlient")
+            } throws SakEllerOppgaveFinnesIkkeException("Feil fra agNotifikasjonKlient")
 
             val innkommendeMelding = Mock.innkommendeMelding()
 
@@ -176,21 +123,13 @@ class UtgaattForespoerselRiverTest :
                     statusTekst = "Avbrutt av Nav",
                     nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
                 )
-                // Feiler
-                mockAgNotifikasjonKlient.nyStatusSakByGrupperingsid(
-                    grupperingsid = innkommendeMelding.forespoerselId.toString(),
-                    merkelapp = "Inntektsmelding",
-                    status = SaksStatus.FERDIG,
-                    statusTekst = "Avbrutt av Nav",
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
             }
         }
 
-        test("Ved feil ved oppgaveUtgaattByEksternId med ny og gammel merkelapp skal saken ikke avbrytes") {
+        test("Ved feil ved oppgaveUtgaattByEksternId skal saken ikke avbrytes") {
             coEvery {
                 mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(any(), any(), any())
-            } throws Exception("Feil fra agNotikitasjonKlient")
+            } throws Exception("Feil fra agNotifikasjonKlient")
 
             val innkommendeMelding = Mock.innkommendeMelding()
 
@@ -203,12 +142,6 @@ class UtgaattForespoerselRiverTest :
                 // Feiler
                 mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
                     merkelapp = "Inntektsmelding sykepenger",
-                    eksternId = innkommendeMelding.forespoerselId.toString(),
-                    nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
-                )
-                // Feiler
-                mockAgNotifikasjonKlient.oppgaveUtgaattByEksternId(
-                    merkelapp = "Inntektsmelding",
                     eksternId = innkommendeMelding.forespoerselId.toString(),
                     nyLenke = "${Mock.LINK_URL}/im-dialog/utgatt",
                 )


### PR DESCRIPTION
Som `Deprecated`-annotasjonen sier så er ble `MERKELAPP_GAMMEL ` utdatert siden 21.05.2024. Da ble den erstattet med `MERKELAPP`. Siden hver Fager-sak har en levetid på 13 måneder, så vet vi at alle saker med den gamle merkelappen nå har blitt slettet. Det gjør at vi kan fjerne koden som prøver å bruke den gamle merkelappen dersom endring av saken feiler når vi bruker den nye merkelappen.

🚮