### PR TITLE
Fjern navn for Fisker og UtenArbeidsforhold i Kvittering

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -87,7 +87,7 @@ fun Route.hentSelvbestemtImRoute(
 
 private fun Inntektsmelding.fjernNavnHvisIngenArbeidsforhold() =
     if (type is Inntektsmelding.Type.Fisker || type is Inntektsmelding.Type.UtenArbeidsforhold) {
-        copy(sykmeldt = sykmeldt.copy(navn = ""))
+        copy(sykmeldt = sykmeldt.copy(navn = "Ukjent navn"))
     } else {
         this
     }

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -86,7 +86,7 @@ class HentSelvbestemtImRouteKtTest : ApiTest() {
             val response = get(pathMedId)
             val responseJson = response.bodyAsText()
             val responseIm = responseJson.fromJson(ResultJson.serializer()).success?.fromJson(HentSelvbestemtImResponseSuccess.serializer())
-            responseIm?.selvbestemtInntektsmelding?.sykmeldt?.navn shouldBe ""
+            responseIm?.selvbestemtInntektsmelding?.sykmeldt?.navn shouldBe "Ukjent navn"
         }
 
     @Test


### PR DESCRIPTION
Fjerner navnet fra kvittering for selvbestemt inntektsmeldinger av type Fisker og UtenArbeidsforhold
Vi ønsker ikke at dette skal kunne knyttes sammen med fnr av personvern hensyn.