### PR TITLE
bump dokarkiv-klient (øker http-timeout)

### DIFF
--- a/apps/joark/gradle.properties
+++ b/apps/joark/gradle.properties
@@ -1,4 +1,4 @@
-dokarkivKlientVersion=0.5.2
+dokarkivKlientVersion=0.5.3
 hagImXmlKontraktVersion=1.0.8
 jacksonVersion=2.19.2
 jaxbAPIVersion=2.3.1


### PR DESCRIPTION
Andre tjenester (spesielt fritak) har timet ut mye mot dokarkiv etter at timeout-verdiene har blitt redusert. 
Ny klient øker timeout til 10 sekunder, dette bør være OK i Simba også, da journalføring skjer asynkront. 
