### PR TITLE
Fiks henting av arbeidsforhold

### DIFF
--- a/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdService.kt
+++ b/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdService.kt
@@ -94,10 +94,13 @@ class HentArbeidsforholdService(
             Key.BEHOV to BehovType.HENT_ANSETTELSESPERIODER.toJson(),
             Key.KONTEKST_ID to steg0.kontekstId.toJson(),
             Key.DATA to
-                mapOf(
-                    Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
-                    Key.FNR to steg1.forespoersel.fnr.toJson(),
-                ).toJson(),
+                data
+                    .plus(
+                        mapOf(
+                            Key.SVAR_KAFKA_KEY to svarKafkaKey.toJson(),
+                            Key.FNR to steg1.forespoersel.fnr.toJson(),
+                        ),
+                    ).toJson(),
         )
     }
 


### PR DESCRIPTION
Dette fikser en feil som ble introdusert i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/1031, hvor `HentArbeidsforholdService` ble gjort stateless, men bare det første steget ble endret for å støtte stateless.