### PR TITLE
Ikke-forespurt AGP: Hensynta egenmeldinger

### DIFF
--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -25,6 +25,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Feilregistrert
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferie
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.InntektEndringAarsak
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
@@ -43,7 +44,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingUtilsKtTest.kt
@@ -8,10 +8,10 @@ import no.nav.hag.simba.utils.felles.test.mock.randomDigitString
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Bonus
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.november

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -136,7 +136,11 @@ class InnsendingService(
 
         val agp = steg0.skjema.agp
         if (agp == null ||
-            agp.erGyldigHvisIkkeForespurt(steg1.forespoersel.forespurtData.arbeidsgiverperiode.paakrevd, steg1.forespoersel.sykmeldingsperioder)
+            agp.erGyldigHvisIkkeForespurt(
+                erAgpForespurt = steg1.forespoersel.forespurtData.arbeidsgiverperiode.paakrevd,
+                egenmeldingsperioder = steg1.forespoersel.egenmeldingsperioder,
+                sykmeldingsperioder = steg1.forespoersel.sykmeldingsperioder,
+            )
         ) {
             publisher
                 .publish(

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
@@ -24,6 +24,7 @@ import no.nav.hag.simba.utils.felles.json.personMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
+import no.nav.hag.simba.utils.felles.test.json.lesEventName
 import no.nav.hag.simba.utils.felles.test.json.plusData
 import no.nav.hag.simba.utils.felles.test.mock.mockFail
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
@@ -107,24 +108,59 @@ class InnsendingServiceTest :
             }
         }
 
+        test("godtar inntektsmeldingskjema dersom ikke-forespurt AGP er gyldig") {
+            val kontekstId = UUID.randomUUID()
+            val forespoersel = mockForespoersel().utenPaakrevdAGP()
+            val skjemaMedGyldigAgp =
+                mockSkjemaInntektsmelding().copy(
+                    agp =
+                        Mock.agpFraFoersteFom(forespoersel).let { agp ->
+                            agp.copy(
+                                perioder =
+                                    agp.perioder.map {
+                                        Periode(
+                                            fom = it.fom.plusDays(1),
+                                            tom = it.tom.plusDays(1),
+                                        )
+                                    },
+                            )
+                        },
+                )
+
+            testRapid.sendJson(
+                Mock.steg2(kontekstId, skjemaMedGyldigAgp).plusData(
+                    Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
+                ),
+            )
+
+            testRapid.inspektør.size shouldBeExactly 1
+            testRapid.message(0).lesBehov() shouldBe BehovType.LAGRE_IM_SKJEMA
+
+            testRapid.sendJson(
+                Mock.steg3(kontekstId, skjemaMedGyldigAgp).plusData(
+                    Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
+                ),
+            )
+
+            testRapid.inspektør.size shouldBeExactly 2
+            testRapid.message(1).lesEventName() shouldBe EventName.INNTEKTSMELDING_SKJEMA_LAGRET
+
+            verifySequence {
+                mockRedisStore.skrivResultat(
+                    kontekstId,
+                    ResultJson(
+                        success = skjemaMedGyldigAgp.forespoerselId.toJson(),
+                    ),
+                )
+            }
+        }
+
         test("avviser inntektsmeldingskjema dersom ikke-forespurt AGP er ugyldig") {
             val kontekstId = UUID.randomUUID()
             val forespoersel = mockForespoersel().utenPaakrevdAGP()
             val skjemaMedUgyldigAgp =
                 mockSkjemaInntektsmelding().copy(
-                    agp =
-                        forespoersel.sykmeldingsperioder.minOf { it.fom }.let {
-                            Arbeidsgiverperiode(
-                                perioder =
-                                    listOf(
-                                        Periode(
-                                            fom = it,
-                                            tom = it.plusDays(15),
-                                        ),
-                                    ),
-                                redusertLoennIAgp = null,
-                            )
-                        },
+                    agp = Mock.agpFraFoersteFom(forespoersel),
                 )
 
             testRapid.sendJson(
@@ -214,6 +250,22 @@ private object Mock {
             fnr = Fnr.genererGyldig(),
             navn = "Skrue McDuck",
         )
+
+    fun agpFraFoersteFom(forespoersel: Forespoersel): Arbeidsgiverperiode =
+        (forespoersel.egenmeldingsperioder + forespoersel.sykmeldingsperioder)
+            .minOf { it.fom }
+            .let {
+                Arbeidsgiverperiode(
+                    perioder =
+                        listOf(
+                            Periode(
+                                fom = it,
+                                tom = it.plusDays(15),
+                            ),
+                        ),
+                    redusertLoennIAgp = null,
+                )
+            }
 
     fun steg0(
         kontekstId: UUID,

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -24,10 +24,10 @@ import no.nav.hag.simba.utils.rr.service.ServiceMed3Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -41,6 +41,7 @@ import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Ferietrekk
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -48,7 +49,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RedusertLoennIAgp
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Refusjon
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.RefusjonEndring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.4.0
 kotlinterVersion=5.5.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.10.0
+hagDomeneInntektsmeldingVersion=0.10.2
 junitJupiterVersion=6.1.0
 kotestVersion=6.2.1
 kotlinxCoroutinesVersion=1.11.0

--- a/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
+++ b/utils/felles/src/testFixtures/kotlin/no/nav/hag/simba/utils/felles/test/mock/MockInntektsmelding.kt
@@ -4,6 +4,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntekt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Naturalytelse
@@ -15,7 +16,6 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykmeldt
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.AvsenderSystem
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.api.Innsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.ArbeidsforholdType
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.FlereArbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaAvsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt


### PR DESCRIPTION
**Problem:**
Sykmeldte kan rapportere ugyldige egenmeldinger i sykmeldingen, uten mulighet til å rette opp. Slike egenmeldinger kan dele et reelt langt gap opp i to korte gap. Da ber vi ikke om AGP, og får ikke AG overstyrt de ugyldige egenmeldingene.

**Løsning:**
Tillat AG å sende ikke-forespurt AGP dersom AGP ikke inkluderer en eller flere av de rapporterte egenmeldingsdagene (i starten av perioden).