### PR TITLE
duplikat IM fra API: svar tilbake med avvistInntektsmelding-melding

### DIFF
--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingService.kt
@@ -3,6 +3,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.innsending.ekstern
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
+import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.toJson
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
@@ -23,6 +24,8 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.time.LocalDateTime
 import java.util.UUID
+import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.EventName as InnsendingEventName
+import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.Key as InnsendingKey
 
 data class Steg0(
     val kontekstId: UUID,
@@ -109,6 +112,25 @@ class ApiInnsendingService(
                 logger.info("Publiserte melding.")
                 sikkerLogger.info("Publiserte melding:\n${publisert.toPretty()}")
             }
+        } else {
+            val avvistInntektsmelding =
+                AvvistInntektsmelding(
+                    inntektsmeldingId = steg0.innsending.innsendingId,
+                    forespoerselId = steg0.innsending.type.id,
+                    vedtaksperiodeId = steg0.forespoersel.vedtaksperiodeId,
+                    orgnr = steg0.forespoersel.orgnr,
+                    feil = Feil(Feilkode.DUPLIKAT, "Duplikat"),
+                )
+            publisher.publish(
+                steg0.innsending.skjema.forespoerselId,
+                Key.EVENT_NAME to InnsendingEventName.AVVIST_INNTEKTSMELDING.toJson(),
+                Key.KONTEKST_ID to steg0.kontekstId.toJson(),
+                Key.DATA to
+                    mapOf(
+                        InnsendingKey.AVVIST_INNTEKTSMELDING to avvistInntektsmelding.toJson(AvvistInntektsmelding.serializer()),
+                    ).toJson(),
+            )
+            logger.info("Publiserte melding om avvist inntektsmelding (duplikat) med id ${avvistInntektsmelding.inntektsmeldingId}.")
         }
     }
 

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/AvvistInntektsmelding.kt
@@ -19,6 +19,7 @@ data class AvvistInntektsmelding(
 
 enum class Feilkode {
     INNTEKT_AVVIKER_FRA_A_ORDNINGEN,
+    DUPLIKAT, // Støttes ikke i API ut til klienter out of the box..
 }
 
 @Serializable

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingServiceTest.kt
@@ -8,6 +8,7 @@ import io.mockk.clearAllMocks
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
+// import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.toJson
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
@@ -84,7 +85,11 @@ class ApiInnsendingServiceTest :
                 ),
             )
 
-            testRapid.inspektør.size shouldBeExactly 1
+            testRapid.inspektør.size shouldBeExactly 2
+//   TODO - feiler just nu - sikkert pga serialize av Key.EVENT_NAME vs InnsendingEventName
+//            testRapid.message(1).toMap().also {
+//                Key.EVENT_NAME.lesOrNull(EventName.serializer(), it) shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING
+//            }
         }
 
         test("svar med feilmelding ved feil") {

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/ekstern/ApiInnsendingServiceTest.kt
@@ -8,7 +8,6 @@ import io.mockk.clearAllMocks
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
-// import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.toJson
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
@@ -30,6 +29,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.august
 import no.nav.helsearbeidsgiver.utils.test.date.kl
 import java.util.UUID
+import no.nav.hag.simba.kontrakt.kafkatopic.innsending.Innsending.EventName as InnsendingEventName
 
 class ApiInnsendingServiceTest :
     FunSpec({
@@ -86,10 +86,9 @@ class ApiInnsendingServiceTest :
             )
 
             testRapid.inspektør.size shouldBeExactly 2
-//   TODO - feiler just nu - sikkert pga serialize av Key.EVENT_NAME vs InnsendingEventName
-//            testRapid.message(1).toMap().also {
-//                Key.EVENT_NAME.lesOrNull(EventName.serializer(), it) shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING
-//            }
+            testRapid.message(1).toMap().also {
+                Key.EVENT_NAME.lesOrNull(InnsendingEventName.serializer(), it) shouldBe InnsendingEventName.AVVIST_INNTEKTSMELDING
+            }
         }
 
         test("svar med feilmelding ved feil") {


### PR DESCRIPTION
IMer som stoppes i duplikatkontroll i Simba, har tidligere bare stoppet opp der, det ble ikke sendt noe svar tilbake til API.
Så da blir IM i API liggende med status MOTTATT, og går ikke til endelig state AVVIST. 

Løsning: send avvist-melding der vi støter på duplikater. 