### PR TITLE
Fjern overgangsdefaults for erBegrenset-felt

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -237,6 +237,7 @@ private object Mock {
             bestemmendeFravaersdager = mapOf(orgnr to 25.april),
             forespurtData = mockForespurtData(),
             erBesvart = false,
+            erBegrenset = false,
         )
 
     val resultat =

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/Forespoersel.kt
@@ -23,8 +23,7 @@ data class Forespoersel(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
-    // TODO fjern default etter overgangsfase
-    val erBegrenset: Boolean = false,
+    val erBegrenset: Boolean,
 ) {
     fun forslagBestemmendeFravaersdag(): LocalDate {
         val forslag = bestemmendeFravaersdager[orgnr]

--- a/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
+++ b/apps/felles/src/main/kotlin/no/nav/helsearbeidsgiver/felles/domene/ForespoerselFraBro.kt
@@ -23,8 +23,7 @@ data class ForespoerselFraBro(
     val bestemmendeFravaersdager: Map<Orgnr, LocalDate>,
     val forespurtData: ForespurtData,
     val erBesvart: Boolean,
-    // TODO fjern default etter overgangsfase
-    val erBegrenset: Boolean = false,
+    val erBegrenset: Boolean,
 ) {
     fun toForespoersel(): Forespoersel =
         Forespoersel(

--- a/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
+++ b/apps/felles/src/testFixtures/kotlin/no/nav/helsearbeidsgiver/felles/test/mock/MockForespoersel.kt
@@ -28,6 +28,7 @@ fun mockForespoersel(): Forespoersel {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        erBegrenset = false,
     )
 }
 

--- a/apps/forespoersel-marker-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/ForespoerselMottattRiverTest.kt
+++ b/apps/forespoersel-marker-besvart/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/forespoerselmarkerbesvart/ForespoerselMottattRiverTest.kt
@@ -91,5 +91,6 @@ object Mock {
             bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
             forespurtData = mockForespurtData(),
             erBesvart = false,
+            erBegrenset = false,
         )
 }

--- a/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
+++ b/apps/helsebro/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/helsebro/MockUtils.kt
@@ -41,6 +41,7 @@ fun mockForespoerselListeSvarMedSuksess(): ForespoerselListeSvar {
                     bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
                     forespurtData = mockForespurtData(),
                     erBesvart = false,
+                    erBegrenset = false,
                 ),
             ),
         boomerang = mockBoomerang(),
@@ -74,6 +75,7 @@ fun mockForespoerselSvarSuksess(forespoerselId: UUID): ForespoerselFraBro {
         bestemmendeFravaersdager = mapOf(orgnr to 1.januar),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        erBegrenset = false,
     )
 }
 

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -310,6 +310,7 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                erBegrenset = false,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ForespoerselMottattIT.kt
@@ -140,6 +140,7 @@ class ForespoerselMottattIT : EndToEndTest() {
                 bestemmendeFravaersdager = emptyMap(),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                erBegrenset = false,
             )
         val sakId = UUID.randomUUID().toString()
         val oppgaveId = UUID.randomUUID().toString()

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingIT.kt
@@ -211,6 +211,7 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 15.juli),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                erBegrenset = false,
             )
 
         val forespoerselSvar =
@@ -224,6 +225,7 @@ class InnsendingIT : EndToEndTest() {
                 bestemmendeFravaersdager = forespoersel.bestemmendeFravaersdager,
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                erBegrenset = false,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -197,6 +197,7 @@ class InnsendingServiceIT : EndToEndTest() {
                 bestemmendeFravaersdager = mapOf(orgnr to 17.mars),
                 forespurtData = mockForespurtData(),
                 erBesvart = false,
+                erBegrenset = false,
             )
     }
 }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/mock/MockData.kt
@@ -25,6 +25,7 @@ fun mockForespoerselSvarSuksess(): ForespoerselFraBro {
             ),
         forespurtData = mockForespurtData(),
         erBesvart = false,
+        erBegrenset = false,
     )
 }
 
@@ -47,6 +48,7 @@ fun mockForespoerselListeSvarResultat(
                 ),
             forespurtData = mockForespurtData(),
             erBesvart = false,
+            erBegrenset = false,
         )
     return listOf(forespoersel, forespoersel.copy(vedtaksperiodeId = vedtaksperiodeId2))
 }


### PR DESCRIPTION
Disse er ikke lenger nødvendig, da alle in-flight meldinger uten `erBegrenset` nå er prosesseret.