### PR TITLE
Endre oppgaveteksten til å spesifisere sykepenger

### DIFF
--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -24,7 +24,7 @@ private val sikkerLogger = sikkerLogger()
 
 object NotifikasjonTekst {
     const val MERKELAPP = "Inntektsmelding sykepenger"
-    const val OPPGAVE_TEKST = "Innsending av inntektsmelding"
+    const val OPPGAVE_TEKST = "Innsending av inntektsmelding for sykepenger"
     const val PAAMINNELSE_TITTEL = "Påminnelse – Vi mangler inntektsmelding for en av deres ansatte"
     const val STATUS_TEKST_UNDER_BEHANDLING = "Nav trenger inntektsmelding"
     const val STATUS_TEKST_FERDIG = "Mottatt – Se kvittering eller korriger inntektsmelding"


### PR DESCRIPTION
Ønsker å spesifisere sykepenger i oppgaveteksten slik at arbeidsgiver kan lettere skille på foreldrepenger / sykepenger
context : https://nav-it.slack.com/archives/GUX7MEP4J/p1756122944173659

<img width="539" height="175" alt="bilde" src="https://github.com/user-attachments/assets/52e15e1f-cc1f-4dd2-89ba-2c5b34a4736d" />
