### PR TITLE
Skru på team-logs for alle apper

### DIFF
--- a/utils/rapids-and-rivers/build.gradle.kts
+++ b/utils/rapids-and-rivers/build.gradle.kts
@@ -3,7 +3,6 @@ val kotestVersion: String by project
 val micrometerVersion: String by project
 val mockkVersion: String by project
 val rapidsAndRiversTestVersion: String by project
-//TODO: bump rapids-and-rivers version
 val rapidsAndRiversVersion: String by project
 val slf4jVersion: String by project
 val utilsVersion: String by project


### PR DESCRIPTION
Skrur på team-logs logging for alle apper. 
Vi bruker logback filen til r&r biblioteket. 
Den inneholder logging til både elastic og team-loggs slik vi har gjort det i de andre repoene.
Tenker derfor at vi kan skru på team-logs for alle apper.