### PR TITLE
Forhindre Redis-timeout etter parallelt steg

### DIFF
--- a/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -158,10 +158,13 @@ class AktiveOrgnrService(
                     Key.BEHOV to BehovType.HENT_VIRKSOMHET_NAVN.toJson(),
                     Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                     Key.DATA to
-                        mapOf(
-                            Key.SVAR_KAFKA_KEY to KafkaKey(steg0.sykmeldtFnr).toJson(),
-                            Key.ORGNR_UNDERENHETER to arbeidsgivere.toJson(Orgnr.serializer()),
-                        ).toJson(),
+                        data
+                            .plus(
+                                mapOf(
+                                    Key.SVAR_KAFKA_KEY to KafkaKey(steg0.sykmeldtFnr).toJson(),
+                                    Key.ORGNR_UNDERENHETER to arbeidsgivere.toJson(Orgnr.serializer()),
+                                ),
+                            ).toJson(),
                 )
             }
         }

--- a/apps/aktiveorgnrservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrServiceTest.kt
+++ b/apps/aktiveorgnrservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrServiceTest.kt
@@ -270,12 +270,7 @@ private object Mock {
         kontekstId: UUID,
         orgnr: Orgnr,
     ): Map<Key, JsonElement> =
-        mapOf(
-            Key.EVENT_NAME to EventName.AKTIVE_ORGNR_REQUESTED.toJson(),
-            Key.KONTEKST_ID to kontekstId.toJson(),
-            Key.DATA to
-                mapOf(
-                    Key.VIRKSOMHETER to mapOf(orgnr.verdi to ORG_NAVN).toJson(),
-                ).toJson(),
+        steg1Data(kontekstId, orgnr).plusData(
+            Key.VIRKSOMHETER to mapOf(orgnr.verdi to ORG_NAVN).toJson(),
         )
 }

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -209,9 +209,10 @@ class LagreSelvbestemtImService(
                         Key.BEHOV to BehovType.LAGRE_SELVBESTEMT_IM.toJson(),
                         Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                         Key.DATA to
-                            mapOf(
-                                Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-                            ).toJson(),
+                            data
+                                .plus(
+                                    Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
+                                ).toJson(),
                     ).also {
                         logger.info("Publiserte melding med behov '${BehovType.LAGRE_SELVBESTEMT_IM}'.")
                         sikkerLogger.info("Publiserte melding:\n${it.toPretty()}")
@@ -246,9 +247,10 @@ class LagreSelvbestemtImService(
                         Key.BEHOV to BehovType.OPPRETT_SELVBESTEMT_SAK.toJson(),
                         Key.KONTEKST_ID to steg0.kontekstId.toJson(),
                         Key.DATA to
-                            mapOf(
-                                Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
-                            ).toJson(),
+                            data
+                                .plus(
+                                    Key.SELVBESTEMT_INNTEKTSMELDING to steg2.inntektsmelding.toJson(Inntektsmelding.serializer()),
+                                ).toJson(),
                     ).also {
                         logger.info("Publiserte melding med behov '${BehovType.OPPRETT_SELVBESTEMT_SAK}'.")
                         sikkerLogger.info("Publiserte melding:\n${it.toPretty()}")

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -79,7 +79,7 @@ class LagreSelvbestemtImServiceTest :
             mockRedis.setup()
         }
 
-        context("Inntektsmeldinger AarsakInnsending.Ny lagres og sak oprettes") {
+        context("Inntektsmeldinger AarsakInnsending.Ny lagres og sak opprettes") {
 
             fun ArbeidsforholdType.skalHaArbeidsforhold(): Boolean =
                 when (this) {
@@ -161,7 +161,7 @@ class LagreSelvbestemtImServiceTest :
                 testRapid.inspektør.size shouldBeExactly 5
                 testRapid.message(4).lesBehov() shouldBe BehovType.OPPRETT_SELVBESTEMT_SAK
 
-                testRapid.sendJson(Mock.steg3(kontekstId))
+                testRapid.sendJson(Mock.steg3(kontekstId, nyInntektsmelding))
 
                 testRapid.inspektør.size shouldBeExactly 6
                 testRapid.message(5).toMap().also {
@@ -588,24 +588,19 @@ private object Mock {
         kontekstId: UUID,
         inntektsmelding: Inntektsmelding,
     ): Map<Key, JsonElement> =
-        mapOf(
-            Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-            Key.KONTEKST_ID to kontekstId.toJson(),
-            Key.DATA to
-                mapOf(
-                    Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
-                    Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
-                ).toJson(),
+        steg1(kontekstId).plusData(
+            mapOf(
+                Key.SELVBESTEMT_INNTEKTSMELDING to inntektsmelding.toJson(Inntektsmelding.serializer()),
+                Key.ER_DUPLIKAT_IM to false.toJson(Boolean.serializer()),
+            ),
         )
 
-    fun steg3(kontekstId: UUID): Map<Key, JsonElement> =
-        mapOf(
-            Key.EVENT_NAME to EventName.SELVBESTEMT_IM_MOTTATT.toJson(),
-            Key.KONTEKST_ID to kontekstId.toJson(),
-            Key.DATA to
-                mapOf(
-                    Key.SAK_ID to "folkelig-lurendreier-sak-id".toJson(),
-                ).toJson(),
+    fun steg3(
+        kontekstId: UUID,
+        inntektsmelding: Inntektsmelding,
+    ): Map<Key, JsonElement> =
+        steg2(kontekstId, inntektsmelding).plusData(
+            Key.SAK_ID to "folkelig-lurendreier-sak-id".toJson(),
         )
 
     fun lagAnsettelsesperioder(orgnr: Orgnr) =


### PR DESCRIPTION
I et servicesteg, dersom man sender med all data som er mottatt så langt så gjør man det steget uavhengig av Redis, på samme måte som alle steg i en stateless service. Servicer er stateful for å kunne hente data parallelt. Etter det parallelle steget så kan man oppføre seg stateless, som denne endringen nå gjør.

`LagreSelvbestemtImService` er den viktigste endringen her, da vi ikke lenger vil kunne få Redis-timeout etter IM har blitt lagret i database. Det kunne man før om enten selve lagringen eller opprettelsen av sak etter lagring tok lang tid.