### PR TITLE
Fjern texas-annotasjon (ut av beta)

### DIFF
--- a/config/nais.yml
+++ b/config/nais.yml
@@ -13,10 +13,6 @@ metadata:
   namespace: helsearbeidsgiver
   labels:
     team: helsearbeidsgiver
-  {{#if entraIdEnabled}}
-  annotations:
-    texas.nais.io/enabled: "{{ entraIdEnabled }}"
-  {{/if}}
 spec:
   image: {{ image }}
   resources:


### PR DESCRIPTION
Texas er ute av beta og har blitt skrudd på som default. Da kan vi fjerne annotasjonen, ref. https://nais.io/log/#2025-06-27-texas-er-ute-av-beta.