### PR TITLE
Fiks lesing av deploy-argumenter

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -167,9 +167,9 @@ fun getBuildableProjects(): List<String> {
     val testfilRegex = Regex("^(?:apps|kontrakt|utils)/[\\w-]+/src/test(?:Fixtures)?.+")
 
     val changedFiles =
-        providers
-            .gradleProperty("changedFiles")
-            .orNull
+        project
+            .property("changedFiles")
+            ?.toString()
             ?.takeIf(String::isNotBlank)
             ?.split(",")
             ?.filterNot(testfilRegex::matches)
@@ -207,7 +207,7 @@ fun getBuildableProjects(): List<String> {
 }
 
 fun deployMatrix() {
-    val cluster = "${providers.gradleProperty("clusterEnv")}-gcp"
+    val cluster = "${project.property("clusterEnv")}-gcp"
 
     val deployableProjects =
         getBuildableProjects()


### PR DESCRIPTION
Fikser bug introdusert i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/1055.

Kort fortalt så fikk vi ikke strengen vi forventet når `toString` ble kalt på `providers.gradleProperty("clusterEnv")`.
`changedFiles` ble lest korrekt, men endrer til å lese på samme måte som `clusterEnv` for å gjøre koden mer enhetlig.

Konsekvensen av bugen er at ingenting har blitt deployet til dev eller prod siden den ble introdusert, selv ved release. Vi har dog ikke prøvd å deploye noe av betydning. 