### PR TITLE
Lagre fnr til avsender sammen med inntektsmelding

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -114,7 +114,7 @@ private suspend fun RoutingContext.lesRequestOrNull(): SkjemaInntektsmelding? =
 
 private fun Producer.sendRequestEvent(
     kontekstId: UUID,
-    arbeidsgiverFnr: Fnr,
+    avsenderFnr: Fnr,
     skjema: SkjemaInntektsmelding,
     mottatt: LocalDateTime,
 ) {
@@ -126,7 +126,7 @@ private fun Producer.sendRequestEvent(
                 Key.KONTEKST_ID to kontekstId.toJson(),
                 Key.DATA to
                     mapOf(
-                        Key.ARBEIDSGIVER_FNR to arbeidsgiverFnr.toJson(),
+                        Key.ARBEIDSGIVER_FNR to avsenderFnr.toJson(),
                         Key.SKJEMA_INNTEKTSMELDING to skjema.toJson(SkjemaInntektsmelding.serializer()),
                         Key.MOTTATT to mottatt.toJson(),
                     ).toJson(),

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -7,6 +7,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
@@ -99,13 +100,15 @@ class InntektsmeldingRepository(
     fun lagreInntektsmeldingSkjema(
         inntektsmeldingId: UUID,
         inntektsmeldingSkjema: SkjemaInntektsmelding,
+        avsenderFnr: Fnr,
         mottatt: LocalDateTime,
     ) {
         transaction(db) {
             InntektsmeldingEntitet.insert {
                 it[this.inntektsmeldingId] = inntektsmeldingId
-                it[this.forespoerselId] = inntektsmeldingSkjema.forespoerselId
+                it[forespoerselId] = inntektsmeldingSkjema.forespoerselId
                 it[skjema] = inntektsmeldingSkjema
+                it[this.avsenderFnr] = avsenderFnr.verdi
                 it[innsendt] = mottatt
             }
         }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepo.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepo.kt
@@ -5,6 +5,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.SelvbestemtInntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SortOrder
 import org.jetbrains.exposed.sql.and
@@ -31,12 +32,16 @@ class SelvbestemtImRepo(
                 .firstOrNull(SelvbestemtInntektsmeldingEntitet.inntektsmelding)
         }
 
-    fun lagreIm(im: Inntektsmelding) {
+    fun lagreIm(
+        im: Inntektsmelding,
+        avsenderFnr: Fnr,
+    ) {
         transaction(db) {
             SelvbestemtInntektsmeldingEntitet.insert {
                 it[inntektsmeldingId] = im.id
                 it[selvbestemtId] = im.type.id
                 it[inntektsmelding] = im
+                it[this.avsenderFnr] = avsenderFnr.verdi
             }
         }
     }

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreImSkjemaRiver.kt
@@ -22,6 +22,7 @@ import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.time.LocalDateTime
 import java.util.UUID
 
@@ -33,6 +34,7 @@ data class LagreImSkjemaMelding(
     val forespoersel: Forespoersel,
     val inntektsmeldingId: UUID,
     val skjema: SkjemaInntektsmelding,
+    val avsenderFnr: Fnr,
     val mottatt: LocalDateTime,
 )
 
@@ -55,6 +57,7 @@ class LagreImSkjemaRiver(
                 forespoersel = Key.FORESPOERSEL_SVAR.les(Forespoersel.serializer(), data),
                 inntektsmeldingId = Key.INNTEKTSMELDING_ID.les(UuidSerializer, data),
                 skjema = Key.SKJEMA_INNTEKTSMELDING.les(SkjemaInntektsmelding.serializer(), data),
+                avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), data),
                 mottatt = Key.MOTTATT.les(LocalDateTimeSerializer, data),
             )
         }
@@ -69,7 +72,7 @@ class LagreImSkjemaRiver(
         if (erDuplikat) {
             sikkerLogger.warn("Fant duplikat av inntektsmeldingskjema.")
         } else {
-            repository.lagreInntektsmeldingSkjema(inntektsmeldingId, skjema, mottatt)
+            repository.lagreInntektsmeldingSkjema(inntektsmeldingId, skjema, avsenderFnr, mottatt)
             sikkerLogger.info("Lagret inntektsmeldingskjema.")
         }
 

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/LagreSelvbestemtImRiver.kt
@@ -20,6 +20,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.pipe.orDefault
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
 data class LagreSelvbestemtImMelding(
@@ -28,6 +29,7 @@ data class LagreSelvbestemtImMelding(
     val kontekstId: UUID,
     val data: Map<Key, JsonElement>,
     val selvbestemtInntektsmelding: Inntektsmelding,
+    val avsenderFnr: Fnr,
 )
 
 class LagreSelvbestemtImRiver(
@@ -48,6 +50,7 @@ class LagreSelvbestemtImRiver(
                 kontekstId = Key.KONTEKST_ID.les(UuidSerializer, json),
                 data = data,
                 selvbestemtInntektsmelding = Key.SELVBESTEMT_INNTEKTSMELDING.les(Inntektsmelding.serializer(), data),
+                avsenderFnr = Key.ARBEIDSGIVER_FNR.les(Fnr.serializer(), data),
             )
         }
 
@@ -64,7 +67,7 @@ class LagreSelvbestemtImRiver(
         val erDuplikat = nyesteIm?.erDuplikatAv(selvbestemtInntektsmelding).orDefault(false)
 
         if (!erDuplikat) {
-            selvbestemtImRepo.lagreIm(selvbestemtInntektsmelding)
+            selvbestemtImRepo.lagreIm(selvbestemtInntektsmelding, avsenderFnr)
 
             "Lagret selvbestemt inntektsmelding.".also {
                 logger.info(it)

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/InntektsmeldingEntitet.kt
@@ -29,6 +29,7 @@ object InntektsmeldingEntitet : Table("inntektsmelding") {
             jsonConfig = jsonConfig,
             kSerializer = EksternInntektsmelding.serializer(),
         ).nullable()
+    val avsenderFnr = varchar("avsender_fnr", 11).nullable()
     val avsenderNavn = text("avsender_navn").nullable()
     val journalpostId = text("journalpost_id").nullable()
     val innsendt = datetime("innsendt")

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/SelvbestemtInntektsmeldingEntitet.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/tabell/SelvbestemtInntektsmeldingEntitet.kt
@@ -15,6 +15,7 @@ object SelvbestemtInntektsmeldingEntitet : Table("selvbestemt_inntektsmelding") 
             jsonConfig = jsonConfig,
             kSerializer = Inntektsmelding.serializer(),
         )
+    val avsenderFnr = varchar("avsender_fnr", 11).nullable()
     val journalpostId = text("journalpost_id").nullable()
     val opprettet = datetime("opprettet")
     val prosessert = datetime("prosessert").nullable()

--- a/apps/db/src/main/resources/db/migration/V24__im_og_sb_add_avsender_fnr.sql
+++ b/apps/db/src/main/resources/db/migration/V24__im_og_sb_add_avsender_fnr.sql
@@ -1,0 +1,5 @@
+ALTER TABLE inntektsmelding
+    ADD COLUMN avsender_fnr VARCHAR(11);
+
+ALTER TABLE selvbestemt_inntektsmelding
+    ADD COLUMN avsender_fnr VARCHAR(11);

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -18,6 +18,8 @@ import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.mars
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.ResultRow
 import org.jetbrains.exposed.sql.selectAll
@@ -50,10 +52,11 @@ class InntektsmeldingRepositoryTest :
             }.shouldBeEmpty()
 
             val skjema = mockSkjemaInntektsmelding()
+            val avsenderFnr = Fnr.genererGyldig()
             val mottatt = 9.desember.atStartOfDay()
             val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, avsenderFnr, mottatt)
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding)
 
             val record = testRepo.hentRecordFraInntektsmelding(skjema.forespoerselId).shouldNotBeNull()
@@ -63,6 +66,7 @@ class InntektsmeldingRepositoryTest :
             record.getOrNull(InntektsmeldingEntitet.skjema) shouldBe skjema
             record.getOrNull(InntektsmeldingEntitet.inntektsmelding) shouldBe inntektsmelding
             record.getOrNull(InntektsmeldingEntitet.eksternInntektsmelding) shouldBe null
+            record.getOrNull(InntektsmeldingEntitet.avsenderFnr) shouldBe avsenderFnr.verdi
             record.getOrNull(InntektsmeldingEntitet.avsenderNavn) shouldBe inntektsmelding.avsender.navn
             record.getOrNull(InntektsmeldingEntitet.journalpostId) shouldBe null
             record.getOrNull(InntektsmeldingEntitet.innsendt) shouldBe mottatt
@@ -79,10 +83,10 @@ class InntektsmeldingRepositoryTest :
             val inntektsmeldingId1 = UUID.randomUUID()
             val inntektsmeldingId2 = UUID.randomUUID()
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, Fnr.genererGyldig(), mottatt)
             inntektsmeldingRepo.hentNyesteInntektsmeldingId(skjema.forespoerselId) shouldBe inntektsmeldingId1
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, Fnr.genererGyldig(), mottatt.plusHours(3))
             inntektsmeldingRepo.hentNyesteInntektsmeldingId(skjema.forespoerselId) shouldBe inntektsmeldingId2
 
             inntektsmeldingRepo.hentNyesteInntektsmeldingId(UUID.randomUUID()) shouldBe null
@@ -98,7 +102,7 @@ class InntektsmeldingRepositoryTest :
             val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
             val journalpost = randomDigitString(7)
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, Fnr.genererGyldig(), mottatt)
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding)
             inntektsmeldingRepo.oppdaterJournalpostId(inntektsmelding.id, journalpost)
 
@@ -118,8 +122,8 @@ class InntektsmeldingRepositoryTest :
             val inntektsmeldingId2 = UUID.randomUUID()
             val journalpostId = randomDigitString(9)
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, Fnr.genererGyldig(), mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, Fnr.genererGyldig(), mottatt.plusHours(3))
 
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding.copy(id = inntektsmeldingId1))
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding.copy(id = inntektsmeldingId2))
@@ -157,8 +161,8 @@ class InntektsmeldingRepositoryTest :
             val gammelJournalpostId = "jp-traust-gevir"
             val nyJournalpostId = "jp-gallant-badehette"
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, mottatt.plusHours(3))
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, Fnr.genererGyldig(), mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, skjema, Fnr.genererGyldig(), mottatt.plusHours(3))
 
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding.copy(id = inntektsmeldingId1))
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding.copy(id = inntektsmeldingId2))
@@ -215,7 +219,7 @@ class InntektsmeldingRepositoryTest :
             val inntektsmelding = mockInntektsmeldingV1().copy(mottatt = mottatt.toOffsetDateTimeOslo())
             val journalpostId = "jp-slem-fryser"
 
-            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+            inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, Fnr.genererGyldig(), mottatt)
             inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding)
 
             inntektsmeldingRepo.lagreEksternInntektsmelding(skjema.forespoerselId, mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(1)))
@@ -252,9 +256,9 @@ class InntektsmeldingRepositoryTest :
                 val b = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(1))
                 val c = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
 
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), a, mottatt)
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), a, Fnr.genererGyldig(), mottatt)
                 inntektsmeldingRepo.lagreEksternInntektsmelding(forespoerselId, b)
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), c, mottatt.plusHours(2))
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), c, Fnr.genererGyldig(), mottatt.plusHours(2))
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(forespoerselId)
 
@@ -270,7 +274,7 @@ class InntektsmeldingRepositoryTest :
                 val skjema = mockSkjemaInntektsmelding()
                 val mottatt = 9.desember.atStartOfDay()
 
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, mottatt)
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), skjema, Fnr.genererGyldig(), mottatt)
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId)
 
@@ -288,7 +292,7 @@ class InntektsmeldingRepositoryTest :
                 // Bruk inntektsmelding som er ulikt skjema for å sjekke at hentet skjema ikke stammer fra inntektsmelding
                 val inntektsmelding = mockInntektsmeldingV1().copy(inntekt = null, mottatt = mottatt.toOffsetDateTimeOslo())
 
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, mottatt)
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmelding.id, skjema, Fnr.genererGyldig(), mottatt)
                 inntektsmeldingRepo.oppdaterMedInntektsmelding(inntektsmelding)
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(skjema.forespoerselId)
@@ -313,7 +317,7 @@ class InntektsmeldingRepositoryTest :
             }
 
             test("tåler at det er ingenting å hente") {
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), mockSkjemaInntektsmelding(), 9.desember.atStartOfDay())
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), mockSkjemaInntektsmelding(), Fnr.genererGyldig(), 9.desember.atStartOfDay())
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(UUID.randomUUID())
 
@@ -328,8 +332,8 @@ class InntektsmeldingRepositoryTest :
                 val inntektsmeldingId1 = UUID.randomUUID()
                 val inntektsmeldingId2 = UUID.randomUUID()
 
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, mottatt)
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, mockSkjemaInntektsmelding(), mottatt.plusHours(4))
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId1, skjema, Fnr.genererGyldig(), mottatt)
+                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId2, mockSkjemaInntektsmelding(), Fnr.genererGyldig(), mottatt.plusHours(4))
 
                 inntektsmeldingRepo.oppdaterSomProsessert(inntektsmeldingId1)
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepoTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/SelvbestemtImRepoTest.kt
@@ -19,6 +19,8 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.SelvbestemtInntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import no.nav.helsearbeidsgiver.utils.test.date.september
+import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
+import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.ResultRow
@@ -63,9 +65,9 @@ class SelvbestemtImRepoTest :
                             ),
                     )
 
-                selvbestemtImRepo.lagreIm(originalInntektsmelding)
-                selvbestemtImRepo.lagreIm(endretInntektsmelding)
-                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
+                selvbestemtImRepo.lagreIm(originalInntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(endretInntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1(), Fnr.genererGyldig())
 
                 selvbestemtImRepo.hentNyesteIm(selvbestemtId) shouldBe endretInntektsmelding
             }
@@ -80,14 +82,14 @@ class SelvbestemtImRepoTest :
                             ),
                     )
 
-                selvbestemtImRepo.lagreIm(inntektsmelding)
-                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
+                selvbestemtImRepo.lagreIm(inntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1(), Fnr.genererGyldig())
 
                 selvbestemtImRepo.hentNyesteIm(selvbestemtId) shouldBe inntektsmelding
             }
 
             test("gir 'null' når ingen funnet") {
-                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
+                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1(), Fnr.genererGyldig())
 
                 selvbestemtImRepo.hentNyesteIm(UUID.randomUUID()).shouldBeNull()
             }
@@ -99,7 +101,7 @@ class SelvbestemtImRepoTest :
                 lesAlleRader(db) shouldHaveSize 0
 
                 repeat(3) {
-                    selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
+                    selvbestemtImRepo.lagreIm(mockInntektsmeldingV1(), Fnr.genererGyldig())
                 }
 
                 lesAlleRader(db) shouldHaveSize 3
@@ -108,7 +110,7 @@ class SelvbestemtImRepoTest :
             test("inntektsmelding- og selvbestemt ID stammer fra inntektsmelding") {
                 val inntektsmelding = mockInntektsmeldingV1()
 
-                selvbestemtImRepo.lagreIm(inntektsmelding)
+                selvbestemtImRepo.lagreIm(inntektsmelding, Fnr.genererGyldig())
 
                 val alleRader = lesAlleRader(db)
 
@@ -132,7 +134,7 @@ class SelvbestemtImRepoTest :
                                 ),
                         )
 
-                    selvbestemtImRepo.lagreIm(inntektsmelding)
+                    selvbestemtImRepo.lagreIm(inntektsmelding, Fnr.genererGyldig())
                 }
 
                 lesAlleRader(db) shouldHaveSize 2
@@ -143,10 +145,10 @@ class SelvbestemtImRepoTest :
                 val inntektsmelding1 = mockInntektsmeldingV1().copy(id = inntektsmeldingId)
                 val inntektsmelding2 = mockInntektsmeldingV1().copy(id = inntektsmeldingId)
 
-                selvbestemtImRepo.lagreIm(inntektsmelding1)
+                selvbestemtImRepo.lagreIm(inntektsmelding1, Fnr.genererGyldig())
 
                 shouldThrowExactly<ExposedSQLException> {
-                    selvbestemtImRepo.lagreIm(inntektsmelding2)
+                    selvbestemtImRepo.lagreIm(inntektsmelding2, Fnr.genererGyldig())
                 }
             }
         }
@@ -164,8 +166,8 @@ class SelvbestemtImRepoTest :
                             ),
                     )
 
-                selvbestemtImRepo.lagreIm(inntektsmelding)
-                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1())
+                selvbestemtImRepo.lagreIm(inntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(mockInntektsmeldingV1(), Fnr.genererGyldig())
                 selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding.id, journalpostId)
 
                 val alleRader = lesAlleRader(db)
@@ -201,8 +203,8 @@ class SelvbestemtImRepoTest :
                         id = UUID.randomUUID(),
                     )
 
-                selvbestemtImRepo.lagreIm(originalInntektsmelding)
-                selvbestemtImRepo.lagreIm(endretInntektsmelding)
+                selvbestemtImRepo.lagreIm(originalInntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(endretInntektsmelding, Fnr.genererGyldig())
                 selvbestemtImRepo.oppdaterJournalpostId(originalInntektsmelding.id, journalpostId1)
                 selvbestemtImRepo.oppdaterJournalpostId(endretInntektsmelding.id, journalpostId2)
 
@@ -239,8 +241,8 @@ class SelvbestemtImRepoTest :
                         id = UUID.randomUUID(),
                     )
 
-                selvbestemtImRepo.lagreIm(originalInntektsmelding)
-                selvbestemtImRepo.lagreIm(endretInntektsmelding)
+                selvbestemtImRepo.lagreIm(originalInntektsmelding, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(endretInntektsmelding, Fnr.genererGyldig())
                 selvbestemtImRepo.oppdaterJournalpostId(endretInntektsmelding.id, gammelJournalpostId)
 
                 val alleRaderEtterSetup = lesAlleRader(db)
@@ -284,8 +286,8 @@ class SelvbestemtImRepoTest :
                 val inntektsmelding1 = mockInntektsmeldingV1()
                 val inntektsmelding2 = mockInntektsmeldingV1()
 
-                selvbestemtImRepo.lagreIm(inntektsmelding1)
-                selvbestemtImRepo.lagreIm(inntektsmelding2)
+                selvbestemtImRepo.lagreIm(inntektsmelding1, Fnr.genererGyldig())
+                selvbestemtImRepo.lagreIm(inntektsmelding2, Fnr.genererGyldig())
 
                 selvbestemtImRepo.oppdaterJournalpostId(inntektsmelding1.id, journalpostId)
 
@@ -306,9 +308,9 @@ class SelvbestemtImRepoTest :
                 val inntektsmelding = mockInntektsmeldingV1().copy(type = Inntektsmelding.Type.Selvbestemt(UUID.randomUUID()))
                 val inntektsmeldingIkkeProsessert = mockInntektsmeldingV1().copy(type = Inntektsmelding.Type.Selvbestemt(UUID.randomUUID()))
 
-                selvbestemtImRepo.lagreIm(inntektsmelding)
+                selvbestemtImRepo.lagreIm(inntektsmelding, Fnr.genererGyldig())
                 delay(1.seconds)
-                selvbestemtImRepo.lagreIm(inntektsmeldingIkkeProsessert)
+                selvbestemtImRepo.lagreIm(inntektsmeldingIkkeProsessert, Fnr.genererGyldig())
 
                 selvbestemtImRepo.oppdaterSomProsessert(inntektsmelding.id)
 


### PR DESCRIPTION
Fnr til avsender er den eneste tingen vi ikke lagrer, så den informasjonen forsvinner. Lagrer dette nå fordi det er nyttig for å kunne rekjøre inntektsmeldinger.