### PR TITLE
Øk minne for hver app

### DIFF
--- a/config/nais.yml
+++ b/config/nais.yml
@@ -18,9 +18,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 512Mi
+      memory: 768Mi
     limits:
-      memory: 1024Mi
+      memory: 1536Mi
   replicas:
     min: 2
     max: {{#if replicasMax}}{{ replicasMax }}{{else}}2{{/if}}


### PR DESCRIPTION
Appene har litt for lite minne, ifølge https://console.nav.cloud.nais.io/team/helsearbeidsgiver/utilization. Øker forespurt minne med 50%, og øker maks minne til det dobbelte av forespurt.