### PR TITLE
Flere arbeidsforhold: Fjern støtte for endringer

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -25,7 +25,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.InntektEndringAarsak
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
@@ -44,6 +43,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse
@@ -56,7 +56,6 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.json.removeJsonWhitespace
 import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import java.time.LocalDate
 import java.util.UUID
 
 private val pathMedId =
@@ -392,18 +391,7 @@ private fun FlereArbeidsforhold.hardcodedJson(): String =
     {
         "harLikLoenn": $harLikLoenn,
         "erSykmeldtFraAlle": $erSykmeldtFraAlle,
-        "arbeidsforholdPerSykmeldingStartdato": ${arbeidsforholdPerSykmeldingStartdato.hardcodedJson()}
-    }
-    """
-
-private fun Map<LocalDate, List<Arbeidsforhold>>.hardcodedJson(): String =
-    """
-    {
-    ${entries.joinToString { (startdato, arbeidsforhold) ->
-        """
-        "$startdato": [${arbeidsforhold.joinToString(transform = Arbeidsforhold::hardcodedJson)}]
-        """
-    }}
+        "arbeidsforhold": [${arbeidsforhold.joinToString(transform = Arbeidsforhold::hardcodedJson)}]
     }
     """
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
@@ -8,12 +8,11 @@ import no.nav.hag.simba.utils.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
-import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.november
 
@@ -101,16 +100,13 @@ private val nyFlereArbeidsforhold =
     FlereArbeidsforhold(
         harLikLoenn = true,
         erSykmeldtFraAlle = true,
-        arbeidsforholdPerSykmeldingStartdato =
-            mapOf(
-                14.april to
-                    listOf(
-                        Arbeidsforhold(
-                            inkludertISykefravaer = false,
-                            yrkesbeskrivelse = "Lokomotivfører",
-                            stillingsprosent = 100.0,
-                            inntekt = 815.0,
-                        ),
-                    ),
+        arbeidsforhold =
+            listOf(
+                Arbeidsforhold(
+                    inkludertISykefravaer = false,
+                    yrkesbeskrivelse = "Lokomotivfører",
+                    stillingsprosent = 100.0,
+                    inntekt = 815.0,
+                ),
             ),
     )

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -24,10 +24,10 @@ import no.nav.hag.simba.utils.rr.service.ServiceMed3Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -41,7 +41,6 @@ import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -49,6 +48,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
@@ -90,7 +90,7 @@ class LagreSelvbestemtImServiceTest :
         context("Inntektsmeldinger AarsakInnsending.Ny lagres og sak opprettes") {
             withData(
                 nameFn = {
-                    "skjema med ${ArbeidsforholdType::class.simpleName}.${it.first::class.simpleName} og ${FlereArbeidsforhold::class.simpleName} (antall datoer ${it.second?.arbeidsforholdPerSykmeldingStartdato.orEmpty().size})"
+                    "skjema med ${ArbeidsforholdType::class.simpleName}.${it.first::class.simpleName} og ${FlereArbeidsforhold::class.simpleName} (antall ${it.second?.arbeidsforhold.orEmpty().size})"
                 },
                 ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID()) to null,
                 ArbeidsforholdType.MedArbeidsforhold(UUID.randomUUID()) to mockFlereArbeidsforhold(),

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.4.0
 kotlinterVersion=5.5.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.10.1
+hagDomeneInntektsmeldingVersion=0.10.0
 junitJupiterVersion=6.1.0
 kotestVersion=6.1.11
 kotlinxCoroutinesVersion=1.11.0

--- a/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
+++ b/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
@@ -4,7 +4,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -16,14 +15,13 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
-import no.nav.helsearbeidsgiver.utils.test.date.juni
 import no.nav.helsearbeidsgiver.utils.test.date.kl
-import no.nav.helsearbeidsgiver.utils.test.date.mai
 import no.nav.helsearbeidsgiver.utils.test.date.mars
 import no.nav.helsearbeidsgiver.utils.test.date.november
 import no.nav.helsearbeidsgiver.utils.test.date.oktober
@@ -200,37 +198,19 @@ fun mockFlereArbeidsforhold(): FlereArbeidsforhold =
     FlereArbeidsforhold(
         harLikLoenn = false,
         erSykmeldtFraAlle = false,
-        arbeidsforholdPerSykmeldingStartdato =
-            mapOf(
-                17.mai to
-                    listOf(
-                        Arbeidsforhold(
-                            inkludertISykefravaer = true,
-                            yrkesbeskrivelse = "Mekker",
-                            stillingsprosent = 30.0,
-                            inntekt = 1000.0,
-                        ),
-                        Arbeidsforhold(
-                            inkludertISykefravaer = false,
-                            yrkesbeskrivelse = "Betjent",
-                            stillingsprosent = 60.0,
-                            inntekt = 544.6,
-                        ),
-                    ),
-                5.juni to
-                    listOf(
-                        Arbeidsforhold(
-                            inkludertISykefravaer = true,
-                            yrkesbeskrivelse = "Mekker",
-                            stillingsprosent = 50.0,
-                            inntekt = 1200.0,
-                        ),
-                        Arbeidsforhold(
-                            inkludertISykefravaer = false,
-                            yrkesbeskrivelse = "Betjent",
-                            stillingsprosent = 20.0,
-                            inntekt = 344.6,
-                        ),
-                    ),
+        arbeidsforhold =
+            listOf(
+                Arbeidsforhold(
+                    inkludertISykefravaer = true,
+                    yrkesbeskrivelse = "Mekker",
+                    stillingsprosent = 30.0,
+                    inntekt = 1000.0,
+                ),
+                Arbeidsforhold(
+                    inkludertISykefravaer = false,
+                    yrkesbeskrivelse = "Betjent",
+                    stillingsprosent = 60.0,
+                    inntekt = 544.6,
+                ),
             ),
     )


### PR DESCRIPTION
Reverter https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/1048.

Etter en diskusjon med SAS-gjengen så kom vi frem til at vi ikke trenger å ha med endringer for flere arbeidsforhold.