### PR TITLE
redisPoller: Øker til 15 retries (gir max ventetid for api 12 sekunder)

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
@@ -5,9 +5,9 @@ import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.valkey.RedisStore
 import java.util.UUID
 
-private const val MAX_RETRIES = 10
+private const val MAX_RETRIES = 15
 private const val WAIT_MILLIS_DEFAULT = 500L
-private val WAIT_MILLIS = List(MAX_RETRIES) { 100L * (1 + it) }
+private val WAIT_MILLIS = List(MAX_RETRIES) { 100L * (1 + it) } // 15 retries = 12000 ms total
 
 // TODO Bruke kotlin.Result istedenfor exceptions?
 class RedisPoller(

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
@@ -27,7 +27,7 @@ class RedisPollerTest :
         }
 
         test("skal finne med tillatt antall forsøk") {
-            every { mockRedisStore.lesResultat(any()) } returnsMany answers(answerOnAttemptNo = 10, answer = etSlagsResultat)
+            every { mockRedisStore.lesResultat(any()) } returnsMany answers(answerOnAttemptNo = 15, answer = etSlagsResultat)
 
             val json = redisPoller.hent(key)
 
@@ -35,7 +35,7 @@ class RedisPollerTest :
         }
 
         test("skal ikke finne etter maks forsøk") {
-            every { mockRedisStore.lesResultat(any()) } returnsMany answers(answerOnAttemptNo = 11, answer = etSlagsResultat)
+            every { mockRedisStore.lesResultat(any()) } returnsMany answers(answerOnAttemptNo = 16, answer = etSlagsResultat)
 
             assertThrows<RedisPollerTimeoutException> {
                 redisPoller.hent(key)


### PR DESCRIPTION
Bakgrunn: Tregheter mot inntekt gjør at inntekt-klienten gjør retries, men summen av all ventetiden blir større enn dagens maxVentetid satt i redisPoller (var 5500 ms).
Dermed resulterer http-kallet fra bruker i en 500-feil fra API etter 5.5 sekunder, når vi egentlig skulle gi tilbake et "partial skjema" uten inntekt utfylt. 
Ved å øke fra 10 til 15 retries, økes max ventetid mot redis fra 5.5 sekunder til 12 sekunder, og vi vil forhåpentligvis se færre 500-feil til frontend ved ikke-kritiske timeouts.