### PR TITLE
Legg Redis-data i nested data for stateful service

### DIFF
--- a/utils/rapids-and-rivers/src/main/kotlin/no/nav/hag/simba/utils/rr/service/Service.kt
+++ b/utils/rapids-and-rivers/src/main/kotlin/no/nav/hag/simba/utils/rr/service/Service.kt
@@ -155,38 +155,6 @@ abstract class ServiceMed3Steg<S0, S1, S2, S3> : ServiceMed2Steg<S0, S1, S2>() {
     }
 }
 
-abstract class ServiceMed4Steg<S0, S1, S2, S3, S4> : ServiceMed3Steg<S0, S1, S2, S3>() {
-    protected abstract fun lesSteg4(melding: Map<Key, JsonElement>): S4
-
-    protected abstract fun utfoerSteg4(
-        data: Map<Key, JsonElement>,
-        steg0: S0,
-        steg1: S1,
-        steg2: S2,
-        steg3: S3,
-        steg4: S4,
-    )
-
-    override fun onData(melding: Map<Key, JsonElement>) {
-        runCatching {
-            Sextuple(
-                first = lesData(melding),
-                second = lesSteg0(melding),
-                third = lesSteg1(melding),
-                fourth = lesSteg2(melding),
-                fifth = lesSteg3(melding),
-                sixth = lesSteg4(melding),
-            )
-        }.onSuccess {
-            medLoggfelt(it.second) {
-                utfoerSteg4(it.first, it.second, it.third, it.fourth, it.fifth, it.sixth)
-            }
-        }.onFailure {
-            super.onData(melding)
-        }
-    }
-}
-
 private class Quadruple<S0, S1, S2, S3>(
     val first: S0,
     val second: S1,
@@ -200,13 +168,4 @@ private class Quintuple<S0, S1, S2, S3, S4>(
     val third: S2,
     val fourth: S3,
     val fifth: S4,
-)
-
-private class Sextuple<S0, S1, S2, S3, S4, S5>(
-    val first: S0,
-    val second: S1,
-    val third: S2,
-    val fourth: S3,
-    val fifth: S4,
-    val sixth: S5,
 )

--- a/utils/rapids-and-rivers/src/main/kotlin/no/nav/hag/simba/utils/rr/service/ServiceRiver.kt
+++ b/utils/rapids-and-rivers/src/main/kotlin/no/nav/hag/simba/utils/rr/service/ServiceRiver.kt
@@ -62,7 +62,10 @@ class ServiceRiverStateful<S>(
                     sikkerLogger.info("$it\n${json.toPretty()}")
                 }
 
-                val meldingMedRedisData = service.redisStore.lesAlleMellomlagrede(kontekstId).plus(json)
+                val mellomlagrede = service.redisStore.lesAlleMellomlagrede(kontekstId)
+                val utvidetDataMap = mellomlagrede.plus(dataMap).toJson()
+                val meldingMedUtvidetData = json.plus(Key.DATA to utvidetDataMap)
+                val meldingMedRedisData = mellomlagrede.plus(meldingMedUtvidetData)
 
                 service.onData(meldingMedRedisData)
             }
@@ -73,11 +76,14 @@ class ServiceRiverStateful<S>(
                     sikkerLogger.error("$it Utløsende melding er \n${fail.utloesendeMelding.toPretty()}")
                 }
 
+                val mellomlagrede = service.redisStore.lesAlleMellomlagrede(kontekstId)
+
                 val meldingMedRedisData =
-                    service.redisStore.lesAlleMellomlagrede(kontekstId).plus(
+                    mellomlagrede.plus(
                         mapOf(
                             Key.EVENT_NAME to eventName.toJson(),
                             Key.KONTEKST_ID to kontekstId.toJson(),
+                            Key.DATA to mellomlagrede.toJson(),
                         ),
                     )
 


### PR DESCRIPTION
Når en melding kommer inn til en stateful service så legges alt som ligger i Redis til på rotnivå. Endrer dette til også å legge Redis-data i nested data (aka under `Key.DATA`). Det er kun nested data som blir lagret i Redis.

Endringen fikser en liten feil vi har i dag, som sjeldent oppstår. Noen stateful servicer starter med å samtidig sende ut flere meldinger hvor man forventer en respons (som kun stateful kan håndtere). Når alle svarene er mottatt, så involverer resten av stegene kun enkeltmeldinger. Da går servicen over til å bruke en stateless framgangsmåte, men det har ikke fungert ettersom pga. manglende felt fra Redis i nested data. Det løses nå.