### PR TITLE
Legg til replication slot etter oppdatering

### DIFF
--- a/apps/db/src/main/resources/db/migration/V25__datastream_replication.sql
+++ b/apps/db/src/main/resources/db/migration/V25__datastream_replication.sql
@@ -1,0 +1,10 @@
+DO
+$$
+BEGIN
+    IF NOT EXISTS
+        (SELECT 1 FROM pg_replication_slots WHERE slot_name = 'simba_replication')
+    THEN
+        PERFORM PG_CREATE_LOGICAL_REPLICATION_SLOT ('simba_replication', 'pgoutput');
+    END IF;
+END;
+$$;


### PR DESCRIPTION
Legger til replication slot etter database oppdatering
Database brukeren må ha en replication tilgang eller være en super bruker for å lage replication slot.
Derfor legger jeg til i migration script istedenfor.

Dette er samme som v15 men den forsvinner etter oppdatering av databasen