### PR TITLE
øker minne for im-altinn pga OOM

### DIFF
--- a/config/altinn/dev-gcp.yml
+++ b/config/altinn/dev-gcp.yml
@@ -1,6 +1,8 @@
 kafkaPool: nav-dev
 replicasMax: 5
 entraIdEnabled: true
+requestMem: 1024Mi
+limitMem: 2048Mi
 apps:
   - name: arbeidsgiver-altinn-tilganger
     namespace: fager

--- a/config/altinn/prod-gcp.yml
+++ b/config/altinn/prod-gcp.yml
@@ -1,6 +1,9 @@
 kafkaPool: nav-prod
 replicasMax: 5
 entraIdEnabled: true
+requestMem: 2048Mi
+limitMem: 4096Mi
+
 apps:
   - name: arbeidsgiver-altinn-tilganger
     namespace: fager

--- a/config/nais.yml
+++ b/config/nais.yml
@@ -19,9 +19,9 @@ spec:
   resources:
     requests:
       cpu: 50m
-      memory: 768Mi
+      memory: {{#if requestMem}}{{ requestMem }}{{else}}768Mi{{/if}}
     limits:
-      memory: 1536Mi
+      memory: {{#if limitMem}}{{ limitMem }}{{else}}1536Mi{{/if}}
   replicas:
     min: 2
     max: {{#if replicasMax}}{{ replicasMax }}{{else}}2{{/if}}


### PR DESCRIPTION
Øker minne på im-altinn pga mistanke om store payloads (altinn-tilganger) 

OOMer ved serialisering, men problemet er også at vi bør klippe bort tilganger / hierarki som vi ikke trenger, og ikke putte hele tilgangsobjektet rett i cache.

Men innfører dette som kjapp workaround først, før vi endrer kode. 