### PR TITLE
Opprett sak uten navn for Fisker og UtenArbeidsforhold

### DIFF
--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -6,6 +6,7 @@ import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Paaminnelse
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveFinnesIkkeException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.utils.tilKortFormat
@@ -47,7 +48,21 @@ object NotifikasjonTekst {
         selvbestemtId: UUID,
     ): String = "$linkUrl/im-dialog/kvittering/agi/$selvbestemtId"
 
-    fun sakTittel(sykmeldt: Person): String = "Inntektsmelding for ${sykmeldt.navn}: f. ${sykmeldt.fnr.lesFoedselsdato()}"
+    fun sakTittel(
+        inntektsmeldingType: Inntektsmelding.Type,
+        sykmeldt: Person,
+    ): String =
+        when (inntektsmeldingType) {
+            is Inntektsmelding.Type.Forespurt,
+            is Inntektsmelding.Type.ForespurtEkstern,
+            is Inntektsmelding.Type.Selvbestemt,
+            is Inntektsmelding.Type.Behandlingsdager,
+            ->
+                "Inntektsmelding for ${sykmeldt.navn}: f. ${sykmeldt.fnr.lesFoedselsdato()}"
+            is Inntektsmelding.Type.UtenArbeidsforhold,
+            is Inntektsmelding.Type.Fisker,
+            -> "Inntektsmelding for: f. ${sykmeldt.fnr.lesFoedselsdato()}"
+        }
 
     fun sakTilleggsinfo(sykmeldingsperioder: List<Periode>): String = "Sykmeldingsperiode ${sykmeldingsperioder.tilKortFormat()}"
 
@@ -79,7 +94,7 @@ object NotifikasjonTekst {
 
 fun ArbeidsgiverNotifikasjonKlient.opprettSak(
     lenke: String,
-    inntektsmeldingTypeId: UUID,
+    inntektsmeldingType: Inntektsmelding.Type,
     orgnr: Orgnr,
     sykmeldt: Person,
     sykmeldingsperioder: List<Periode>,
@@ -95,10 +110,10 @@ fun ArbeidsgiverNotifikasjonKlient.opprettSak(
         runBlocking {
             opprettNySak(
                 virksomhetsnummer = orgnr.verdi,
-                grupperingsid = inntektsmeldingTypeId.toString(),
+                grupperingsid = inntektsmeldingType.id.toString(),
                 merkelapp = NotifikasjonTekst.MERKELAPP,
                 lenke = lenke,
-                tittel = NotifikasjonTekst.sakTittel(sykmeldt),
+                tittel = NotifikasjonTekst.sakTittel(inntektsmeldingType, sykmeldt),
                 statusTekst = statusTekst,
                 tilleggsinfo = NotifikasjonTekst.sakTilleggsinfo(sykmeldingsperioder),
                 initiellStatus = initiellStatus,

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiver.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
 import no.nav.helsearbeidsgiver.felles.domene.Forespoersel
@@ -67,7 +68,7 @@ class OpprettForespoerselSakOgOppgaveRiver(
         val sakId =
             agNotifikasjonKlient.opprettSak(
                 lenke = lenke,
-                inntektsmeldingTypeId = forespoerselId,
+                inntektsmeldingType = Inntektsmelding.Type.Forespurt(forespoerselId),
                 orgnr = forespoersel.orgnr,
                 sykmeldt = sykmeldt,
                 sykmeldingsperioder = forespoersel.sykmeldingsperioder,

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiver.kt
@@ -60,7 +60,7 @@ class OpprettSelvbestemtSakRiver(
         val sakId =
             agNotifikasjonKlient.opprettSak(
                 lenke = NotifikasjonTekst.lenkeFerdigstiltSelvbestemt(linkUrl, inntektsmelding.type.id),
-                inntektsmeldingTypeId = inntektsmelding.type.id,
+                inntektsmeldingType = inntektsmelding.type,
                 orgnr = inntektsmelding.avsender.orgnr,
                 sykmeldt = inntektsmelding.sykmeldt.let { Person(it.fnr, it.navn) },
                 sykmeldingsperioder = inntektsmelding.sykmeldingsperioder,

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtilsTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtilsTest.kt
@@ -4,27 +4,42 @@ import io.kotest.core.spec.style.FunSpec
 import io.kotest.data.row
 import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.felles.domene.Person
 import no.nav.helsearbeidsgiver.felles.utils.tilKortFormat
 import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
+import java.util.UUID
 
 class ArbeidsgiverNotifikasjonKlientUtilsTest :
     FunSpec({
-
+        val defaultFnr = Fnr("31030267462")
         context(NotifikasjonTekst::sakTittel.name) {
             test("fnr gir forventet saktittel") {
-                val person = Person(Fnr("31030267462"), "James Bånn")
-
-                NotifikasjonTekst.sakTittel(person) shouldBe "Inntektsmelding for James Bånn: f. 310302"
+                val person = Person(defaultFnr, "James Bånn")
+                NotifikasjonTekst.sakTittel(Inntektsmelding.Type.Forespurt(UUID.randomUUID()), person) shouldBe "Inntektsmelding for James Bånn: f. 310302"
             }
 
             test("dnr gir forventet saktittel") {
                 val person = Person(Fnr("63047505900"), "Pierce Brosjan")
+                NotifikasjonTekst.sakTittel(Inntektsmelding.Type.Forespurt(UUID.randomUUID()), person) shouldBe "Inntektsmelding for Pierce Brosjan: f. 230475"
+            }
 
-                NotifikasjonTekst.sakTittel(person) shouldBe "Inntektsmelding for Pierce Brosjan: f. 230475"
+            test("Selvbestemt gir forventet saktittel med navn") {
+                val person = Person(defaultFnr, "Sean Kånneri")
+                NotifikasjonTekst.sakTittel(Inntektsmelding.Type.Selvbestemt(UUID.randomUUID()), person) shouldBe "Inntektsmelding for Sean Kånneri: f. 310302"
+            }
+
+            test("Fisker gir forventet saktittel uten navn") {
+                val person = Person(defaultFnr, "Daniel Kraig")
+                NotifikasjonTekst.sakTittel(Inntektsmelding.Type.Fisker(UUID.randomUUID()), person) shouldBe "Inntektsmelding for: f. 310302"
+            }
+
+            test("UtenArbeidsforhold gir forventet saktittel uten navn") {
+                val person = Person(defaultFnr, "Roger Mår")
+                NotifikasjonTekst.sakTittel(Inntektsmelding.Type.UtenArbeidsforhold(UUID.randomUUID()), person) shouldBe "Inntektsmelding for: f. 310302"
             }
         }
 

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
@@ -16,6 +16,7 @@ import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjo
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Paaminnelse
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.felles.BehovType
 import no.nav.helsearbeidsgiver.felles.EventName
 import no.nav.helsearbeidsgiver.felles.Key
@@ -75,7 +76,7 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
                     grupperingsid = innkommendeMelding.forespoerselId.toString(),
                     merkelapp = NotifikasjonTekst.MERKELAPP,
                     lenke = "en-slags-url/im-dialog/${innkommendeMelding.forespoerselId}",
-                    tittel = NotifikasjonTekst.sakTittel(innkommendeMelding.sykmeldt),
+                    tittel = NotifikasjonTekst.sakTittel(Inntektsmelding.Type.Forespurt(innkommendeMelding.forespoerselId), innkommendeMelding.sykmeldt),
                     statusTekst = NotifikasjonTekst.STATUS_TEKST_UNDER_BEHANDLING,
                     tilleggsinfo = NotifikasjonTekst.sakTilleggsinfo(innkommendeMelding.forespoersel.sykmeldingsperioder),
                     initiellStatus = SaksStatus.UNDER_BEHANDLING,


### PR DESCRIPTION
VI ønsker å fjerne knytningen mellom navn og fødselsdato i saksteksen for inntektsmeldinger vi ikke har noen søknad for da dette bryter personvern.