### PR TITLE
Bump avhengigheter

### DIFF
--- a/apps/altinn/gradle.properties
+++ b/apps/altinn/gradle.properties
@@ -1,2 +1,2 @@
 altinnClientVersion=1.3.0
-mockwebserverVersion=5.3.0
+mockwebserverVersion=5.3.2

--- a/apps/api/gradle.properties
+++ b/apps/api/gradle.properties
@@ -1,3 +1,3 @@
 # Dependency versions
 mockOauth2ServerVersion=3.0.1
-tokenSupportVersion=6.0.1
+tokenSupportVersion=6.0.5

--- a/apps/feil-behandler/gradle.properties
+++ b/apps/feil-behandler/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
 bakgrunnsjobbVersion=1.0.4
-flywayVersion=11.20.3
+flywayVersion=12.4.0
 hikariVersion=7.0.2
-postgresqlVersion=42.7.9
-testcontainersVersion=2.0.3
+postgresqlVersion=42.7.10
+testcontainersVersion=2.0.5

--- a/apps/integrasjonstest/gradle.properties
+++ b/apps/integrasjonstest/gradle.properties
@@ -1,4 +1,4 @@
 # Dependency versions
-lettuceVersion=7.2.1.RELEASE
+lettuceVersion=7.5.1.RELEASE
 testcontainersRedisVersion=2.2.4
-testcontainersVersion=2.0.3
+testcontainersVersion=2.0.5

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,15 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=2.3.0
-kotlinterVersion=5.4.0
+kotlinVersion=2.3.20
+kotlinterVersion=5.4.2
 
 # Dependency versions
 hagDomeneInntektsmeldingVersion=0.9.0
-junitJupiterVersion=6.0.2
-kotestVersion=6.1.1
+junitJupiterVersion=6.0.3
+kotestVersion=6.1.11
 kotlinxCoroutinesVersion=1.10.2
-kotlinxSerializationVersion=1.10.0
-ktorVersion=3.4.0
+kotlinxSerializationVersion=1.11.0
+ktorVersion=3.4.2
 mockkVersion=1.14.9
 utilsVersion=0.10.2

--- a/utils/db-exposed/gradle.properties
+++ b/utils/db-exposed/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
-exposedVersion=1.0.0
-flywayVersion=11.20.3
+exposedVersion=1.2.0
+flywayVersion=12.4.0
 hikariVersion=7.0.2
-postgresqlVersion=42.7.9
-testcontainersVersion=2.0.3
+postgresqlVersion=42.7.10
+testcontainersVersion=2.0.5

--- a/utils/kafka/gradle.properties
+++ b/utils/kafka/gradle.properties
@@ -1,2 +1,2 @@
 # Dependency versions
-kafkaClientVersion=4.1.1
+kafkaClientVersion=4.2.0

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency versions
-micrometerVersion=1.16.1
-rapidsAndRiversTestVersion=2026.01.27-10.26-c79baf3a
-rapidsAndRiversVersion=2026012320541769198088.1c6293179de6
+micrometerVersion=1.16.4
+rapidsAndRiversTestVersion=2026.04.08-15.53-0e79d272
+rapidsAndRiversVersion=2026042008201776666058
 slf4jVersion=2.0.17

--- a/utils/valkey/gradle.properties
+++ b/utils/valkey/gradle.properties
@@ -1,2 +1,2 @@
 # Dependency versions
-lettuceVersion=7.2.1.RELEASE
+lettuceVersion=7.5.1.RELEASE


### PR DESCRIPTION
`rapidsAndRiversTestVersion` er ikke bumpet til siste ettersom det oppsto problemer med noen tester. Lurer på om det har noe med at de har tatt i bruk Jackson 3, som krasjer med vår Jackson 2. Jeg skal uansett bumpe Jackson i en egen PR, for å unngå samme problemer når vi skal bumpe R&R-pappen i fremtiden.