### PR TITLE
Bump avhengigheter

### DIFF
--- a/apps/api/gradle.properties
+++ b/apps/api/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
 logbackEncoderVersion=9.0
-logbackVersion=1.5.34
-mockOauth2ServerVersion=4.0.0
+logbackVersion=1.5.37
+mockOauth2ServerVersion=5.0.1
 slf4jVersion=2.0.18
-tokenSupportVersion=6.0.8
+tokenSupportVersion=6.0.11

--- a/apps/feil-behandler/gradle.properties
+++ b/apps/feil-behandler/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
 bakgrunnsjobbVersion=1.0.4
-flywayVersion=12.7.0
-hikariVersion=7.0.2
+flywayVersion=12.9.0
+hikariVersion=7.1.0
 postgresqlVersion=42.7.11
 testcontainersVersion=2.0.5

--- a/apps/joark/gradle.properties
+++ b/apps/joark/gradle.properties
@@ -1,6 +1,6 @@
 dokarkivKlientVersion=0.5.4
 hagImXmlKontraktVersion=1.0.10
-jacksonVersion=3.1.4
+jacksonVersion=3.2.0
 jaxbApiVersion=4.0.5
 jaxbRuntimeVersion=4.0.9
-pdfboxVersion=2.0.27
+pdfboxVersion=2.0.36

--- a/gradle.properties
+++ b/gradle.properties
@@ -7,10 +7,9 @@ kotlinterVersion=5.5.0
 # Dependency versions
 hagDomeneInntektsmeldingVersion=0.10.0
 junitJupiterVersion=6.1.0
-kotestVersion=6.1.11
+kotestVersion=6.2.1
 kotlinxCoroutinesVersion=1.11.0
 kotlinxSerializationVersion=1.11.0
-# Unngå ktor 3.5.0. Se https://github.com/ktorio/ktor/issues/5651 for forklaring. Forhåpentligvis løst i 3.5.1.
-ktorVersion=3.4.3
+ktorVersion=3.5.1
 mockkVersion=1.14.11
 utilsVersion=0.10.2

--- a/utils/db-exposed/gradle.properties
+++ b/utils/db-exposed/gradle.properties
@@ -1,6 +1,6 @@
 # Dependency versions
 exposedVersion=1.3.0
-flywayVersion=12.7.0
-hikariVersion=7.0.2
+flywayVersion=12.9.0
+hikariVersion=7.1.0
 postgresqlVersion=42.7.11
 testcontainersVersion=2.0.5

--- a/utils/kafka/gradle.properties
+++ b/utils/kafka/gradle.properties
@@ -1,2 +1,2 @@
 # Dependency versions
-kafkaClientVersion=4.3.0
+kafkaClientVersion=4.3.1

--- a/utils/rapids-and-rivers/gradle.properties
+++ b/utils/rapids-and-rivers/gradle.properties
@@ -1,3 +1,3 @@
 # Dependency versions
-micrometerVersion=1.16.5
+micrometerVersion=1.17.0
 rapidsAndRiversVersion=2026051812441779101082


### PR DESCRIPTION
Bumper oss forbi Ktor 3.5.0, som har en [bug](https://nav-it.slack.com/archives/C60FFACN5/p1779554617643229). Vi opplevde denne bugen da vi bumpet i https://github.com/navikt/helsearbeidsgiver-inntektsmelding/pull/1045.