### PR TITLE
Bump avhengigheter med sårbarheter

### DIFF
--- a/apps/feil-behandler/gradle.properties
+++ b/apps/feil-behandler/gradle.properties
@@ -3,4 +3,4 @@ bakgrunnsjobbVersion=1.0.4
 flywayVersion=11.5.0
 hikariVersion=6.3.0
 postgresqlVersion=42.7.7
-testcontainersPostgresqlVersion=1.20.6
+testcontainersPostgresqlVersion=1.21.3

--- a/apps/felles-db-exposed/gradle.properties
+++ b/apps/felles-db-exposed/gradle.properties
@@ -3,4 +3,4 @@ exposedVersion=0.60.0
 flywayVersion=11.5.0
 hikariVersion=6.3.0
 postgresqlVersion=42.7.7
-testcontainersPostgresqlVersion=1.20.6
+testcontainersPostgresqlVersion=1.21.3

--- a/apps/integrasjonstest/build.gradle.kts
+++ b/apps/integrasjonstest/build.gradle.kts
@@ -64,7 +64,7 @@ dependencies {
     testImplementation("no.nav.helsearbeidsgiver:inntekt-klient:$inntektKlientVersion")
     testImplementation("no.nav.helsearbeidsgiver:pdl-client:$pdlKlientVersion")
 
-    testImplementation("com.redis.testcontainers:testcontainers-redis-junit:$testcontainersRedisJunitVersion")
+    testImplementation("com.redis:testcontainers-redis:$testcontainersRedisJunitVersion")
     testImplementation("no.nav.helsearbeidsgiver:hag-bakgrunnsjobb:$bakgrunnsjobbVersion")
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")
     testImplementation("org.testcontainers:postgresql:$testcontainersVersion")

--- a/apps/integrasjonstest/gradle.properties
+++ b/apps/integrasjonstest/gradle.properties
@@ -1,3 +1,3 @@
 # Dependency versions
-testcontainersRedisJunitVersion=1.6.4
-testcontainersVersion=1.20.6
+testcontainersRedisJunitVersion=2.2.4
+testcontainersVersion=1.21.3

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -120,11 +120,8 @@ subprojects {
                 because("rapids-and-rivers")
             }
 
-            testImplementation("commons-io:commons-io:2.14.0") {
-                because("testcontainers-redis-junit")
-            }
             testImplementation("org.apache.commons:commons-compress:1.26.2") {
-                because("kafka, testcontainers-redis-junit, postgresql")
+                because("kafka, testcontainers-redis, postgresql")
             }
         }
 


### PR DESCRIPTION
Bytter fra https://mvnrepository.com/artifact/com.redis.testcontainers/testcontainers-redis-junit til https://mvnrepository.com/artifact/com.redis/testcontainers-redis, som begge peker på https://github.com/redis-field-engineering/testcontainers-redis (HomePage ser annerledes ut for første pakke, men klikker du på den så ender du samme sted som for andre pakke).