### PR TITLE
Kjør databasemigrering etter appens startsignal, men før klarsignal

### DIFF
--- a/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/App.kt
+++ b/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.aktiveorgnrservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateful
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createAktiveOrgnrService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/App.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/App.kt
@@ -3,7 +3,8 @@ package no.nav.helsearbeidsgiver.inntektsmelding.db
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helsearbeidsgiver.felles.db.exposed.Database
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onStartup
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.HentLagretImRiver
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.HentSelvbestemtImRiver
 import no.nav.helsearbeidsgiver.inntektsmelding.db.river.LagreEksternImRiver
@@ -19,20 +20,21 @@ private val logger = "helsearbeidsgiver-im-db".logger()
 fun main() {
     val database = Database("NAIS_DATABASE_IM_DB_INNTEKTSMELDING")
 
-    logger.info("Migrering starter...")
-    database.migrate()
-    logger.info("Migrering ferdig.")
-
     val imRepo = InntektsmeldingRepository(database.db)
     val selvbestemtImRepo = SelvbestemtImRepo(database.db)
 
     return RapidApplication
         .create(System.getenv())
-        .createDbRivers(imRepo, selvbestemtImRepo)
-        .registerShutdownLifecycle {
-            logger.info("Stoppsignal mottatt, lukker databasetilkobling.")
+        .onStartup {
+            logger.info("Migrering starter...")
+            database.migrate()
+            logger.info("Migrering ferdig.")
+        }.onShutdown {
+            logger.info("Stoppsignal mottatt, lukker databasetilkobling...")
             database.dataSource.close()
-        }.start()
+            logger.info("Databasetilkobling lukket.")
+        }.createDbRivers(imRepo, selvbestemtImRepo)
+        .start()
 }
 
 fun RapidsConnection.createDbRivers(

--- a/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/App.kt
+++ b/apps/distribusjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/distribusjon/App.kt
@@ -3,7 +3,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.distribusjon
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helsearbeidsgiver.felles.kafka.Producer
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.utils.log.logger
 
 private val logger = "im-distribusjon".logger()
@@ -14,7 +14,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createDistribusjonRiver(producer)
-        .registerShutdownLifecycle {
+        .onShutdown {
             producer.close()
         }.start()
 }

--- a/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/App.kt
+++ b/apps/feil-behandler/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/feilbehandler/App.kt
@@ -4,7 +4,8 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.hag.utils.bakgrunnsjobb.BakgrunnsjobbService
 import no.nav.hag.utils.bakgrunnsjobb.PostgresBakgrunnsjobbRepository
 import no.nav.helse.rapids_rivers.RapidApplication
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onStartup
 import no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.config.Database
 import no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.prosessor.FeilProsessor
 import no.nav.helsearbeidsgiver.inntektsmelding.feilbehandler.river.FeilLytter
@@ -13,23 +14,20 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 private val logger = "helsearbeidsgiver-im-feil-behandler".logger()
 
 fun main() {
-    buildApp(System.getenv()).start()
-}
-
-fun buildApp(env: Map<String, String>): RapidsConnection {
     val database = Database("NAIS_DATABASE_IM_FEIL_BEHANDLER_IM_ERROR_RECOVERY")
 
-    logger.info("Migrering starter...")
-    database.migrate()
-    logger.info("Migrering ferdig.")
-
-    return RapidApplication
-        .create(env)
-        .createFeilLytter(database)
-        .registerShutdownLifecycle {
-            logger.info("Stoppsignal mottatt, lukker databasetilkobling.")
+    RapidApplication
+        .create(System.getenv())
+        .onStartup {
+            logger.info("Migrering starter...")
+            database.migrate()
+            logger.info("Migrering ferdig.")
+        }.onShutdown {
+            logger.info("Stoppsignal mottatt, lukker databasetilkobling...")
             database.dataSource.close()
-        }
+            logger.info("Databasetilkobling lukket.")
+        }.createFeilLytter(database)
+        .start()
 }
 
 fun RapidsConnection.createFeilLytter(database: Database): RapidsConnection =

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/LifecycleUtils.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/rapidsrivers/LifecycleUtils.kt
@@ -2,12 +2,23 @@ package no.nav.helsearbeidsgiver.felles.rapidsrivers
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 
-fun RapidsConnection.registerShutdownLifecycle(onShutdown: () -> Unit): RapidsConnection =
+fun RapidsConnection.onStartup(block: () -> Unit): RapidsConnection =
+    also {
+        it.register(
+            object : RapidsConnection.StatusListener {
+                override fun onStartup(rapidsConnection: RapidsConnection) {
+                    block()
+                }
+            },
+        )
+    }
+
+fun RapidsConnection.onShutdown(block: () -> Unit): RapidsConnection =
     also {
         it.register(
             object : RapidsConnection.StatusListener {
                 override fun onShutdown(rapidsConnection: RapidsConnection) {
-                    onShutdown()
+                    block()
                 }
             },
         )

--- a/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/App.kt
+++ b/apps/forespoersel-marker-besvart/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/App.kt
@@ -4,7 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helsearbeidsgiver.felles.kafka.Producer
 import no.nav.helsearbeidsgiver.felles.kafka.pritopic.Pri
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.utils.log.logger
 
 private val logger = "im-forespoersel-marker-besvart".logger()
@@ -17,7 +17,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createForespoerselEventSwitch(producer)
-        .registerShutdownLifecycle {
+        .onShutdown {
             producer.close()
         }.start()
 

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/App.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/App.kt
@@ -4,7 +4,7 @@ import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
 import no.nav.helsearbeidsgiver.felles.kafka.Producer
 import no.nav.helsearbeidsgiver.felles.kafka.pritopic.Pri
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.utils.log.logger
 
 private val logger = "helsearbeidsgiver-im-helsebro".logger()
@@ -17,7 +17,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createHelsebroRivers(producer)
-        .registerShutdownLifecycle {
+        .onShutdown {
             producer.close()
         }.start()
 

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/App.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.innsending
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateful
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.inntektsmelding.innsending.api.ApiInnsendingService
@@ -25,7 +25,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createInnsending(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/App.kt
+++ b/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.inntektselvbestemtservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createInntektSelvbestemtService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/App.kt
+++ b/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.inntektservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createInntektService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/App.kt
+++ b/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.selvbestemthentimservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createHentSelvbestemtImService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/App.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.selvbestemtlagreimservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateful
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createLagreSelvbestemtImService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/App.kt
+++ b/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.tilgangservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
 
@@ -23,7 +23,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createTilgangService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }

--- a/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/App.kt
+++ b/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/App.kt
@@ -2,10 +2,10 @@ package no.nav.helsearbeidsgiver.inntektsmelding.trengerservice
 
 import com.github.navikt.tbd_libs.rapids_and_rivers_api.RapidsConnection
 import no.nav.helse.rapids_rivers.RapidApplication
+import no.nav.helsearbeidsgiver.felles.rapidsrivers.onShutdown
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisConnection
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisPrefix
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.redis.RedisStore
-import no.nav.helsearbeidsgiver.felles.rapidsrivers.registerShutdownLifecycle
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateful
 import no.nav.helsearbeidsgiver.felles.rapidsrivers.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.utils.log.logger
@@ -24,7 +24,7 @@ fun main() {
     RapidApplication
         .create(System.getenv())
         .createHentForespoerselService(redisConnection)
-        .registerShutdownLifecycle {
+        .onShutdown {
             redisConnection.close()
         }.start()
 }


### PR DESCRIPTION
Dette er for å hindre apper å bli drept fordi de ikke svarer på helsesjekker mens de jobber med databasemigreringer.