### PR TITLE
Legg til reserveløsning for IM-er som mangler i databasen

### DIFF
--- a/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
+++ b/apps/aktiveorgnrservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrService.kt
@@ -8,7 +8,6 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.ansettelsesperioderSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.orgMapSerializer
@@ -20,6 +19,7 @@ import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.Service
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.set
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/aktiveorgnrservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrServiceTest.kt
+++ b/apps/aktiveorgnrservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/aktiveorgnrservice/AktiveOrgnrServiceTest.kt
@@ -15,7 +15,6 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.ansettelsesperioderSerializer
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
@@ -30,6 +29,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.mars

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPoller.kt
@@ -1,8 +1,8 @@
 package no.nav.helsearbeidsgiver.inntektsmelding.api
 
 import kotlinx.coroutines.delay
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import java.util.UUID

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -5,13 +5,13 @@ import io.ktor.server.routing.get
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
 import no.nav.hag.simba.utils.valkey.RedisPrefix
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -66,7 +66,7 @@ fun Route.kvittering(
                             respondOk(eksternResponse, KvitteringResponse.serializer())
                         }
 
-                        null -> {
+                        is LagretInntektsmelding.IkkeFunnet -> {
                             respondError(ErrorResponse.NotFound(kontekstId, "Kvittering ikke funnet for forespørsel-ID '$forespoerselId'."))
                         }
                     }

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/RedisPollerTest.kt
@@ -6,8 +6,8 @@ import io.kotest.matchers.shouldBe
 import io.mockk.clearAllMocks
 import io.mockk.every
 import io.mockk.mockk
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID
 

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRouteKtTest.kt
@@ -14,8 +14,8 @@ import no.nav.hag.simba.kontrakt.domene.arbeidsgiver.AktiveArbeidsgivere
 import no.nav.hag.simba.kontrakt.domene.arbeidsgiver.AktiveArbeidsgivere.Arbeidsgiver
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforhold/HentArbeidsforholdRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforhold/HentArbeidsforholdRouteKtTest.kt
@@ -14,8 +14,8 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.Ansettelsesforhold
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforholdselvbestemt/HentArbeidsforholdSelvbestemtRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforholdselvbestemt/HentArbeidsforholdSelvbestemtRouteKtTest.kt
@@ -14,8 +14,8 @@ import kotlinx.serialization.json.jsonObject
 import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.Ansettelsesforhold
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRouteKtTest.kt
@@ -17,9 +17,9 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespurtData
 import no.nav.hag.simba.kontrakt.resultat.forespoersel.HentForespoerselResultat
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.gjennomsnitt
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRouteKtTest.kt
@@ -18,8 +18,8 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRouteKtTest.kt
@@ -14,10 +14,10 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.mock.mockFlereArbeidsforhold
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsforhold
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
@@ -14,11 +14,11 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.json.minusData
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRouteKtTest.kt
@@ -11,10 +11,10 @@ import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.gjennomsnitt
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRouteKtTest.kt
@@ -13,10 +13,10 @@ import io.mockk.verifySequence
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.gjennomsnitt
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.response.ErrorResponse

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRouteKtTest.kt
@@ -13,9 +13,9 @@ import no.nav.hag.simba.kontrakt.domene.inntektsmelding.LagretInntektsmelding
 import no.nav.hag.simba.kontrakt.resultat.kvittering.KvitteringResultat
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.ApiTest

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/lagreselvbestemtim/LagreSelvbestemtImRouteKtTest.kt
@@ -15,12 +15,12 @@ import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.json.minusData
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmeldingSelvbestemt
 import no.nav.hag.simba.utils.felles.test.mock.randomDigitString
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmeldingSelvbestemt
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/utils/TestUtils.kt
@@ -16,8 +16,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import kotlinx.serialization.KSerializer
 import no.nav.hag.simba.kontrakt.resultat.tilgang.Tilgang
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.kafka.Producer
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.api.RedisPoller
 import no.nav.helsearbeidsgiver.inntektsmelding.api.apiModule
 import no.nav.helsearbeidsgiver.utils.json.jsonConfig

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepository.kt
@@ -7,6 +7,7 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsm
 import no.nav.helsearbeidsgiver.inntektsmelding.db.tabell.InntektsmeldingEntitet
 import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
+import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 import org.jetbrains.exposed.v1.core.SortOrder
 import org.jetbrains.exposed.v1.core.and
 import org.jetbrains.exposed.v1.core.eq
@@ -26,27 +27,7 @@ class InntektsmeldingRepository(
     private val logger = logger()
     private val sikkerLogger = sikkerLogger()
 
-    fun hentInntektsmelding(inntektsmeldingId: UUID): LagretInntektsmelding? =
-        transaction(db) {
-            InntektsmeldingEntitet
-                .select(
-                    InntektsmeldingEntitet.skjema,
-                    InntektsmeldingEntitet.eksternInntektsmelding,
-                    InntektsmeldingEntitet.innsendt,
-                    InntektsmeldingEntitet.avsenderNavn,
-                ).where { InntektsmeldingEntitet.inntektsmeldingId eq inntektsmeldingId }
-                .map {
-                    InntektsmeldingResult(
-                        it[InntektsmeldingEntitet.skjema],
-                        it[InntektsmeldingEntitet.eksternInntektsmelding],
-                        it[InntektsmeldingEntitet.innsendt],
-                        it[InntektsmeldingEntitet.avsenderNavn],
-                    )
-                }
-        }.firstOrNull()
-            ?.tilLagretInntektsmelding()
-
-    fun hentNyesteInntektsmelding(forespoerselId: UUID): LagretInntektsmelding? =
+    fun hentNyesteInntektsmelding(forespoerselId: UUID): LagretInntektsmelding =
         transaction(db) {
             InntektsmeldingEntitet
                 .select(
@@ -67,6 +48,7 @@ class InntektsmeldingRepository(
                 }
         }.firstOrNull()
             ?.tilLagretInntektsmelding()
+            .orDefault(LagretInntektsmelding.IkkeFunnet)
 
     fun hentNyesteInntektsmeldingSkjema(forespoerselId: UUID): SkjemaInntektsmelding? =
         transaction(db) {

--- a/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
+++ b/apps/db/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiver.kt
@@ -7,7 +7,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.krev
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -68,10 +67,7 @@ class HentLagretImRiver(
             Key.DATA to
                 data
                     .plus(
-                        Key.LAGRET_INNTEKTSMELDING to
-                            ResultJson(
-                                success = lagret?.toJson(LagretInntektsmelding.serializer()),
-                            ).toJson(),
+                        Key.LAGRET_INNTEKTSMELDING to lagret.toJson(LagretInntektsmelding.serializer()),
                     ).toJson(),
         )
     }
@@ -102,7 +98,7 @@ class HentLagretImRiver(
             Log.forespoerselId(forespoerselId),
         )
 
-    private fun loggHentet(lagret: LagretInntektsmelding?) {
+    private fun loggHentet(lagret: LagretInntektsmelding) {
         when (lagret) {
             is LagretInntektsmelding.Skjema -> {
                 logger.info("Fant lagret inntektsmeldingsskjema.")
@@ -114,7 +110,7 @@ class HentLagretImRiver(
                 sikkerLogger.info("Fant lagret ekstern inntektsmelding.\n${lagret.ekstern.toJson(EksternInntektsmelding.serializer()).toPretty()}")
             }
 
-            null -> {
+            is LagretInntektsmelding.IkkeFunnet -> {
                 "Fant _ikke_ lagret inntektsmeldingsskjema eller ekstern inntektsmelding.".also {
                     logger.info(it)
                     sikkerLogger.info(it)

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/InntektsmeldingRepositoryTest.kt
@@ -20,10 +20,7 @@ import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.desember
 import no.nav.helsearbeidsgiver.utils.test.date.januar
-import no.nav.helsearbeidsgiver.utils.test.date.juni
-import no.nav.helsearbeidsgiver.utils.test.date.mai
 import no.nav.helsearbeidsgiver.utils.test.date.mars
-import no.nav.helsearbeidsgiver.utils.test.date.september
 import org.jetbrains.exposed.v1.core.ResultRow
 import org.jetbrains.exposed.v1.core.eq
 import org.jetbrains.exposed.v1.exceptions.ExposedSQLException
@@ -53,69 +50,6 @@ class InntektsmeldingRepositoryTest :
 
         val inntektsmeldingRepo = InntektsmeldingRepository(db)
         val testRepo = TestRepo(db)
-
-        context(InntektsmeldingRepository::hentInntektsmelding.name) {
-            test("henter skjema med inntektsmelding-ID") {
-                val forespoerselId = UUID.randomUUID()
-                val inntektsmeldingId = UUID.randomUUID()
-                val mottatt = 20.september.atStartOfDay()
-
-                val a = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
-                val b = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(1))
-                val c = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
-                val d = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
-                val e = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(4))
-
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), a, AVSENDER_NAVN, mottatt)
-                inntektsmeldingRepo.lagreEksternInntektsmelding(UUID.randomUUID(), forespoerselId, b)
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(inntektsmeldingId, c, AVSENDER_NAVN, mottatt.plusHours(2))
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), d, AVSENDER_NAVN, mottatt.plusHours(3))
-                inntektsmeldingRepo.lagreEksternInntektsmelding(UUID.randomUUID(), forespoerselId, e)
-
-                val lagret = inntektsmeldingRepo.hentInntektsmelding(inntektsmeldingId)
-
-                lagret shouldBe
-                    LagretInntektsmelding.Skjema(
-                        avsenderNavn = AVSENDER_NAVN,
-                        skjema = c,
-                        mottatt = mottatt.plusHours(2),
-                    )
-            }
-
-            test("henter ekstern inntektsmelding med inntektsmelding-ID") {
-                val forespoerselId = UUID.randomUUID()
-                val inntektsmeldingId = UUID.randomUUID()
-                val mottatt = 3.mai.atStartOfDay()
-
-                val a = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
-                val b = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(1))
-                val c = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(2))
-                val d = mockSkjemaInntektsmelding().copy(forespoerselId = forespoerselId)
-                val e = mockEksternInntektsmelding().copy(tidspunkt = mottatt.plusHours(4))
-
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), a, AVSENDER_NAVN, mottatt)
-                inntektsmeldingRepo.lagreEksternInntektsmelding(UUID.randomUUID(), forespoerselId, b)
-                inntektsmeldingRepo.lagreEksternInntektsmelding(inntektsmeldingId, forespoerselId, c)
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), d, AVSENDER_NAVN, mottatt.plusHours(3))
-                inntektsmeldingRepo.lagreEksternInntektsmelding(UUID.randomUUID(), forespoerselId, e)
-
-                val lagret = inntektsmeldingRepo.hentInntektsmelding(inntektsmeldingId)
-
-                lagret shouldBe
-                    LagretInntektsmelding.Ekstern(
-                        ekstern = c,
-                    )
-            }
-
-            test("tåler at det er ingenting å hente med inntektsmelding-ID") {
-                inntektsmeldingRepo.lagreInntektsmeldingSkjema(UUID.randomUUID(), mockSkjemaInntektsmelding(), AVSENDER_NAVN, 16.juni.atStartOfDay())
-                inntektsmeldingRepo.lagreEksternInntektsmelding(UUID.randomUUID(), UUID.randomUUID(), mockEksternInntektsmelding())
-
-                val lagret = inntektsmeldingRepo.hentInntektsmelding(UUID.randomUUID())
-
-                lagret.shouldBeNull()
-            }
-        }
 
         context(InntektsmeldingRepository::hentNyesteInntektsmelding.name) {
 
@@ -191,7 +125,7 @@ class InntektsmeldingRepositoryTest :
 
                 val lagret = inntektsmeldingRepo.hentNyesteInntektsmelding(UUID.randomUUID())
 
-                lagret.shouldBeNull()
+                lagret shouldBe LagretInntektsmelding.IkkeFunnet
             }
         }
 

--- a/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
+++ b/apps/db/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/db/river/HentLagretImRiverTest.kt
@@ -16,7 +16,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.mock.mockFail
@@ -53,7 +52,7 @@ class HentLagretImRiverTest :
                     "kun skjema (med navn)" to LagretInntektsmelding.Skjema("Nifs Krumkake", mockSkjemaInntektsmelding(), 12.april.atStartOfDay()),
                     "kun skjema (uten navn)" to LagretInntektsmelding.Skjema(null, mockSkjemaInntektsmelding(), 12.april.atStartOfDay()),
                     "kun ekstern inntektsmelding" to LagretInntektsmelding.Ekstern(mockEksternInntektsmelding()),
-                    "ingen funnet" to null,
+                    "ingen funnet" to LagretInntektsmelding.IkkeFunnet,
                 ),
             ) { lagret ->
                 every { mockImRepo.hentNyesteInntektsmelding(any()) } returns lagret
@@ -73,10 +72,7 @@ class HentLagretImRiverTest :
                         Key.DATA to
                             innkommendeMelding.data
                                 .plus(
-                                    Key.LAGRET_INNTEKTSMELDING to
-                                        ResultJson(
-                                            success = lagret?.toJson(LagretInntektsmelding.serializer()),
-                                        ).toJson(),
+                                    Key.LAGRET_INNTEKTSMELDING to lagret.toJson(LagretInntektsmelding.serializer()),
                                 ).toJson(),
                     )
 

--- a/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdSelvbestemtService.kt
+++ b/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdSelvbestemtService.kt
@@ -8,7 +8,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
@@ -16,6 +15,7 @@ import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed1Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdService.kt
+++ b/apps/faisu-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdService.kt
@@ -9,7 +9,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
@@ -17,6 +16,7 @@ import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.log.logger

--- a/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdSelvbestemtServiceTest.kt
+++ b/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdSelvbestemtServiceTest.kt
@@ -13,7 +13,6 @@ import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.Ansettelsesforhold
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
 import no.nav.hag.simba.utils.felles.test.json.plusData
@@ -23,6 +22,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdServiceTest.kt
+++ b/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdServiceTest.kt
@@ -15,7 +15,6 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
@@ -28,6 +27,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.februar

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -10,7 +10,6 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -19,6 +18,7 @@ import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed3Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringService.kt
@@ -2,6 +2,7 @@ package no.nav.helsearbeidsgiver.inntektsmelding.innsending
 
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
+import no.nav.hag.simba.kontrakt.domene.inntektsmelding.EksternInntektsmelding
 import no.nav.hag.simba.kontrakt.domene.inntektsmelding.LagretInntektsmelding
 import no.nav.hag.simba.kontrakt.resultat.kvittering.KvitteringResultat
 import no.nav.hag.simba.utils.felles.BehovType
@@ -10,7 +11,6 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.orgMapSerializer
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
@@ -21,7 +21,7 @@ import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.Service
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
-import no.nav.helsearbeidsgiver.utils.json.fromJson
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
@@ -30,6 +30,7 @@ import no.nav.helsearbeidsgiver.utils.log.logger
 import no.nav.helsearbeidsgiver.utils.log.sikkerLogger
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.time.LocalDateTime
 import java.util.UUID
 
 class KvitteringService(
@@ -56,7 +57,7 @@ class KvitteringService(
         data class Komplett(
             val orgnrMedNavn: Map<Orgnr, String>,
             val personer: Map<Fnr, Person>,
-            val lagret: LagretInntektsmelding?,
+            val lagret: LagretInntektsmelding,
         ) : Steg2()
 
         data object Delvis : Steg2()
@@ -76,13 +77,7 @@ class KvitteringService(
     override fun lesSteg2(melding: Map<Key, JsonElement>): Steg2 {
         val orgnrMedNavn = runCatching { Key.VIRKSOMHETER.les(orgMapSerializer, melding) }
         val personer = runCatching { Key.PERSONER.les(personMapSerializer, melding) }
-        val lagret =
-            runCatching {
-                Key.LAGRET_INNTEKTSMELDING
-                    .les(ResultJson.serializer(), melding)
-                    .success
-                    ?.fromJson(LagretInntektsmelding.serializer())
-            }
+        val lagret = runCatching { Key.LAGRET_INNTEKTSMELDING.les(LagretInntektsmelding.serializer(), melding) }
 
         val results = listOf(orgnrMedNavn, personer, lagret)
 
@@ -170,6 +165,7 @@ class KvitteringService(
         if (steg2 is Steg2.Komplett) {
             val sykmeldtNavn = steg2.personer[steg1.forespoersel.fnr]?.navn ?: Tekst.UKJENT_NAVN
             val orgNavn = steg2.orgnrMedNavn[steg1.forespoersel.orgnr] ?: Tekst.UKJENT_VIRKSOMHET
+            val lagretEllerFallback = steg2.lagret.ellerFallback(steg1.forespoersel.erBesvart)
 
             val resultJson =
                 ResultJson(
@@ -178,7 +174,7 @@ class KvitteringService(
                             forespoersel = steg1.forespoersel,
                             sykmeldtNavn = sykmeldtNavn,
                             orgNavn = orgNavn,
-                            lagret = steg2.lagret,
+                            lagret = lagretEllerFallback,
                         ).toJson(KvitteringResultat.serializer()),
                 )
 
@@ -221,10 +217,33 @@ class KvitteringService(
         MdcUtils.withLogFields(
             Log.behov(behovType),
         ) {
-            "Publiserte melding med behov $behovType.".let {
+            "Publiserte melding med behov $behovType.".also {
                 logger.info(it)
                 sikkerLogger.info("$it\n${publisert.toPretty()}")
             }
         }
     }
+
+    // Vi mangler noen inntektsmeldinger i databasen. Frontend sliter når backend ikke svarer med en lagret inntektsmelding.
+    private fun LagretInntektsmelding.ellerFallback(erForespoerselBesvart: Boolean): LagretInntektsmelding =
+        // Alle forespørsler vi henter kvittering for skal være besvart, men vi sjekker for sikkerhets skyld
+        if (this is LagretInntektsmelding.IkkeFunnet && erForespoerselBesvart) {
+            "Mangler inntektsmelding i databasen. Bruker reserveløsning for kvittering.".also {
+                logger.warn(it)
+                sikkerLogger.warn(it)
+            }
+
+            LagretInntektsmelding.Ekstern(
+                EksternInntektsmelding(
+                    avsenderSystemNavn = "et system tilknyttet Altinn 2 (avviklet)",
+                    // Vises ikke til arbeidsgiver
+                    avsenderSystemVersjon = "0",
+                    arkivreferanse = "ikke tilgjengelig",
+                    // Vises ikke til arbeidsgiver
+                    tidspunkt = LocalDateTime.of(2000, 1, 1, 0, 0),
+                ),
+            )
+        } else {
+            this
+        }
 }

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
@@ -18,7 +18,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -33,6 +32,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringServiceTest.kt
@@ -10,6 +10,7 @@ import io.mockk.verify
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
+import no.nav.hag.simba.kontrakt.domene.inntektsmelding.EksternInntektsmelding
 import no.nav.hag.simba.kontrakt.domene.inntektsmelding.LagretInntektsmelding
 import no.nav.hag.simba.kontrakt.domene.inntektsmelding.test.mockEksternInntektsmelding
 import no.nav.hag.simba.kontrakt.resultat.kvittering.KvitteringResultat
@@ -35,6 +36,7 @@ import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.november
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import no.nav.helsearbeidsgiver.utils.wrapper.Orgnr
+import java.time.LocalDateTime
 import java.util.UUID
 
 class KvitteringServiceTest :
@@ -61,16 +63,91 @@ class KvitteringServiceTest :
                 mapOf(
                     "inntektsmelding hentes" to LagretInntektsmelding.Skjema("Barbie Roberts", mockSkjemaInntektsmelding(), 6.november.atStartOfDay()),
                     "ekstern inntektsmelding hentes" to LagretInntektsmelding.Ekstern(mockEksternInntektsmelding()),
-                    "ingen inntektsmelding funnet" to LagretInntektsmelding.IkkeFunnet,
                 ),
             ) { lagret ->
+                withData(
+                    nameFn = { "forespoersel.erBesvart=${it.erBesvart}" },
+                    mockForespoersel().copy(erBesvart = true),
+                    mockForespoersel().copy(erBesvart = false),
+                ) { forespoersel ->
+                    val kontekstId: UUID = UUID.randomUUID()
+                    val expectedResult =
+                        KvitteringResultat(
+                            forespoersel = forespoersel,
+                            sykmeldtNavn = "Kenneth Sean Carson",
+                            orgNavn = "Mattel",
+                            lagret = lagret,
+                        )
+                    val sykmeldtFnr = expectedResult.forespoersel.fnr
+
+                    testRapid.sendJson(
+                        MockKvittering.steg0(kontekstId),
+                    )
+
+                    testRapid.inspektør.size shouldBeExactly 1
+                    testRapid.firstMessage().lesBehov() shouldBe BehovType.HENT_TRENGER_IM
+
+                    testRapid.sendJson(
+                        MockKvittering.steg1(kontekstId, expectedResult.forespoersel),
+                    )
+
+                    testRapid.inspektør.size shouldBeExactly 4
+                    testRapid.message(1).lesBehov() shouldBe BehovType.HENT_VIRKSOMHET_NAVN
+                    testRapid.message(2).lesBehov() shouldBe BehovType.HENT_PERSONER
+                    testRapid.message(3).lesBehov() shouldBe BehovType.HENT_LAGRET_IM
+
+                    testRapid.sendJson(
+                        MockKvittering.steg2(
+                            kontekstId,
+                            mapOf(expectedResult.forespoersel.orgnr to expectedResult.orgNavn),
+                            mapOf(sykmeldtFnr to Person(sykmeldtFnr, expectedResult.sykmeldtNavn)),
+                            expectedResult.lagret,
+                        ),
+                    )
+
+                    testRapid.inspektør.size shouldBeExactly 4
+
+                    verify {
+                        mockRedis.store.skrivResultat(
+                            kontekstId,
+                            ResultJson(
+                                success = expectedResult.toJson(KvitteringResultat.serializer()),
+                            ),
+                        )
+                    }
+                }
+            }
+        }
+
+        context("inntektsmelding ikke funnet") {
+            withData(
+                mapOf(
+                    "svarer at inntektsmelding ikke ble funnet dersom forespørsel ikke er besvart" to
+                        Pair(
+                            mockForespoersel().copy(erBesvart = false),
+                            LagretInntektsmelding.IkkeFunnet,
+                        ),
+                    "svarer med reserveløsning dersom forespørsel er besvart" to
+                        Pair(
+                            mockForespoersel().copy(erBesvart = true),
+                            LagretInntektsmelding.Ekstern(
+                                EksternInntektsmelding(
+                                    avsenderSystemNavn = "et system tilknyttet Altinn 2 (avviklet)",
+                                    avsenderSystemVersjon = "0",
+                                    arkivreferanse = "ikke tilgjengelig",
+                                    tidspunkt = LocalDateTime.of(2000, 1, 1, 0, 0),
+                                ),
+                            ),
+                        ),
+                ),
+            ) { (forespoersel, expectedLagret) ->
                 val kontekstId: UUID = UUID.randomUUID()
                 val expectedResult =
                     KvitteringResultat(
-                        forespoersel = mockForespoersel(),
-                        sykmeldtNavn = "Kenneth Sean Carson",
-                        orgNavn = "Mattel",
-                        lagret = lagret,
+                        forespoersel = forespoersel,
+                        sykmeldtNavn = "Viggo Mortensen",
+                        orgNavn = "Gondor",
+                        lagret = expectedLagret,
                     )
                 val sykmeldtFnr = expectedResult.forespoersel.fnr
 
@@ -95,7 +172,8 @@ class KvitteringServiceTest :
                         kontekstId,
                         mapOf(expectedResult.forespoersel.orgnr to expectedResult.orgNavn),
                         mapOf(sykmeldtFnr to Person(sykmeldtFnr, expectedResult.sykmeldtNavn)),
-                        expectedResult.lagret,
+                        // database svarer at inntektsmelding ikke ble funnet
+                        LagretInntektsmelding.IkkeFunnet,
                     ),
                 )
 

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/KvitteringServiceTest.kt
@@ -17,7 +17,6 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.orgMapSerializer
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -30,6 +29,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.november
@@ -61,7 +61,7 @@ class KvitteringServiceTest :
                 mapOf(
                     "inntektsmelding hentes" to LagretInntektsmelding.Skjema("Barbie Roberts", mockSkjemaInntektsmelding(), 6.november.atStartOfDay()),
                     "ekstern inntektsmelding hentes" to LagretInntektsmelding.Ekstern(mockEksternInntektsmelding()),
-                    "ingen inntektsmelding funnet" to null,
+                    "ingen inntektsmelding funnet" to LagretInntektsmelding.IkkeFunnet,
                 ),
             ) { lagret ->
                 val kontekstId: UUID = UUID.randomUUID()
@@ -162,7 +162,7 @@ private object MockKvittering {
         kontekstId: UUID,
         orgnrMedNavn: Map<Orgnr, String>,
         personer: Map<Fnr, Person>,
-        lagret: LagretInntektsmelding?,
+        lagret: LagretInntektsmelding,
     ): Map<Key, JsonElement> =
         mapOf(
             Key.EVENT_NAME to EventName.SERVICE_FORESPURT_IM_HENT.toJson(),
@@ -171,10 +171,7 @@ private object MockKvittering {
                 mapOf(
                     Key.VIRKSOMHETER to orgnrMedNavn.toJson(orgMapSerializer),
                     Key.PERSONER to personer.toJson(personMapSerializer),
-                    Key.LAGRET_INNTEKTSMELDING to
-                        ResultJson(
-                            success = lagret?.toJson(LagretInntektsmelding.serializer()),
-                        ).toJson(),
+                    Key.LAGRET_INNTEKTSMELDING to lagret.toJson(LagretInntektsmelding.serializer()),
                 ).toJson(),
         )
 

--- a/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
+++ b/apps/inntekt-selvbestemt-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtService.kt
@@ -6,7 +6,6 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -15,6 +14,7 @@ import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed1Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
+++ b/apps/inntekt-selvbestemt-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektselvbestemtservice/InntektSelvbestemtServiceTest.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
@@ -22,6 +21,7 @@ import no.nav.hag.simba.utils.rr.test.firstMessage
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.april
 import no.nav.helsearbeidsgiver.utils.test.date.juni

--- a/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
+++ b/apps/inntektservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/InntektService.kt
@@ -7,7 +7,6 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -16,6 +15,7 @@ import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/AktiveOrgnrServiceIT.kt
@@ -15,7 +15,6 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.ansettelsesperioderSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.orgMapSerializer
@@ -23,6 +22,7 @@ import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.rr.KafkaKey
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.aareg.Periode
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.arveAvsender

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentArbeidsforholdSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentArbeidsforholdSelvbestemtIT.kt
@@ -11,9 +11,9 @@ import kotlinx.serialization.builtins.serializer
 import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.Ansettelsesforhold
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerselIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerselIT.kt
@@ -8,9 +8,9 @@ import no.nav.hag.simba.kontrakt.resultat.forespoersel.HentForespoerselResultat
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.mock.mockForespoerselSvarSuksess
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.pdl.domene.FullPerson

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerslerForVedtaksperiodeIdListeIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentForespoerslerForVedtaksperiodeIdListeIT.kt
@@ -8,10 +8,10 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.mock.mockForespoerselListeSvarResultat
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentSelvbestemtIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/HentSelvbestemtIT.kt
@@ -11,12 +11,12 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.inntektsmelding.integrasjonstest.utils.EndToEndTest
 import no.nav.helsearbeidsgiver.utils.json.fromJson

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/InnsendingServiceIT.kt
@@ -11,13 +11,13 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespurtData
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
 import no.nav.hag.simba.utils.felles.test.mock.mockSkjemaInntektsmelding
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.dokarkiv.domene.OpprettOgFerdigstillResponse
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/KvitteringIT.kt
@@ -6,7 +6,6 @@ import no.nav.hag.simba.kontrakt.domene.inntektsmelding.LagretInntektsmelding
 import no.nav.hag.simba.kontrakt.domene.inntektsmelding.test.mockEksternInntektsmelding
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
@@ -64,13 +63,15 @@ class KvitteringIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
 
-                val success = data[Key.LAGRET_INNTEKTSMELDING].shouldNotBeNull().fromJson(ResultJson.serializer()).success
-                success.shouldNotBeNull()
-                success.fromJson(LagretInntektsmelding.serializer()) shouldBe
-                    LagretInntektsmelding.Skjema(
-                        avsenderNavn = arveAvsender.navn.fulltNavn(),
-                        skjema = skjema,
-                        mottatt = mottatt,
+                data[Key.LAGRET_INNTEKTSMELDING]
+                    .shouldNotBeNull()
+                    .fromJson(LagretInntektsmelding.serializer())
+                    .shouldBe(
+                        LagretInntektsmelding.Skjema(
+                            avsenderNavn = arveAvsender.navn.fulltNavn(),
+                            skjema = skjema,
+                            mottatt = mottatt,
+                        ),
                     )
             }
 
@@ -109,9 +110,10 @@ class KvitteringIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
 
-                val success = data[Key.LAGRET_INNTEKTSMELDING].shouldNotBeNull().fromJson(ResultJson.serializer()).success
-                success.shouldNotBeNull()
-                success.fromJson(LagretInntektsmelding.serializer()) shouldBe LagretInntektsmelding.Ekstern(eksternIm)
+                data[Key.LAGRET_INNTEKTSMELDING]
+                    .shouldNotBeNull()
+                    .fromJson(LagretInntektsmelding.serializer())
+                    .shouldBe(LagretInntektsmelding.Ekstern(eksternIm))
             }
 
         redisConnection.get(RedisPrefix.Kvittering, kontekstId).shouldNotBeNull()
@@ -146,7 +148,7 @@ class KvitteringIT : EndToEndTest() {
             .also {
                 val data = it[Key.DATA].shouldNotBeNull().toMap()
 
-                data[Key.LAGRET_INNTEKTSMELDING] shouldBe ResultJson(success = null).toJson()
+                data[Key.LAGRET_INNTEKTSMELDING] shouldBe LagretInntektsmelding.IkkeFunnet.toJson(LagretInntektsmelding.serializer())
             }
     }
 }

--- a/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
+++ b/apps/selvbestemt-hent-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImService.kt
@@ -5,13 +5,13 @@ import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed1Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/selvbestemt-hent-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-hent-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemthentimservice/HentSelvbestemtImServiceTest.kt
@@ -11,7 +11,6 @@ import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
 import no.nav.hag.simba.utils.felles.test.json.plusData
@@ -22,6 +21,7 @@ import no.nav.hag.simba.utils.rr.test.firstMessage
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Inntektsmelding
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID

--- a/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
+++ b/apps/selvbestemt-lagre-im-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImService.kt
@@ -9,7 +9,6 @@ import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.ansettelsesperioderSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.lesOrNull
@@ -22,6 +21,7 @@ import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.Service
 import no.nav.hag.simba.utils.rr.service.ServiceMed3Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Avsender
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.FlereArbeidsforhold

--- a/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
+++ b/apps/selvbestemt-lagre-im-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/selvbestemtlagreimservice/LagreSelvbestemtImServiceTest.kt
@@ -19,7 +19,6 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.ansettelsesperioderSerializer
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.personMapSerializer
@@ -37,6 +36,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.AarsakInnsending
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode

--- a/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
+++ b/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangForespoerselService.kt
@@ -8,13 +8,13 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty

--- a/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
+++ b/apps/tilgangservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/tilgangservice/TilgangOrgService.kt
@@ -7,13 +7,13 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed1Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty

--- a/apps/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangForespoerselServiceTest.kt
+++ b/apps/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangForespoerselServiceTest.kt
@@ -8,11 +8,11 @@ import io.mockk.verify
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Tekst
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.test.mock.mockFail
 import no.nav.hag.simba.utils.rr.service.ServiceRiverStateless
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.tilgangservice.TilgangForespoerselService
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import org.junit.jupiter.api.BeforeEach

--- a/apps/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangOrgServiceTest.kt
+++ b/apps/tilgangservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/inntektservice/TilgangOrgServiceTest.kt
@@ -8,11 +8,11 @@ import io.mockk.verify
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Tekst
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.test.mock.mockFail
 import no.nav.hag.simba.utils.rr.service.ServiceRiverStateless
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.tilgangservice.TilgangOrgService
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import org.junit.jupiter.api.BeforeEach

--- a/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
+++ b/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselService.kt
@@ -10,7 +10,6 @@ import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.lesOrNull
@@ -23,6 +22,7 @@ import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.Service
 import no.nav.hag.simba.utils.rr.service.ServiceMed2Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty

--- a/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
+++ b/apps/trengerservice/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeService.kt
@@ -8,13 +8,13 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Fail
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.les
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.service.ServiceMed1Steg
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselServiceTest.kt
+++ b/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerselServiceTest.kt
@@ -16,7 +16,6 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.Fail
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.lesOrNull
 import no.nav.hag.simba.utils.felles.json.orgMapSerializer
@@ -30,6 +29,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisPrefix
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.hag.simba.utils.valkey.test.MockRedis
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.juli

--- a/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeServiceTest.kt
+++ b/apps/trengerservice/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/trengerservice/HentForespoerslerForVedtaksperiodeIdListeServiceTest.kt
@@ -14,7 +14,6 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.hag.simba.utils.felles.test.json.lesBehov
 import no.nav.hag.simba.utils.felles.test.json.plusData
@@ -25,6 +24,7 @@ import no.nav.hag.simba.utils.rr.test.message
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.hag.simba.utils.valkey.RedisStore
+import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.inntektsmelding.trengerservice.MockHent.forespoersler
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson

--- a/kontrakt/domene-inntektsmelding/src/main/kotlin/no/nav/hag/simba/kontrakt/domene/inntektsmelding/LagretInntektsmelding.kt
+++ b/kontrakt/domene-inntektsmelding/src/main/kotlin/no/nav/hag/simba/kontrakt/domene/inntektsmelding/LagretInntektsmelding.kt
@@ -24,4 +24,8 @@ sealed class LagretInntektsmelding {
     data class Ekstern(
         val ekstern: EksternInntektsmelding,
     ) : LagretInntektsmelding()
+
+    @Serializable
+    @SerialName("IkkeFunnet")
+    data object IkkeFunnet : LagretInntektsmelding()
 }

--- a/kontrakt/resultat-kvittering/src/main/kotlin/no/nav/hag/simba/kontrakt/resultat/kvittering/KvitteringResultat.kt
+++ b/kontrakt/resultat-kvittering/src/main/kotlin/no/nav/hag/simba/kontrakt/resultat/kvittering/KvitteringResultat.kt
@@ -9,5 +9,5 @@ data class KvitteringResultat(
     val forespoersel: Forespoersel,
     val sykmeldtNavn: String,
     val orgNavn: String,
-    val lagret: LagretInntektsmelding?,
+    val lagret: LagretInntektsmelding,
 )

--- a/utils/felles/src/main/kotlin/no/nav/hag/simba/utils/felles/json/KotlinxUtils.kt
+++ b/utils/felles/src/main/kotlin/no/nav/hag/simba/utils/felles/json/KotlinxUtils.kt
@@ -11,7 +11,6 @@ import no.nav.hag.simba.utils.felles.IKey
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.domene.PeriodeAapen
 import no.nav.hag.simba.utils.felles.domene.Person
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.fromJsonMapFiltered
 import no.nav.helsearbeidsgiver.utils.json.serializer.YearMonthSerializer
@@ -48,8 +47,6 @@ val ansettelsesperioderSerializer =
 fun EventName.toJson(): JsonElement = toJson(EventName.serializer())
 
 fun BehovType.toJson(): JsonElement = toJson(BehovType.serializer())
-
-fun ResultJson.toJson(): JsonElement = toJson(ResultJson.serializer())
 
 fun <T> Set<T>.toJson(elementSerializer: KSerializer<T>): JsonElement =
     toJson(

--- a/utils/valkey/src/main/kotlin/no/nav/hag/simba/utils/valkey/RedisStore.kt
+++ b/utils/valkey/src/main/kotlin/no/nav/hag/simba/utils/valkey/RedisStore.kt
@@ -2,7 +2,6 @@ package no.nav.hag.simba.utils.valkey
 
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.felles.json.toJson
 import no.nav.helsearbeidsgiver.utils.collection.mapKeysNotNull
 import no.nav.helsearbeidsgiver.utils.collection.mapValuesNotNull

--- a/utils/valkey/src/main/kotlin/no/nav/hag/simba/utils/valkey/ResultJson.kt
+++ b/utils/valkey/src/main/kotlin/no/nav/hag/simba/utils/valkey/ResultJson.kt
@@ -1,10 +1,13 @@
-package no.nav.hag.simba.utils.felles.domene
+package no.nav.hag.simba.utils.valkey
 
 import kotlinx.serialization.Serializable
 import kotlinx.serialization.json.JsonElement
+import no.nav.helsearbeidsgiver.utils.json.toJson
 
 @Serializable
 data class ResultJson(
     val success: JsonElement? = null,
     val failure: JsonElement? = null,
-)
+) {
+    fun toJson(): JsonElement = toJson(serializer())
+}

--- a/utils/valkey/src/test/kotlin/no/nav/hag/simba/utils/valkey/RedisStoreTest.kt
+++ b/utils/valkey/src/test/kotlin/no/nav/hag/simba/utils/valkey/RedisStoreTest.kt
@@ -8,7 +8,6 @@ import io.kotest.matchers.nulls.shouldBeNull
 import io.kotest.matchers.shouldBe
 import kotlinx.serialization.SerializationException
 import no.nav.hag.simba.utils.felles.Key
-import no.nav.hag.simba.utils.felles.domene.ResultJson
 import no.nav.hag.simba.utils.valkey.test.redisWithMockRedisClient
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import java.util.UUID


### PR DESCRIPTION
Når SAS mottar søknader der IM har blitt sendt inn på forhånd, så vil SAS av og til sende oss en forespørsel og deretter umiddelbart en beskjed om at forespørselen er besvart. Dette stammer fra nå deaktiverte Altinn 2. Vi visste ikke om denne oppførselen, så vi sluttet å lagre Altinn-IM-er i Simba. Dersom man prøver å hente en kvittering for en slik IM på nav.no, så vil backend svare at den ikke finner IM-en. Det tåler frontend dårlig. Denne PR-en løser det ved å legge til en reserveløsning, der man svarer med en generisk ekstern inntektsmelding dersom man ikke finner IM-en i databasen.

Hva som blir vist i frontend dersom IM mangler i databasen:
<img width="1027" height="512" alt="Screenshot from 2026-07-10 14-44-20" src="https://github.com/user-attachments/assets/64de3423-dec6-480f-a844-ff8677dddeeb" />