### PR TITLE
Ta i bruk nytt felt for flere arbeidsforhold

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -16,7 +16,9 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.test.mock.mockFlereArbeidsforhold
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
@@ -41,6 +43,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse
@@ -274,6 +277,7 @@ private fun mockSelvbestemtInntektsmelding(): Inntektsmelding =
         type =
             Inntektsmelding.Type.Selvbestemt(
                 id = UUID.randomUUID(),
+                flereArbeidsforhold = mockFlereArbeidsforhold(),
             ),
     )
 
@@ -301,7 +305,8 @@ private fun Inntektsmelding.Type.hardcodedJson(): String =
             """
             {
                 "type": "Forespurt",
-                "id": "$id"
+                "id": "$id",
+                "flereArbeidsforhold": ${flereArbeidsforhold?.hardcodedJson()}
             }
             """
         }
@@ -320,7 +325,8 @@ private fun Inntektsmelding.Type.hardcodedJson(): String =
             """
             {
                 "type": "Selvbestemt",
-                "id": "$id"
+                "id": "$id",
+                "flereArbeidsforhold": ${flereArbeidsforhold?.hardcodedJson()}
             }
             """
         }
@@ -377,6 +383,25 @@ private fun AvsenderSystem.hardcodedJson(): String =
         "orgnr": "$orgnr",
         "navn": "$navn",
         "versjon": "$versjon"
+    }
+    """
+
+private fun FlereArbeidsforhold.hardcodedJson(): String =
+    """
+    {
+        "harLikLoenn": $harLikLoenn,
+        "erSykmeldtFraAlle": $erSykmeldtFraAlle,
+        "arbeidsforhold": [${arbeidsforhold.joinToString(transform = Arbeidsforhold::hardcodedJson)}]
+    }
+    """
+
+private fun Arbeidsforhold.hardcodedJson(): String =
+    """
+    {
+        "inkludertISykefravaer": $inkludertISykefravaer,
+        "yrkesbeskrivelse": "$yrkesbeskrivelse",
+        "stillingsprosent": $stillingsprosent,
+        "inntekt": $inntekt
     }
     """
 

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRouteKtTest.kt
@@ -147,6 +147,7 @@ class LagreSelvbestemtImRouteKtTest : ApiTest() {
                     "Sykmeldingsperioder må fylles ut",
                     "Beløp må være større eller lik 0",
                     "Refusjonsbeløp må være mindre eller lik inntekt",
+                    "Summen av inntekter fra flere arbeidsforhold må være lik innrapportert inntekt",
                 )
 
             coEvery { anyConstructed<RedisPoller>().hent(any()) } returns harTilgangResultat

--- a/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/MapInntektsmelding.kt
+++ b/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/MapInntektsmelding.kt
@@ -38,6 +38,7 @@ fun mapInntektsmelding(
                 ?: Inntektsmelding.Type.Forespurt(
                     id = skjema.forespoerselId,
                     erAgpForespurt = forespoersel.forespurtData.arbeidsgiverperiode.paakrevd,
+                    flereArbeidsforhold = skjema.flereArbeidsforhold,
                 ),
         sykmeldt =
             Sykmeldt(

--- a/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/MapInntektsmeldingKtTest.kt
+++ b/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/MapInntektsmeldingKtTest.kt
@@ -6,6 +6,7 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.types.shouldBeInstanceOf
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.utenPaakrevdAGP
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
@@ -55,6 +56,7 @@ class MapInntektsmeldingKtTest :
                         Inntektsmelding.Type.Forespurt(
                             id = skjema.forespoerselId,
                             erAgpForespurt = true,
+                            flereArbeidsforhold = skjema.flereArbeidsforhold,
                         )
 
                     sykmeldt shouldBe
@@ -91,13 +93,14 @@ class MapInntektsmeldingKtTest :
                 }
             }
 
-            test("beholder tomme verdier for AGP, inntekt og refusjon") {
+            test("beholder tomme verdier for AGP, inntekt, refusjon og flere arbeidsforhold") {
                 val forespoersel = mockForespoersel()
                 val skjema =
                     mockSkjemaInntektsmelding().copy(
                         agp = null,
                         inntekt = null,
                         refusjon = null,
+                        flereArbeidsforhold = null,
                     )
 
                 val inntektsmelding =
@@ -115,6 +118,9 @@ class MapInntektsmeldingKtTest :
                 inntektsmelding.agp.shouldBeNull()
                 inntektsmelding.inntekt.shouldBeNull()
                 inntektsmelding.refusjon.shouldBeNull()
+                inntektsmelding.type.shouldBeInstanceOf<Inntektsmelding.Type.Forespurt> {
+                    it.flereArbeidsforhold.shouldBeNull()
+                }
             }
 
             test("setter AGP som ikke forespurt dersom AGP _ikke_ er påkrevd") {

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
@@ -5,11 +5,13 @@ import io.kotest.matchers.booleans.shouldBeFalse
 import io.kotest.matchers.booleans.shouldBeTrue
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.hag.simba.utils.felles.test.mock.randomDigitString
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.november
@@ -42,6 +44,13 @@ class InntektsmeldingUtilsKtTest :
                 test("skjema med ulik refusjon er _ikke_ duplikater") {
                     val gammel = mockSkjemaInntektsmelding()
                     val ny = gammel.copy(refusjon = nyRefusjon)
+
+                    ny.erDuplikatAv(gammel).shouldBeFalse()
+                }
+
+                test("skjema med ulik 'flere arbeidsforhold' er _ikke_ duplikater") {
+                    val gammel = mockSkjemaInntektsmelding()
+                    val ny = gammel.copy(flereArbeidsforhold = nyFlereArbeidsforhold)
 
                     ny.erDuplikatAv(gammel).shouldBeFalse()
                 }
@@ -85,4 +94,19 @@ private val nyRefusjon =
     Refusjon(
         beloepPerMaaned = 4021.1,
         endringer = listOf(RefusjonEndring(beloep = 0.0, startdato = 31.desember)),
+    )
+
+private val nyFlereArbeidsforhold =
+    FlereArbeidsforhold(
+        harLikLoenn = true,
+        erSykmeldtFraAlle = true,
+        arbeidsforhold =
+            listOf(
+                Arbeidsforhold(
+                    inkludertISykefravaer = false,
+                    yrkesbeskrivelse = "Lokomotivfører",
+                    stillingsprosent = 100.0,
+                    inntekt = 815.0,
+                ),
+            ),
     )

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/LagreSelvbestemtIT.kt
@@ -30,6 +30,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson
@@ -64,10 +65,10 @@ class LagreSelvbestemtIT : EndToEndTest() {
                 type =
                     Inntektsmelding.Type.Selvbestemt(
                         id = UUID.randomUUID(),
+                        flereArbeidsforhold = Mock.skjema.flereArbeidsforhold,
                     ),
                 aarsakInnsending = AarsakInnsending.Ny,
             )
-
         coEvery { brregClient.hentOrganisasjonNavn(any()) } returns mapOf(Mock.organisasjon)
         coEvery { pdlKlient.personBolk(any()) } returns Mock.personer
         coEvery { aaregClient.hentAnsettelsesperioder(any(), any()) } returns Mock.ansettelsesperioder
@@ -418,6 +419,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
                 type =
                     Inntektsmelding.Type.Selvbestemt(
                         id = skjema.selvbestemtId.shouldNotBeNull(),
+                        flereArbeidsforhold = skjema.flereArbeidsforhold,
                     ),
                 sykmeldt =
                     Sykmeldt(
@@ -432,7 +434,7 @@ class LagreSelvbestemtIT : EndToEndTest() {
                         tlf = skjema.avsender.tlf,
                     ),
                 aarsakInnsending = AarsakInnsending.Endring,
-                vedtaksperiodeId = skjema.vedtaksperiodeId.shouldNotBeNull(),
+                vedtaksperiodeId = (skjema.arbeidsforholdType as? ArbeidsforholdType.MedArbeidsforhold)?.vedtaksperiodeId,
             )
     }
 }

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -27,6 +27,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
@@ -38,7 +39,6 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
-import java.time.LocalDate
 import java.time.LocalDateTime
 import java.util.UUID
 import kotlin.collections.orEmpty
@@ -125,8 +125,6 @@ class LagreSelvbestemtImService(
         steg0: Steg0,
     ) {
         val svarKafkaKey = KafkaKey(steg0.skjema.sykmeldtFnr)
-
-        kontrollerSkjema(steg0.skjema)
 
         publisher.publish(
             key = steg0.skjema.sykmeldtFnr,
@@ -333,25 +331,6 @@ class LagreSelvbestemtImService(
         }
     }
 
-    private fun kontrollerSkjema(skjema: SkjemaInntektsmeldingSelvbestemt) {
-        skjema.agp?.let { arbeidsgiverperiode ->
-            if (arbeidsgiverperiode.perioder.sumOf
-                    {
-                        it.fom.datesUntil(it.tom).count() + 1 // datesuntil er eksklusiv t.o.m, så legg til 1
-                    } < 16
-            ) {
-                sikkerLogger.info("Skjema fra orgnr ${skjema.avsender.orgnr} har kort AGP")
-            }
-        }
-        skjema.sykmeldingsperioder.let { smp ->
-            smp.forEach {
-                if (it.tom.isAfter(LocalDate.now())) {
-                    sikkerLogger.warn("Skjema fra orgnr ${skjema.avsender.orgnr} har sykemeldingsperiode med tom-dato fram i tid")
-                }
-            }
-        }
-    }
-
     override fun Steg0.loggfelt(): Map<String, String> =
         mapOf(
             Log.klasse(this@LagreSelvbestemtImService),
@@ -359,20 +338,6 @@ class LagreSelvbestemtImService(
             Log.kontekstId(kontekstId),
         )
 }
-
-fun ArbeidsforholdType.tilVedtaksperiodeId(): UUID? =
-    when (this) {
-        is ArbeidsforholdType.MedArbeidsforhold -> vedtaksperiodeId
-        else -> null
-    }
-
-fun ArbeidsforholdType.tilInntektsmeldingType(id: UUID): Inntektsmelding.Type =
-    when (this) {
-        is ArbeidsforholdType.MedArbeidsforhold -> Inntektsmelding.Type.Selvbestemt(id = id)
-        is ArbeidsforholdType.Fisker -> Inntektsmelding.Type.Fisker(id = id)
-        is ArbeidsforholdType.UtenArbeidsforhold -> Inntektsmelding.Type.UtenArbeidsforhold(id = id)
-        is ArbeidsforholdType.Behandlingsdager -> Inntektsmelding.Type.Behandlingsdager(id = id)
-    }
 
 fun tilInntektsmelding(
     skjema: SkjemaInntektsmeldingSelvbestemt,
@@ -393,6 +358,7 @@ fun tilInntektsmelding(
         type =
             skjema.arbeidsforholdType.tilInntektsmeldingType(
                 id = skjema.selvbestemtId ?: UUID.randomUUID(),
+                flereArbeidsforhold = skjema.flereArbeidsforhold,
             ),
         sykmeldt =
             Sykmeldt(
@@ -413,7 +379,27 @@ fun tilInntektsmelding(
         naturalytelser = skjema.naturalytelser,
         aarsakInnsending = aarsakInnsending,
         mottatt = mottatt.toOffsetDateTimeOslo(),
-        // TODO: Fjerne "?: skjema.vedtaksperiodeId" etter frontend har implementert arbeidsforholdType
-        vedtaksperiodeId = skjema.arbeidsforholdType.tilVedtaksperiodeId() ?: skjema.vedtaksperiodeId,
+        vedtaksperiodeId = skjema.arbeidsforholdType.tilVedtaksperiodeId(),
     )
 }
+
+fun ArbeidsforholdType.tilInntektsmeldingType(
+    id: UUID,
+    flereArbeidsforhold: FlereArbeidsforhold?,
+): Inntektsmelding.Type =
+    when (this) {
+        is ArbeidsforholdType.MedArbeidsforhold -> Inntektsmelding.Type.Selvbestemt(id, flereArbeidsforhold)
+        is ArbeidsforholdType.Fisker -> Inntektsmelding.Type.Fisker(id)
+        is ArbeidsforholdType.UtenArbeidsforhold -> Inntektsmelding.Type.UtenArbeidsforhold(id)
+        is ArbeidsforholdType.Behandlingsdager -> Inntektsmelding.Type.Behandlingsdager(id)
+    }
+
+fun ArbeidsforholdType.tilVedtaksperiodeId(): UUID? =
+    when (this) {
+        is ArbeidsforholdType.MedArbeidsforhold -> vedtaksperiodeId
+
+        ArbeidsforholdType.Behandlingsdager,
+        ArbeidsforholdType.Fisker,
+        ArbeidsforholdType.UtenArbeidsforhold,
+        -> null
+    }

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -30,6 +30,7 @@ import no.nav.hag.simba.utils.felles.test.json.lesData
 import no.nav.hag.simba.utils.felles.test.json.minusData
 import no.nav.hag.simba.utils.felles.test.json.plusData
 import no.nav.hag.simba.utils.felles.test.mock.mockFail
+import no.nav.hag.simba.utils.felles.test.mock.mockFlereArbeidsforhold
 import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.service.ServiceRiverStateful
 import no.nav.hag.simba.utils.rr.test.message
@@ -47,6 +48,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
@@ -86,29 +88,38 @@ class LagreSelvbestemtImServiceTest :
         }
 
         context("Inntektsmeldinger AarsakInnsending.Ny lagres og sak opprettes") {
-
-            fun ArbeidsforholdType.skalHaArbeidsforhold(): Boolean =
-                when (this) {
-                    is ArbeidsforholdType.MedArbeidsforhold, is ArbeidsforholdType.Behandlingsdager -> true
-                    is ArbeidsforholdType.UtenArbeidsforhold, is ArbeidsforholdType.Fisker -> false
-                }
-
             withData(
-                nameFn = { "med skjema ${ArbeidsforholdType::class.simpleName}.${it::class.simpleName}" },
-                ts =
-                    setOf(
-                        Mock.skjema.arbeidsforholdType,
-                        ArbeidsforholdType.Fisker,
-                        ArbeidsforholdType.UtenArbeidsforhold,
-                    ),
-            ) { arbeidsforholdType ->
-
-                val skjema = Mock.skjema.copy(selvbestemtId = null, arbeidsforholdType = arbeidsforholdType)
-
-                val inntektsmeldingType = arbeidsforholdType.tilInntektsmeldingType(UUID.randomUUID())
-                val nyInntektsmelding = Mock.inntektsmelding.copy(aarsakInnsending = AarsakInnsending.Ny, type = inntektsmeldingType)
-
+                nameFn = {
+                    "skjema med ${ArbeidsforholdType::class.simpleName}.${it.first::class.simpleName} og ${FlereArbeidsforhold::class.simpleName} (antall ${it.second?.arbeidsforhold.orEmpty().size})"
+                },
+                ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID()) to null,
+                ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID()) to mockFlereArbeidsforhold(),
+                ArbeidsforholdType.Behandlingsdager to null,
+                ArbeidsforholdType.Fisker to null,
+                ArbeidsforholdType.UtenArbeidsforhold to null,
+            ) { (arbeidsforholdType, flereArbeidsforhold) ->
                 val kontekstId = UUID.randomUUID()
+                val skjema =
+                    Mock.skjema.copy(
+                        selvbestemtId = null,
+                        arbeidsforholdType = arbeidsforholdType,
+                        flereArbeidsforhold = flereArbeidsforhold,
+                    )
+
+                val inntektsmeldingType = arbeidsforholdType.tilInntektsmeldingType(UUID.randomUUID(), skjema.flereArbeidsforhold)
+                val nyInntektsmelding =
+                    Mock.inntektsmelding.copy(
+                        aarsakInnsending = AarsakInnsending.Ny,
+                        type = inntektsmeldingType,
+                        vedtaksperiodeId = arbeidsforholdType.tilVedtaksperiodeId(),
+                    )
+
+                val arbeidsforholdListe =
+                    if (arbeidsforholdType.skalHaArbeidsforhold()) {
+                        Mock.lagAnsettelsesperioder(orgnr = Mock.skjema.avsender.orgnr)
+                    } else {
+                        emptyMap()
+                    }
 
                 testRapid.sendJson(
                     Mock
@@ -136,13 +147,6 @@ class LagreSelvbestemtImServiceTest :
                     it.lesBehov() shouldBe BehovType.HENT_ANSETTELSESPERIODER
                     Key.SVAR_KAFKA_KEY.lesOrNull(KafkaKey.serializer(), it.lesData()) shouldBe KafkaKey(skjema.sykmeldtFnr)
                 }
-
-                val arbeidsforholdListe =
-                    if (arbeidsforholdType.skalHaArbeidsforhold()) {
-                        Mock.lagAnsettelsesperioder(orgnr = Mock.skjema.avsender.orgnr)
-                    } else {
-                        emptyMap()
-                    }
 
                 mockStatic(OffsetDateTime::class) {
                     every { OffsetDateTime.now() } returns nyInntektsmelding.mottatt
@@ -462,6 +466,12 @@ class LagreSelvbestemtImServiceTest :
         }
     })
 
+private fun ArbeidsforholdType.skalHaArbeidsforhold(): Boolean =
+    when (this) {
+        is ArbeidsforholdType.MedArbeidsforhold, is ArbeidsforholdType.Behandlingsdager -> true
+        is ArbeidsforholdType.UtenArbeidsforhold, is ArbeidsforholdType.Fisker -> false
+    }
+
 private fun Map<Key, JsonElement>.lesInntektsmelding(): Inntektsmelding {
     val data = this[Key.DATA].shouldNotBeNull().toMap()
     return Key.SELVBESTEMT_INNTEKTSMELDING.lesOrNull(Inntektsmelding.serializer(), data).shouldNotBeNull()
@@ -485,6 +495,7 @@ private object Mock {
     val skjema =
         SkjemaInntektsmeldingSelvbestemt(
             selvbestemtId = UUID.randomUUID(),
+            arbeidsforholdType = ArbeidsforholdType.MedArbeidsforhold(vedtaksperiodeId = vedtaksperiodeId),
             sykmeldtFnr = sykmeldt.fnr,
             avsender =
                 SkjemaAvsender(
@@ -545,8 +556,6 @@ private object Mock {
                             ),
                         ),
                 ),
-            vedtaksperiodeId = vedtaksperiodeId,
-            arbeidsforholdType = ArbeidsforholdType.MedArbeidsforhold(vedtaksperiodeId = vedtaksperiodeId),
         )
 
     val inntektsmelding =
@@ -605,7 +614,7 @@ private object Mock {
             Key.SAK_ID to "folkelig-lurendreier-sak-id".toJson(),
         )
 
-    fun lagAnsettelsesperioder(orgnr: Orgnr) =
+    fun lagAnsettelsesperioder(orgnr: Orgnr): Map<Orgnr, Set<PeriodeAapen>> =
         mapOf(
             orgnr to
                 setOf(

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/SelvbestemtImUtilsTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/SelvbestemtImUtilsTest.kt
@@ -1,19 +1,38 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.selvbestemtlagreimservice
 
 import io.kotest.core.spec.style.FunSpec
+import io.kotest.datatest.withData
 import io.kotest.matchers.shouldBe
+import no.nav.hag.simba.utils.felles.test.mock.mockFlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
 import java.util.UUID
 
 class SelvbestemtImUtilsTest :
     FunSpec({
-        test("tilInntektsmeldingType mapper Skjema.ArbeidsforholdType til riktig Inntektsmelding.Type") {
+        test("ArbeidsforholdType.MedArbeidsforhold mappes til korrekt Inntektsmelding.Type") {
             val id = UUID.randomUUID()
+            val flereArbeidsforhold = mockFlereArbeidsforhold()
+            val medArbeidsforhold = ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID())
 
-            ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID()).tilInntektsmeldingType(id) shouldBe Inntektsmelding.Type.Selvbestemt(id)
-            ArbeidsforholdType.Fisker.tilInntektsmeldingType(id) shouldBe Inntektsmelding.Type.Fisker(id)
-            ArbeidsforholdType.UtenArbeidsforhold.tilInntektsmeldingType(id) shouldBe Inntektsmelding.Type.UtenArbeidsforhold(id)
-            ArbeidsforholdType.Behandlingsdager.tilInntektsmeldingType(id) shouldBe Inntektsmelding.Type.Behandlingsdager(id)
+            medArbeidsforhold.tilInntektsmeldingType(id, null) shouldBe Inntektsmelding.Type.Selvbestemt(id, null)
+            medArbeidsforhold.tilInntektsmeldingType(id, flereArbeidsforhold) shouldBe Inntektsmelding.Type.Selvbestemt(id, flereArbeidsforhold)
+        }
+
+        context("ArbeidsforholdType mappes til korrekt Inntektsmelding.Type") {
+            withData(
+                nameFn = { it.first::class.simpleName.orEmpty() },
+                listOf<Pair<ArbeidsforholdType, (UUID) -> Inntektsmelding.Type>>(
+                    ArbeidsforholdType.Behandlingsdager to { Inntektsmelding.Type.Behandlingsdager(it) },
+                    ArbeidsforholdType.Fisker to { Inntektsmelding.Type.Fisker(it) },
+                    ArbeidsforholdType.UtenArbeidsforhold to { Inntektsmelding.Type.UtenArbeidsforhold(it) },
+                ),
+            ) { (arbeidsforholdType, imTypeMedId) ->
+                val id = UUID.randomUUID()
+                arbeidsforholdType.tilInntektsmeldingType(id, null) shouldBe imTypeMedId(id)
+
+                // Flere arbeidsforhold skal ignoreres for arbeidsforholdstyper utenom 'MedArbeidsforhold'
+                arbeidsforholdType.tilInntektsmeldingType(id, mockFlereArbeidsforhold()) shouldBe imTypeMedId(id)
+            }
         }
     })

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.3.20
 kotlinterVersion=5.4.2
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.9.0
+hagDomeneInntektsmeldingVersion=0.10.0
 junitJupiterVersion=6.0.3
 kotestVersion=6.1.11
 kotlinxCoroutinesVersion=1.10.2

--- a/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
+++ b/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
@@ -1,6 +1,7 @@
 package no.nav.hag.simba.utils.felles.test.mock
 
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
@@ -14,6 +15,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
@@ -39,6 +41,7 @@ fun mockSkjemaInntektsmelding(): SkjemaInntektsmelding {
         inntekt = inntektsmelding.inntekt,
         naturalytelser = inntektsmelding.naturalytelser,
         refusjon = inntektsmelding.refusjon,
+        flereArbeidsforhold = mockFlereArbeidsforhold(),
     )
 }
 
@@ -64,6 +67,10 @@ fun mockSkjemaInntektsmeldingSelvbestemt(): SkjemaInntektsmeldingSelvbestemt {
     val vedtaksperiodeId = UUID.randomUUID()
     return SkjemaInntektsmeldingSelvbestemt(
         selvbestemtId = UUID.randomUUID(),
+        arbeidsforholdType =
+            ArbeidsforholdType.MedArbeidsforhold(
+                vedtaksperiodeId = vedtaksperiodeId,
+            ),
         sykmeldtFnr = inntektsmelding.sykmeldt.fnr,
         avsender =
             SkjemaAvsender(
@@ -75,11 +82,7 @@ fun mockSkjemaInntektsmeldingSelvbestemt(): SkjemaInntektsmeldingSelvbestemt {
         inntekt = inntektsmelding.inntekt!!,
         naturalytelser = inntektsmelding.naturalytelser,
         refusjon = inntektsmelding.refusjon,
-        vedtaksperiodeId = vedtaksperiodeId,
-        arbeidsforholdType =
-            ArbeidsforholdType.MedArbeidsforhold(
-                vedtaksperiodeId = vedtaksperiodeId,
-            ),
+        flereArbeidsforhold = mockFlereArbeidsforhold(),
     )
 }
 
@@ -89,6 +92,8 @@ fun mockInntektsmeldingV1(): Inntektsmelding =
         type =
             Inntektsmelding.Type.Forespurt(
                 id = UUID.randomUUID(),
+                erAgpForespurt = true,
+                flereArbeidsforhold = mockFlereArbeidsforhold(),
             ),
         sykmeldt =
             Sykmeldt(
@@ -134,7 +139,7 @@ fun mockArbeidsgiverperiode(): Arbeidsgiverperiode =
 
 fun mockInntekt(): Inntekt =
     Inntekt(
-        beloep = 544.6,
+        beloep = 1544.6,
         inntektsdato = 28.september,
         endringAarsaker =
             listOf(
@@ -187,4 +192,25 @@ fun mockAvsenderSystem(): AvsenderSystem =
         orgnr = Orgnr.genererGyldig(),
         navn = "Slapp Tiger",
         versjon = "8.8.8",
+    )
+
+fun mockFlereArbeidsforhold(): FlereArbeidsforhold =
+    FlereArbeidsforhold(
+        harLikLoenn = false,
+        erSykmeldtFraAlle = false,
+        arbeidsforhold =
+            listOf(
+                Arbeidsforhold(
+                    inkludertISykefravaer = true,
+                    yrkesbeskrivelse = "Mekker",
+                    stillingsprosent = 30.0,
+                    inntekt = 1000.0,
+                ),
+                Arbeidsforhold(
+                    inkludertISykefravaer = false,
+                    yrkesbeskrivelse = "Betjent",
+                    stillingsprosent = 60.0,
+                    inntekt = 544.6,
+                ),
+            ),
     )


### PR DESCRIPTION
Denne PR-en sender det nye feltet `flereArbeidsforhold` gjennom Simba. Det fører til at verdien blir lagret i vår database, men ikke journalført.