### PR TITLE
avvist im : legg til forklarende tekst med snittbeløp fra A-ordningen

### DIFF
--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
@@ -14,9 +14,16 @@ data class AvvistInntektsmelding(
     val forespoerselId: UUID,
     val vedtaksperiodeId: UUID,
     val orgnr: Orgnr,
-    val feilkode: Feilkode,
+    val feilkode: Feilkode, // deprecated, bruk Feil
+    val feil: Feil,
 )
 
 enum class Feilkode {
     INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
 }
+
+@Serializable
+class Feil(
+    val feilkode: Feilkode,
+    val feilmelding: String? = null,
+)

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
@@ -23,7 +23,7 @@ enum class Feilkode {
 }
 
 @Serializable
-class Feil(
+data class Feil(
     val feilkode: Feilkode,
     val feilmelding: String? = null,
 )

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingService.kt
@@ -135,7 +135,6 @@ class ValiderApiInnsendingService(
         steg2: ValideringsSteg2,
     ) {
         val inntekt = steg0.innsending.skjema.inntekt
-
         val feilkoder =
             if (inntekt == null || steg2.unnlatHentingAvInntekt) {
                 emptySet()
@@ -150,7 +149,8 @@ class ValiderApiInnsendingService(
                     forespoerselId = steg0.innsending.type.id,
                     vedtaksperiodeId = steg1.forespoersel.vedtaksperiodeId,
                     orgnr = steg1.forespoersel.orgnr,
-                    feilkode = feilkoder.first(),
+                    feilkode = feilkoder.first().feilkode,
+                    feil = feilkoder.first(),
                 )
             producer.send(
                 key = steg0.innsending.skjema.forespoerselId,

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
@@ -9,13 +9,13 @@ import kotlin.math.abs
 private const val FEILMARGIN_INNTEKT_A_ORDNING_KRONER: Double = 10.0
 
 /** Validerer om inntekten i inntektsmeldingen avviker fra inntekten i a-ordningen. */
-fun Inntekt.validerInntektMotAordningen(aordningInntekt: Map<YearMonth, Double?>): Set<Feilkode> {
+fun Inntekt.validerInntektMotAordningen(aordningInntekt: Map<YearMonth, Double?>): Set<Feil> {
     val aordningSnittInntekt = aordningInntekt.gjennomsnitt()
 
     val inntektErUtenforFeilmargin = abs(beloep - aordningSnittInntekt) > FEILMARGIN_INNTEKT_A_ORDNING_KRONER
 
     return if (inntektErUtenforFeilmargin || aordningInntekt.all { it.value == null }) {
-        setOf(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN).also {
+        setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Oppgitt beløp $beloep matcher ikke snittinntekt i A-ordning: $aordningSnittInntekt")).also {
             sikkerLogger().info(
                 "Validering av inntekt mot a-ordningen resulterte i feilen INNTEKT_AVVIKER_FRA_A_ORDNINGEN. Inntekt i inntektsmelding: $beloep kroner, " +
                     "utregnet gjennomsnitt fra a-ordninginntekter: $aordningSnittInntekt kroner, " +

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
@@ -104,16 +104,19 @@ class ValiderApiInnsendingServiceTest :
             testRapid.inspektør.size shouldBeExactly 2
             testRapid.message(1).lesBehov() shouldBe BehovType.HENT_INNTEKT
 
+            val mndInntekt = Mock.inntektBeloep.minus(100)
             val inntektFraAordningen =
                 mapOf(
-                    mai(2018) to Mock.inntektBeloep.minus(100),
-                    juni(2018) to Mock.inntektBeloep.minus(100),
-                    juli(2018) to Mock.inntektBeloep.minus(100),
+                    mai(2018) to mndInntekt,
+                    juni(2018) to mndInntekt,
+                    juli(2018) to mndInntekt,
                 )
 
             testRapid.sendJson(
                 Mock.steg2(kontekstId).plusData(Key.INNTEKT to inntektFraAordningen.toJson(inntektMapSerializer)),
             )
+
+            val forventetFeilmelding = "Oppgitt beløp ${Mock.inntektBeloep} matcher ikke snittinntekt i A-ordning: $mndInntekt"
 
             testRapid.inspektør.size shouldBeExactly 2
             val forventetNoekkel = Mock.innsending.skjema.forespoerselId
@@ -121,7 +124,7 @@ class ValiderApiInnsendingServiceTest :
                 ProducerRecord(
                     testTopic,
                     forventetNoekkel.toString(),
-                    Mock.avvistMelding(kontekstId).toJson(),
+                    Mock.avvistMelding(kontekstId, forventetFeilmelding).toJson(),
                 )
 
             verifySequence { mockKafkaProducer.send(forventetRecord) }
@@ -214,7 +217,10 @@ class ValiderApiInnsendingServiceTest :
                 Key.INNTEKT to inntektFraAordningen.toJson(inntektMapSerializer),
             )
 
-        fun avvistMelding(kontekstId: UUID): Map<InnsendingKey, JsonElement> {
+        fun avvistMelding(
+            kontekstId: UUID,
+            feilmelding: String = "Generisk feilmelding",
+        ): Map<InnsendingKey, JsonElement> {
             val avvistInntektsmelding =
                 AvvistInntektsmelding(
                     inntektsmeldingId = innsending.innsendingId,
@@ -222,7 +228,7 @@ class ValiderApiInnsendingServiceTest :
                     vedtaksperiodeId = forespoersel.vedtaksperiodeId,
                     orgnr = forespoersel.orgnr,
                     feilkode = Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
-                    feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Generisk feilmelding"),
+                    feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, feilmelding),
                 )
             return mapOf(
                 InnsendingKey.EVENT_NAME to InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson(),

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
@@ -222,6 +222,7 @@ class ValiderApiInnsendingServiceTest :
                     vedtaksperiodeId = forespoersel.vedtaksperiodeId,
                     orgnr = forespoersel.orgnr,
                     feilkode = Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                    feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Generisk feilmelding"),
                 )
             return mapOf(
                 InnsendingKey.EVENT_NAME to InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson(),

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
@@ -45,7 +45,12 @@ class ValideringsUtilsTest :
                                 49985.0,
                                 49975.0,
                             ),
-                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
+                            setOf(
+                                Feil(
+                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 49980.0",
+                                ),
+                            ),
                         ),
                     "alle a-ordninginntekter er null gir valideringsfeil" to
                         Pair(
@@ -54,12 +59,22 @@ class ValideringsUtilsTest :
                                 null,
                                 null,
                             ),
-                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
+                            setOf(
+                                Feil(
+                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 0.0",
+                                ),
+                            ),
                         ),
                     "tom a-ordning map gir valideringsfeil" to
                         Pair(
                             emptyList(),
-                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
+                            setOf(
+                                Feil(
+                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 0.0",
+                                ),
+                            ),
                         ),
                 ),
             ) { (aordningInntektListe, forventetFeil) ->

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
@@ -17,6 +17,8 @@ class ValideringsUtilsTest :
             )
         val testAar = 2024
 
+        val feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "whatever")
+
         context(Inntekt::validerInntektMotAordningen.name) {
             withData(
                 mapOf(
@@ -46,10 +48,7 @@ class ValideringsUtilsTest :
                                 49975.0,
                             ),
                             setOf(
-                                Feil(
-                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
-                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 49980.0",
-                                ),
+                                feil,
                             ),
                         ),
                     "alle a-ordninginntekter er null gir valideringsfeil" to
@@ -60,20 +59,14 @@ class ValideringsUtilsTest :
                                 null,
                             ),
                             setOf(
-                                Feil(
-                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
-                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 0.0",
-                                ),
+                                feil,
                             ),
                         ),
                     "tom a-ordning map gir valideringsfeil" to
                         Pair(
                             emptyList(),
                             setOf(
-                                Feil(
-                                    Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
-                                    "Oppgitt beløp ${testInntekt.beloep} matcher ikke snittinntekt i A-ordning: 0.0",
-                                ),
+                                feil,
                             ),
                         ),
                 ),
@@ -82,8 +75,11 @@ class ValideringsUtilsTest :
                     aordningInntektListe
                         .withIndex()
                         .associate { YearMonth.of(testAar, it.index + 1) to it.value }
-
-                testInntekt.validerInntektMotAordningen(aordningInntektMap) shouldBe forventetFeil
+                if (forventetFeil.isEmpty()) {
+                    testInntekt.validerInntektMotAordningen(aordningInntektMap) shouldBe forventetFeil
+                } else {
+                    testInntekt.validerInntektMotAordningen(aordningInntektMap).first().feilkode shouldBe forventetFeil.first().feilkode
+                }
             }
         }
     })

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtilsTest.kt
@@ -45,7 +45,7 @@ class ValideringsUtilsTest :
                                 49985.0,
                                 49975.0,
                             ),
-                            setOf(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN),
+                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
                         ),
                     "alle a-ordninginntekter er null gir valideringsfeil" to
                         Pair(
@@ -54,12 +54,12 @@ class ValideringsUtilsTest :
                                 null,
                                 null,
                             ),
-                            setOf(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN),
+                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
                         ),
                     "tom a-ordning map gir valideringsfeil" to
                         Pair(
                             emptyList(),
-                            setOf(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN),
+                            setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN)),
                         ),
                 ),
             ) { (aordningInntektListe, forventetFeil) ->

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
@@ -22,9 +22,6 @@ import no.nav.hag.simba.utils.felles.test.mock.mockInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
-import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.AvvistInntektsmelding
-import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.Feil
-import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.Feilkode
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.parseJson
@@ -277,30 +274,15 @@ class ValiderApiInnsendingServiceIT : EndToEndTest() {
                 ).toJson(),
         )
 
-        val avvistInntektsmelding =
-            AvvistInntektsmelding(
-                inntektsmeldingId = Mock.innsending.innsendingId,
-                forespoerselId = Mock.innsending.type.id,
-                vedtaksperiodeId = Mock.forespoersel.vedtaksperiodeId,
-                orgnr = Mock.forespoersel.orgnr,
-                feilkode = Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
-                feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Generisk feilmelding"),
-            )
-
+        val sentMessages = mutableListOf<Map<InnsendingKey, JsonElement>>()
         verify(exactly = 1) {
             producer.send(
                 key = Mock.forespoerselId,
-                message =
-                    mapOf(
-                        InnsendingKey.EVENT_NAME to InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson(),
-                        InnsendingKey.KONTEKST_ID to kontekstId.toJson(),
-                        InnsendingKey.DATA to
-                            mapOf(
-                                InnsendingKey.AVVIST_INNTEKTSMELDING to avvistInntektsmelding.toJson(AvvistInntektsmelding.serializer()),
-                            ).toJson(),
-                    ),
+                message = capture(sentMessages),
             )
         }
+        val avvist = sentMessages.first()
+        avvist[InnsendingKey.EVENT_NAME] shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson()
 
         // Sender _ikke_ inntektsmeldingen videre i innsendingsløypa
         messages.filter(EventName.API_INNSENDING_VALIDERT).all() shouldBe emptyList()

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
@@ -4,6 +4,7 @@ import io.kotest.assertions.throwables.shouldNotThrowAny
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.mockk.coEvery
+import io.mockk.slot
 import io.mockk.verify
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.bro.forespoersel.ForespoerselFraBro
@@ -274,16 +275,15 @@ class ValiderApiInnsendingServiceIT : EndToEndTest() {
                 ).toJson(),
         )
 
-        val sentMessages = mutableListOf<Map<InnsendingKey, JsonElement>>()
+        val melding = slot<Map<InnsendingKey, JsonElement>>()
         verify(exactly = 1) {
             producer.send(
                 key = Mock.forespoerselId,
-                message = capture(sentMessages),
+                message = capture(melding),
             )
         }
-        val avvist = sentMessages.first()
-        avvist[InnsendingKey.EVENT_NAME] shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson()
-
+        val avvistMelding = melding.captured
+        avvistMelding[InnsendingKey.EVENT_NAME] shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson()
         // Sender _ikke_ inntektsmeldingen videre i innsendingsløypa
         messages.filter(EventName.API_INNSENDING_VALIDERT).all() shouldBe emptyList()
     }

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/ValiderApiInnsendingServiceIT.kt
@@ -23,6 +23,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.AvvistInntektsmelding
+import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.Feil
 import no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern.Feilkode
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson
@@ -283,6 +284,7 @@ class ValiderApiInnsendingServiceIT : EndToEndTest() {
                 vedtaksperiodeId = Mock.forespoersel.vedtaksperiodeId,
                 orgnr = Mock.forespoersel.orgnr,
                 feilkode = Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Generisk feilmelding"),
             )
 
         verify(exactly = 1) {


### PR DESCRIPTION
Når vi avviser IM fra API pga mismatch mot A-ordningen, bør vi gi avsender informasjon om hvilket beløp vi har lagt til grunn for avgjørelsen. 
Innfører nytt feilobjekt, beholder gammel feilmelding og fjerner denne i neste versjon for å ikke brekke kommunikasjon mot LPS-API