### PR TITLE
bytt fra intern til ekstern.dev.nav.no i notifikasjon-linker i dev

### DIFF
--- a/config/notifikasjon/dev-gcp.yml
+++ b/config/notifikasjon/dev-gcp.yml
@@ -9,6 +9,6 @@ env:
   - name: ARBEIDSGIVER_NOTIFIKASJON_SCOPE
     value: "api://dev-gcp.fager.notifikasjon-produsent-api/.default"
   - name: LINK_URL
-    value: "https://arbeidsgiver.intern.dev.nav.no"
+    value: "https://arbeidsgiver.ekstern.dev.nav.no"
   - name: TID_MELLOM_OPPGAVEOPPRETTELSE_OG_PAAMINNELSE
     value: "PT10M"


### PR DESCRIPTION
LPS har etterlyst muligheten for å se / sende inn manuelt i test. 
Vi har lagt til ekstern.dev.nav.no i frontend, slik at simba kan nåes både via nav intern url og åpen ekstern url. 
Endrer notifikasjonslinken for ny sak/oppgave til å peke til ekstern-url, slik at LPS kan navigere sømløst fra fager-sak / oppgave inn til simba. 
For oss som er interne kan vi uansett bruke disse URLene på kryss og tvers (gå fra intern til ekstern uten ny innlogging).
