### PR TITLE
Inkluderer månedsinntektene i feilmelding i avvist IM til LPS-API

### DIFF
--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
@@ -14,7 +14,6 @@ data class AvvistInntektsmelding(
     val forespoerselId: UUID,
     val vedtaksperiodeId: UUID,
     val orgnr: Orgnr,
-    val feilkode: Feilkode, // deprecated, bruk Feil
     val feil: Feil,
 )
 

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingService.kt
@@ -149,7 +149,6 @@ class ValiderApiInnsendingService(
                     forespoerselId = steg0.innsending.type.id,
                     vedtaksperiodeId = steg1.forespoersel.vedtaksperiodeId,
                     orgnr = steg1.forespoersel.orgnr,
-                    feilkode = feilkoder.first().feilkode,
                     feil = feilkoder.first(),
                 )
             producer.send(

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValideringsUtils.kt
@@ -15,7 +15,12 @@ fun Inntekt.validerInntektMotAordningen(aordningInntekt: Map<YearMonth, Double?>
     val inntektErUtenforFeilmargin = abs(beloep - aordningSnittInntekt) > FEILMARGIN_INNTEKT_A_ORDNING_KRONER
 
     return if (inntektErUtenforFeilmargin) {
-        setOf(Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, "Oppgitt beløp $beloep matcher ikke snittinntekt i A-ordning: $aordningSnittInntekt")).also {
+        setOf(
+            Feil(
+                Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+                "Oppgitt beløp $beloep matcher ikke snittinntekt i A-ordning: $aordningSnittInntekt ($aordningInntekt)",
+            ),
+        ).also {
             sikkerLogger().info(
                 "Validering av inntekt mot a-ordningen resulterte i feilen INNTEKT_AVVIKER_FRA_A_ORDNINGEN. Inntekt i inntektsmelding: $beloep kroner, " +
                     "utregnet gjennomsnitt fra a-ordninginntekter: $aordningSnittInntekt kroner, " +

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ValiderApiInnsendingServiceTest.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern
 
 import com.github.navikt.tbd_libs.rapids_and_rivers.test_support.TestRapid
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.ints.shouldBeAtMost
 import io.kotest.matchers.ints.shouldBeExactly
 import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
@@ -116,8 +117,8 @@ class ValiderApiInnsendingServiceTest :
                 Mock.steg2(kontekstId).plusData(Key.INNTEKT to inntektFraAordningen.toJson(inntektMapSerializer)),
             )
 
-            val forventetFeilmelding = "Oppgitt beløp ${Mock.inntektBeloep} matcher ikke snittinntekt i A-ordning: $mndInntekt"
-
+            val forventetFeilmelding = "Oppgitt beløp ${Mock.inntektBeloep} matcher ikke snittinntekt i A-ordning: $mndInntekt ($inntektFraAordningen)"
+            forventetFeilmelding.length shouldBeAtMost 255 // Feilmelding bør ikke være for lang, LPS-API klipper meldingen hvis over 255 tegn
             testRapid.inspektør.size shouldBeExactly 2
             val forventetNoekkel = Mock.innsending.skjema.forespoerselId
             val forventetRecord =
@@ -227,7 +228,6 @@ class ValiderApiInnsendingServiceTest :
                     forespoerselId = innsending.type.id,
                     vedtaksperiodeId = forespoersel.vedtaksperiodeId,
                     orgnr = forespoersel.orgnr,
-                    feilkode = Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
                     feil = Feil(Feilkode.INNTEKT_AVVIKER_FRA_A_ORDNINGEN, feilmelding),
                 )
             return mapOf(


### PR DESCRIPTION
Gir litt mer info til LPS, så de forstår grunnen til at vi avviser.

Fjerner også utdatert felt 'feilkode' fra AvvistInntektsmelding (erstattet av feltet 'feil')
