### PR TITLE
Fjern utdatert kolonne fra inntektsmeldingsdatabase

### DIFF
--- a/apps/db/src/main/resources/db/migration/V23__inntektsmelding_drop_dokument.sql
+++ b/apps/db/src/main/resources/db/migration/V23__inntektsmelding_drop_dokument.sql
@@ -1,0 +1,1 @@
+ALTER TABLE inntektsmelding DROP COLUMN dokument;


### PR DESCRIPTION
Må merges etter https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/953, som fjerner bruken av denne kolonnen.