### PR TITLE
Les nytt erBegrenset-felt fra forespørsel

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselResponse.kt
@@ -24,6 +24,7 @@ data class HentForespoerselResponse(
     val inntekt: Inntekt?,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
+    val erBegrenset: Boolean,
 )
 
 @Serializable

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -188,4 +188,5 @@ private fun HentForespoerselResultat.toResponse(): HentForespoerselResponse =
             },
         forespurtData = forespoersel.forespurtData,
         erBesvart = forespoersel.erBesvart,
+        erBegrenset = forespoersel.erBegrenset,
     )

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -278,7 +278,8 @@ fun HentForespoerselResultat.tilResponseJson(): String =
         "eksternInntektsdato": ${forespoersel.eksternInntektsdato().jsonStrOrNull()},
         "inntekt": ${inntekt?.hardcodedJson()},
         "forespurtData": ${forespoersel.forespurtData.hardcodedJson()},
-        "erBesvart": ${forespoersel.erBesvart}
+        "erBesvart": ${forespoersel.erBesvart},
+        "erBegrenset": ${forespoersel.erBegrenset}
     }
     """.removeJsonWhitespace()
 

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -23,6 +23,8 @@ data class Forespoersel(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
+    // TODO fjern default etter overgangsfase
+    val erBegrenset: Boolean = false,
 ) {
     fun forslagBestemmendeFravaersdag(): LocalDate {
         val forslag = bestemmendeFravaersdager[orgnr]

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -23,6 +23,8 @@ data class ForespoerselFraBro(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
+    // TODO fjern default etter overgangsfase
+    val erBegrenset: Boolean = false,
 ) {
     fun toForespoersel(): Forespoersel =
         Forespoersel(
@@ -34,5 +36,6 @@ data class ForespoerselFraBro(
             bestemmendeFravaersdager = bestemmendeFravaersdager,
             forespurtData = forespurtData,
             erBesvart = erBesvart,
+            erBegrenset = erBegrenset,
         )
 }

--- a/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselListeSvar.kt
+++ b/apps/helsebro/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/domene/ForespoerselListeSvar.kt
@@ -12,8 +12,8 @@ import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 @Serializable
 data class ForespoerselListeSvar(
     val resultat: List<ForespoerselFraBro>,
-    val boomerang: JsonElement,
     val feil: Feil? = null,
+    val boomerang: JsonElement,
 ) {
     enum class Feil {
         FORESPOERSEL_FOR_VEDTAKSPERIODE_ID_LISTE_FEILET,


### PR DESCRIPTION
Dette feltet sendes til frontend for å muliggjøre spesialhåndtering av begrensede forespørsler.

Denne er trygg å deploye uavhengig av Storebror pga. defaults.