### PR TITLE
Bump Jackson til versjon 3

### DIFF
--- a/apps/bro-spinn/build.gradle.kts
+++ b/apps/bro-spinn/build.gradle.kts
@@ -5,14 +5,13 @@ val spinnInntektsmeldingKontraktVersion: String by project
 dependencies {
     implementation(project(":kontrakt-domene-inntektsmelding"))
     implementation(project(":utils-auth"))
-    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:$jacksonVersion")
-    implementation("com.fasterxml.jackson.module:jackson-module-kotlin:$jacksonVersion")
     implementation("io.ktor:ktor-client-apache5:$ktorVersion")
     implementation("io.ktor:ktor-client-content-negotiation:$ktorVersion")
     implementation("io.ktor:ktor-client-core:$ktorVersion")
     implementation("io.ktor:ktor-serialization-kotlinx-json:$ktorVersion")
     implementation("no.nav.sykepenger.kontrakter:inntektsmelding-kontrakt:$spinnInntektsmeldingKontraktVersion")
+    implementation("tools.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    implementation("tools.jackson.module:jackson-module-kotlin:$jacksonVersion")
 
     testImplementation(testFixtures(project(":kontrakt-domene-inntektsmelding")))
     testImplementation("io.ktor:ktor-client-mock:$ktorVersion")

--- a/apps/bro-spinn/gradle.properties
+++ b/apps/bro-spinn/gradle.properties
@@ -1,2 +1,2 @@
-jacksonVersion=2.20.1
-spinnInntektsmeldingKontraktVersion=2023.10.13-04-47-c372d
+jacksonVersion=3.1.2
+spinnInntektsmeldingKontraktVersion=2026.04.15-10-22-eb2ae

--- a/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/Jackson.kt
+++ b/apps/bro-spinn/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/brospinn/Jackson.kt
@@ -1,20 +1,18 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.brospinn
 
-import com.fasterxml.jackson.databind.DeserializationFeature
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.kotlin.jacksonObjectMapper
 import no.nav.inntektsmeldingkontrakt.Inntektsmelding
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.cfg.DateTimeFeature
+import tools.jackson.module.kotlin.jsonMapper
+import tools.jackson.module.kotlin.kotlinModule
 
 object Jackson {
     private val objectMapper: ObjectMapper =
-        jacksonObjectMapper()
-            .registerModule(JavaTimeModule())
-            .disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
-            .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            .disable(DeserializationFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
-            .configure(SerializationFeature.WRITE_DATES_WITH_ZONE_ID, true)
+        jsonMapper {
+            addModule(kotlinModule())
+            disable(DateTimeFeature.ADJUST_DATES_TO_CONTEXT_TIME_ZONE)
+            enable(DateTimeFeature.WRITE_DATES_WITH_ZONE_ID)
+        }
 
     fun fromJson(json: String): Inntektsmelding = objectMapper.readValue(json, Inntektsmelding::class.java)
 

--- a/apps/joark/build.gradle.kts
+++ b/apps/joark/build.gradle.kts
@@ -13,13 +13,19 @@ tasks {
 
 dependencies {
     implementation(project(":utils-auth"))
-    implementation("javax.xml.bind:jaxb-api:$jaxbApiVersion")
+    implementation("jakarta.xml.bind:jakarta.xml.bind-api:$jaxbApiVersion")
     implementation("no.nav.helsearbeidsgiver:dokarkiv-client:$dokarkivKlientVersion")
-    implementation("no.nav.helsearbeidsgiver:helsearbeidsgiver-kontrakt-inntektsmelding:$hagImXmlKontraktVersion")
+    implementation("no.nav.helsearbeidsgiver:helsearbeidsgiver-kontrakt-inntektsmelding:$hagImXmlKontraktVersion") {
+        constraints {
+            // Uten denne så får vi problemer med mocking i integrasjonstestene.
+            // Synderen er trolig avhengigheten jaxb-xew-plugin, som ikke har vært oppdatert på flere år og bruker en gammel versjon av byte-buddy.
+            runtimeOnly("net.bytebuddy:byte-buddy:1.17.0")
+        }
+    }
     implementation("org.apache.pdfbox:pdfbox:$pdfboxVersion")
 
     runtimeOnly("org.glassfish.jaxb:jaxb-runtime:$jaxbRuntimeVersion")
 
-    testImplementation("com.fasterxml.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
-    testImplementation("com.fasterxml.jackson.module:jackson-module-jaxb-annotations:$jacksonVersion")
+    testImplementation("tools.jackson.dataformat:jackson-dataformat-xml:$jacksonVersion")
+    testImplementation("tools.jackson.module:jackson-module-jaxb-annotations:$jacksonVersion")
 }

--- a/apps/joark/gradle.properties
+++ b/apps/joark/gradle.properties
@@ -1,6 +1,6 @@
 dokarkivKlientVersion=0.5.4
-hagImXmlKontraktVersion=1.0.8
-jacksonVersion=2.20.1
-jaxbApiVersion=2.4.0-b180830.0359
-jaxbRuntimeVersion=2.4.0-b180830.0438
+hagImXmlKontraktVersion=1.0.9
+jacksonVersion=3.1.2
+jaxbApiVersion=4.0.5
+jaxbRuntimeVersion=4.0.7
 pdfboxVersion=2.0.27

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLUtils.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/XMLUtils.kt
@@ -1,10 +1,10 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.joark.dokument
 
+import jakarta.xml.bind.JAXBContext
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.tilXmlInntektsmelding
 import no.seres.xsd.nav.inntektsmelding_m._20181211.ObjectFactory
 import java.io.StringWriter
-import javax.xml.bind.JAXBContext
 
 val CONTEXT: JAXBContext = JAXBContext.newInstance(ObjectFactory::class.java)
 

--- a/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
+++ b/apps/joark/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/TilXmlInntektsmeldingTest.kt
@@ -1,11 +1,5 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.joark
 
-import com.fasterxml.jackson.databind.ObjectMapper
-import com.fasterxml.jackson.databind.SerializationFeature
-import com.fasterxml.jackson.dataformat.xml.XmlMapper
-import com.fasterxml.jackson.dataformat.xml.deser.FromXmlParser
-import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule
-import com.fasterxml.jackson.module.jaxb.JaxbAnnotationModule
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
@@ -18,6 +12,11 @@ import no.nav.helsearbeidsgiver.utils.test.date.januar
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
 import org.junit.jupiter.api.Assertions
 import org.junit.jupiter.api.Test
+import tools.jackson.databind.ObjectMapper
+import tools.jackson.databind.SerializationFeature
+import tools.jackson.dataformat.xml.XmlMapper
+import tools.jackson.dataformat.xml.XmlReadFeature
+import tools.jackson.module.jaxb.JaxbAnnotationModule
 
 class TilXmlInntektsmeldingTest {
     @Test
@@ -94,9 +93,9 @@ class TilXmlInntektsmeldingTest {
 }
 
 private fun xmlMapper(): ObjectMapper =
-    XmlMapper().apply {
-        registerModule(JaxbAnnotationModule())
-        registerModule(JavaTimeModule())
-        configure(FromXmlParser.Feature.EMPTY_ELEMENT_AS_NULL, true)
-        enable(SerializationFeature.INDENT_OUTPUT)
-    }
+    XmlMapper
+        .builder()
+        .addModule(JaxbAnnotationModule())
+        .enable(XmlReadFeature.EMPTY_ELEMENT_AS_NULL)
+        .enable(SerializationFeature.INDENT_OUTPUT)
+        .build()

--- a/utils/rapids-and-rivers/build.gradle.kts
+++ b/utils/rapids-and-rivers/build.gradle.kts
@@ -2,7 +2,6 @@ val hagDomeneInntektsmeldingVersion: String by project
 val kotestVersion: String by project
 val micrometerVersion: String by project
 val mockkVersion: String by project
-val rapidsAndRiversTestVersion: String by project
 val rapidsAndRiversVersion: String by project
 val slf4jVersion: String by project
 val utilsVersion: String by project
@@ -23,7 +22,7 @@ dependencies {
     testImplementation(testFixtures(project(":utils-felles")))
     testImplementation(testFixtures(project(":utils-valkey")))
 
-    testFixturesApi("com.github.navikt.tbd-libs:rapids-and-rivers-test:$rapidsAndRiversTestVersion")
+    testFixturesApi("com.github.navikt.rapids-and-rivers:rapids-and-rivers-test:$rapidsAndRiversVersion")
     testFixturesApi("com.github.navikt:rapids-and-rivers:$rapidsAndRiversVersion")
     testFixturesApi("no.nav.helsearbeidsgiver:domene-inntektsmelding:$hagDomeneInntektsmeldingVersion")
 

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,5 +1,5 @@
 # Dependency versions
 micrometerVersion=1.16.4
-rapidsAndRiversTestVersion=2026.04.08-15.53-0e79d272
-rapidsAndRiversVersion=2026042008201776666058
+rapidsAndRiversTestVersion=20260429.1019
+rapidsAndRiversVersion=2026042913501777463400
 slf4jVersion=2.0.17

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,5 +1,4 @@
 # Dependency versions
 micrometerVersion=1.16.4
-rapidsAndRiversTestVersion=20260429.1019
 rapidsAndRiversVersion=2026042913501777463400
 slf4jVersion=2.0.17

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,4 +1,4 @@
 # Dependency versions
 micrometerVersion=1.16.4
-rapidsAndRiversVersion=2026042913501777463400
+rapidsAndRiversVersion=2026043009341777534451
 slf4jVersion=2.0.17


### PR DESCRIPTION
Rapids-and-river-biblioteket planlegger å bumpe Jackson fra versjon 2 til 3. For at vi skal kunne bumpe R&R-versjon i fremtiden uten problemer, så bumper vi Jackson i forkant.

Hos oss er det kun lagring av journalposter og henting av IM-er fra Spinosaurus som er påvirket.