### PR TITLE
Dokumentbeskrivelse og pdf tittel for fisker og uten arbeidsforhold

### DIFF
--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenter.kt
@@ -46,11 +46,17 @@ fun tilDokumenter(inntektsmelding: Inntektsmelding): List<Dokument> =
 private fun ByteArray.encode(): String = base64.encodeToString(this)
 
 fun Inntektsmelding.tilDokumentbeskrivelse(): String {
+    val arbeidsforhold =
+        when (this.type) {
+            is Inntektsmelding.Type.UtenArbeidsforhold -> " (Uten arbeidsforhold)"
+            is Inntektsmelding.Type.Fisker -> " (Fisker m/hyre)"
+            else -> ""
+        }
     val agp =
         this.agp
             ?.perioder
             ?.ifEmpty { null }
             ?.tilKortFormat()
             .orDefault("(ingen agp)")
-    return "Inntektsmelding-$agp"
+    return "Inntektsmelding-$agp$arbeidsforhold"
 }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -114,7 +114,7 @@ class PdfDokument(
 
     private fun Inntektsmelding.Type.genererTittel(): String =
         when (this) {
-            is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker m/ hyre) for sykepenger"
+            is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker m/hyre) for sykepenger"
             is Inntektsmelding.Type.UtenArbeidsforhold -> "Inntektsmelding (Uten Arbeidsforhold) for sykepenger"
             is Inntektsmelding.Type.Selvbestemt,
             is Inntektsmelding.Type.Forespurt,

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -115,7 +115,7 @@ class PdfDokument(
     private fun Inntektsmelding.Type.genererTittel(): String =
         when (this) {
             is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker m/hyre) for sykepenger"
-            is Inntektsmelding.Type.UtenArbeidsforhold -> "Inntektsmelding (Uten Arbeidsforhold) for sykepenger"
+            is Inntektsmelding.Type.UtenArbeidsforhold -> "Inntektsmelding (Uten arbeidsforhold) for sykepenger"
             is Inntektsmelding.Type.Selvbestemt,
             is Inntektsmelding.Type.Forespurt,
             is Inntektsmelding.Type.ForespurtEkstern,

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -112,12 +112,22 @@ class PdfDokument(
         }
     }
 
+    private fun Inntektsmelding.Type.genererTittel(): String =
+        when (this) {
+            is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker) for sykepenger"
+            is Inntektsmelding.Type.UtenArbeidsforhold -> "Inntektsmelding (Uten Arbeidsforhold) for sykepenger"
+            is Inntektsmelding.Type.Selvbestemt,
+            is Inntektsmelding.Type.Forespurt,
+            is Inntektsmelding.Type.ForespurtEkstern,
+            -> "Inntektsmelding for sykepenger"
+        }
+
     private fun addHeader() {
         pdf.addTitle(
             title =
                 when (inntektsmelding.aarsakInnsending) {
-                    AarsakInnsending.Ny -> "Inntektsmelding for sykepenger"
-                    AarsakInnsending.Endring -> "Inntektsmelding for sykepenger - endring"
+                    AarsakInnsending.Ny -> inntektsmelding.type.genererTittel()
+                    AarsakInnsending.Endring -> "${inntektsmelding.type.genererTittel()} - endring"
                 },
             x = 0,
             y = y,
@@ -217,19 +227,25 @@ class PdfDokument(
 
                 is Ferie ->
                     addInntektEndringPerioder(forklaringEndring, endringAarsak.beskrivelse(), endringAarsak.ferier)
+
                 is Permisjon ->
                     addInntektEndringPerioder(forklaringEndring, endringAarsak.beskrivelse(), endringAarsak.permisjoner)
+
                 is Permittering ->
                     addInntektEndringPerioder(forklaringEndring, endringAarsak.beskrivelse(), endringAarsak.permitteringer)
+
                 is Sykefravaer ->
                     addInntektEndringPerioder(forklaringEndring, endringAarsak.beskrivelse(), endringAarsak.sykefravaer)
 
                 is NyStilling ->
                     addNyStilling(forklaringEndring, endringAarsak)
+
                 is Tariffendring ->
                     addTariffendring(forklaringEndring, endringAarsak)
+
                 is VarigLoennsendring ->
                     addVarigLonnsendring(forklaringEndring, endringAarsak)
+
                 is NyStillingsprosent ->
                     addNyStillingsprosent(forklaringEndring, endringAarsak)
             }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -114,7 +114,7 @@ class PdfDokument(
 
     private fun Inntektsmelding.Type.genererTittel(): String =
         when (this) {
-            is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker) for sykepenger"
+            is Inntektsmelding.Type.Fisker -> "Inntektsmelding (Fisker m/ hyre) for sykepenger"
             is Inntektsmelding.Type.UtenArbeidsforhold -> "Inntektsmelding (Uten Arbeidsforhold) for sykepenger"
             is Inntektsmelding.Type.Selvbestemt,
             is Inntektsmelding.Type.Forespurt,

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
@@ -63,7 +63,7 @@ class TilDokumenterKtTest {
             im.copy(type = Inntektsmelding.Type.Forespurt(id)) to standardBeskrivelse,
             im.copy(type = Inntektsmelding.Type.Selvbestemt(id)) to standardBeskrivelse,
         ).forEach { (im, forventet) ->
-            assertEquals(standardBeskrivelse + forventet, im.tilDokumentbeskrivelse())
+            assertEquals(forventet, im.tilDokumentbeskrivelse())
         }
     }
 

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
@@ -23,7 +23,7 @@ class TilDokumenterKtTest {
     }
 
     @Test
-    fun dokumentbeskrivelseToPerioder() {
+    fun `tilDokumentbeskrivelse returnerer forventet med to perioder`() {
         val im =
             mockInntekstmeldingMedPerioder(
                 listOf(
@@ -35,7 +35,7 @@ class TilDokumenterKtTest {
     }
 
     @Test
-    fun dokumentbeskrivelseEnPeriode() {
+    fun `tilDokumentbeskrivelse returnerer forventet med en periode`() {
         val im =
             mockInntekstmeldingMedPerioder(
                 listOf(
@@ -46,9 +46,25 @@ class TilDokumenterKtTest {
     }
 
     @Test
-    fun dokumentbeskrivelseIngenPeriode() {
+    fun `tilDokumentbeskrivelse returnerer forventet med ingen perioder`() {
         val im = mockInntekstmeldingMedPerioder(emptyList())
         assertEquals("Inntektsmelding-(ingen agp)", im.tilDokumentbeskrivelse())
+    }
+
+    @Test
+    fun `tilDokumentbeskrivelse returnerer forventet for forskjellige typer`() {
+        val im = mockInntektsmeldingV1()
+        val id = im.type.id
+        val standardBeskrivelse = "Inntektsmelding-05.10.2018 - [...] - 22.10.2018"
+
+        setOf(
+            im.copy(type = Inntektsmelding.Type.Fisker(id)) to "$standardBeskrivelse (Fisker m/hyre)",
+            im.copy(type = Inntektsmelding.Type.UtenArbeidsforhold(id)) to "$standardBeskrivelse (Uten arbeidsforhold)",
+            im.copy(type = Inntektsmelding.Type.Forespurt(id)) to standardBeskrivelse,
+            im.copy(type = Inntektsmelding.Type.Selvbestemt(id)) to standardBeskrivelse,
+        ).forEach { (im, forventet) ->
+            assertEquals(standardBeskrivelse + forventet, im.tilDokumentbeskrivelse())
+        }
     }
 
     private fun mockInntekstmeldingMedPerioder(perioder: List<Periode>): Inntektsmelding =

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilDokumenterKtTest.kt
@@ -52,7 +52,7 @@ class TilDokumenterKtTest {
     }
 
     @Test
-    fun `tilDokumentbeskrivelse returnerer forventet for forskjellige typer`() {
+    fun `tilDokumentbeskrivelse returnerer det som er forventet for forskjellige typer`() {
         val im = mockInntektsmeldingV1()
         val id = im.type.id
         val standardBeskrivelse = "Inntektsmelding-05.10.2018 - [...] - 22.10.2018"

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -327,7 +327,7 @@ class PdfDokumentTest {
             forespurtEkstern to "Inntektsmelding for sykepenger",
             Inntektsmelding.Type.Forespurt(id) to "Inntektsmelding for sykepenger",
             Inntektsmelding.Type.Selvbestemt(id) to "Inntektsmelding for sykepenger",
-            Inntektsmelding.Type.Fisker(id) to "Inntektsmelding (Fisker) for sykepenger",
+            Inntektsmelding.Type.Fisker(id) to "Inntektsmelding (Fisker m/ hyre) for sykepenger",
             Inntektsmelding.Type.UtenArbeidsforhold(id) to "Inntektsmelding (Uten Arbeidsforhold) for sykepenger",
         ).forEach { (imType, forventetTittel) ->
             val inntektsmelding = im.copy(type = imType)

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -316,6 +316,23 @@ class PdfDokumentTest {
         }
     }
 
+    @Test
+    fun `fisker og utenarbeidsforhold markeres i tittel`() {
+        val medFisker =
+            im.copy(
+                type =
+                    Inntektsmelding.Type.Fisker(
+                        id = im.type.id,
+                    ),
+            )
+        writePDF(
+            "med_fisker",
+            medFisker,
+        )
+        val pdfTekst = extractTextFromPdf(PdfDokument(medFisker).export())
+        assert(pdfTekst!!.contains("Inntektsmelding (Fisker) for sykepenger"))
+    }
+
     private fun List<InntektEndringAarsak>.tilIm(): Inntektsmelding =
         im.copy(
             inntekt =

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -327,8 +327,8 @@ class PdfDokumentTest {
             forespurtEkstern to "Inntektsmelding for sykepenger",
             Inntektsmelding.Type.Forespurt(id) to "Inntektsmelding for sykepenger",
             Inntektsmelding.Type.Selvbestemt(id) to "Inntektsmelding for sykepenger",
-            Inntektsmelding.Type.Fisker(id) to "Inntektsmelding (Fisker m/ hyre) for sykepenger",
-            Inntektsmelding.Type.UtenArbeidsforhold(id) to "Inntektsmelding (Uten Arbeidsforhold) for sykepenger",
+            Inntektsmelding.Type.Fisker(id) to "Inntektsmelding (Fisker m/hyre) for sykepenger",
+            Inntektsmelding.Type.UtenArbeidsforhold(id) to "Inntektsmelding (Uten arbeidsforhold) for sykepenger",
         ).forEach { (imType, forventetTittel) ->
             val inntektsmelding = im.copy(type = imType)
             val pdfTekst = pdfTekstFraIm(inntektsmelding)

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokumentTest.kt
@@ -332,7 +332,6 @@ class PdfDokumentTest {
         ).forEach { (imType, forventetTittel) ->
             val inntektsmelding = im.copy(type = imType)
             val pdfTekst = pdfTekstFraIm(inntektsmelding)
-
             pdfTekst shouldContain forventetTittel
         }
     }
@@ -356,8 +355,8 @@ class PdfDokumentTest {
         title: String,
         im: Inntektsmelding,
     ) {
-        val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
-        // val file = File.createTempFile(title, ".pdf")
+        // val file = File(System.getProperty("user.home"), "/Desktop/pdf/$title.pdf")
+        val file = File.createTempFile(title, ".pdf")
         val writer = FileOutputStream(file)
         writer.write(PdfDokument(im).export())
         println("Lagde PDF $title med filnavn ${file.toPath()}")


### PR DESCRIPTION
Generer pdf tittel basert på inntektsmeldingtype.
Genrer dokumentbeskrivelse i joark basert på inntektsmeldingtype.

Dette gjør at saksbehandler ser at det gjelder UtenArbeidsforhold og fisker m/ hyre i gosys