### PR TITLE
Bump avhengigheter

### DIFF
--- a/apps/api/build.gradle.kts
+++ b/apps/api/build.gradle.kts
@@ -10,11 +10,6 @@ tasks {
 }
 
 dependencies {
-    constraints {
-        // token-validation-ktor-v3 bruker (transitivt) 0.6.x av kotlinx-datetime, mens exposed bruker 0.7.x. Uten denne constrainten så får vi konflikt i integrasjonstestene.
-        implementation("org.jetbrains.kotlinx:kotlinx-datetime:0.7.1-0.6.x-compat")
-    }
-
     implementation(project(":kontrakt-domene-ansettelsesforhold"))
     implementation(project(":kontrakt-domene-arbeidsgiver"))
     implementation(project(":kontrakt-resultat-forespoersel"))

--- a/apps/api/gradle.properties
+++ b/apps/api/gradle.properties
@@ -1,3 +1,3 @@
 # Dependency versions
-mockOauth2ServerVersion=3.0.1
-tokenSupportVersion=6.0.5
+mockOauth2ServerVersion=4.0.0
+tokenSupportVersion=6.0.8

--- a/apps/bro-spinn/gradle.properties
+++ b/apps/bro-spinn/gradle.properties
@@ -1,2 +1,2 @@
-jacksonVersion=3.1.2
+jacksonVersion=3.1.4
 spinnInntektsmeldingKontraktVersion=2026.04.15-10-22-eb2ae

--- a/apps/feil-behandler/gradle.properties
+++ b/apps/feil-behandler/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
 bakgrunnsjobbVersion=1.0.4
-flywayVersion=12.4.0
+flywayVersion=12.7.0
 hikariVersion=7.0.2
-postgresqlVersion=42.7.10
+postgresqlVersion=42.7.11
 testcontainersVersion=2.0.5

--- a/apps/integrasjonstest/gradle.properties
+++ b/apps/integrasjonstest/gradle.properties
@@ -1,4 +1,4 @@
 # Dependency versions
-lettuceVersion=7.5.1.RELEASE
+lettuceVersion=7.6.0.RELEASE
 testcontainersRedisVersion=2.2.4
 testcontainersVersion=2.0.5

--- a/apps/joark/gradle.properties
+++ b/apps/joark/gradle.properties
@@ -1,6 +1,6 @@
 dokarkivKlientVersion=0.5.4
-hagImXmlKontraktVersion=1.0.9
-jacksonVersion=3.1.2
+hagImXmlKontraktVersion=1.0.10
+jacksonVersion=3.1.4
 jaxbApiVersion=4.0.5
-jaxbRuntimeVersion=4.0.7
+jaxbRuntimeVersion=4.0.9
 pdfboxVersion=2.0.27

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,14 +101,8 @@ subprojects {
     dependencies {
         // Sjekk om disse er nødvendige ved oppgradering av pakker
         constraints {
-            implementation("commons-beanutils:commons-beanutils:1.11.0") {
-                because("helsearbeidsgiver-kontrakt-inntektsmelding")
-            }
             implementation("io.ktor:ktor-client-core-jvm:2.3.13") {
                 because("hag-bakgrunnsjobb")
-            }
-            implementation("org.apache.commons:commons-lang3:3.18.0") {
-                because("helsearbeidsgiver-kontrakt-inntektsmelding")
             }
         }
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=2.3.21
+kotlinVersion=2.4.0
 kotlinterVersion=5.5.0
 
 # Dependency versions

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,15 +1,16 @@
 kotlin.code.style=official
 
 # Plugin versions
-kotlinVersion=2.3.20
-kotlinterVersion=5.4.2
+kotlinVersion=2.3.21
+kotlinterVersion=5.5.0
 
 # Dependency versions
 hagDomeneInntektsmeldingVersion=0.9.0
-junitJupiterVersion=6.0.3
+junitJupiterVersion=6.1.0
 kotestVersion=6.1.11
-kotlinxCoroutinesVersion=1.10.2
+kotlinxCoroutinesVersion=1.11.0
 kotlinxSerializationVersion=1.11.0
-ktorVersion=3.4.2
-mockkVersion=1.14.9
+# Unngå ktor 3.5.0. Se https://github.com/ktorio/ktor/issues/5651 for forklaring. Forhåpentligvis løst i 3.5.1.
+ktorVersion=3.4.3
+mockkVersion=1.14.11
 utilsVersion=0.10.2

--- a/utils/db-exposed/gradle.properties
+++ b/utils/db-exposed/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
-exposedVersion=1.2.0
-flywayVersion=12.4.0
+exposedVersion=1.3.0
+flywayVersion=12.7.0
 hikariVersion=7.0.2
-postgresqlVersion=42.7.10
+postgresqlVersion=42.7.11
 testcontainersVersion=2.0.5

--- a/utils/kafka/gradle.properties
+++ b/utils/kafka/gradle.properties
@@ -1,2 +1,2 @@
 # Dependency versions
-kafkaClientVersion=4.2.0
+kafkaClientVersion=4.3.0

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,4 +1,4 @@
 # Dependency versions
-micrometerVersion=1.16.4
-rapidsAndRiversVersion=2026043009341777534451
-slf4jVersion=2.0.17
+micrometerVersion=1.16.5
+rapidsAndRiversVersion=2026051812441779101082
+slf4jVersion=2.0.18

--- a/utils/valkey/gradle.properties
+++ b/utils/valkey/gradle.properties
@@ -1,2 +1,2 @@
 # Dependency versions
-lettuceVersion=7.5.1.RELEASE
+lettuceVersion=7.6.0.RELEASE


### PR DESCRIPTION
Bumper avhengigheter, som inkluderer bumpene fra https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/1045. Den PR-en ble rullet tilbake pga. en bug i ktor 3.5.0.

Bumpene vil fjerne mange sårbarheter.