### PR TITLE
bugfix: tillat at inntekt mangler

### DIFF
--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
@@ -14,7 +14,7 @@ fun Inntekt.validerInntektMotAordningen(aordningInntekt: Map<YearMonth, Double?>
 
     val inntektErUtenforFeilmargin = abs(beloep - aordningSnittInntekt) > FEILMARGIN_INNTEKT_A_ORDNING_KRONER
 
-    return if (inntektErUtenforFeilmargin || aordningInntekt.all { it.value == null }) {
+    return if (inntektErUtenforFeilmargin) {
         setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Oppgitt beløp $beloep matcher ikke snittinntekt i A-ordning: $aordningSnittInntekt")).also {
             sikkerLogger().info(
                 "Validering av inntekt mot a-ordningen resulterte i feilen INNTEKT_AVVIKER_FRA_A_ORDNINGEN. Inntekt i inntektsmelding: $beloep kroner, " +


### PR DESCRIPTION
Dagens kode ga valideringsfeil hvis alle måneder har null-verdi (ingen inntekt oppgitt) 

Om man sender inn en inntektsmelding med inntekt 0 kroner, fikk man dermed den interessante valideringsfeilen: 

**Oppgitt beløp 0.0 matcher ikke snittinntekt i A-ordning: 0.0**

Fjerner denne sjekken, vi validerer som vanlig i disse tilfellene: 3 x null = 0. 
Og dermed kan bruker få lov til å oppgi 0 kroner i inntekt. 

Dette gjelder validering av API-innsendte inntektsmeldinger 