### PR TITLE
Legg til validering av egenmeldinger i AGP

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -68,8 +68,9 @@ fun Route.innsending(
                         onFailureCustomError = { failure ->
                             failure
                                 ?.fromJson(LagreImError.serializer())
-                                ?.feiletValidering
-                                ?.let { ErrorResponse.Validering(kontekstId, setOf(it)) }
+                                ?.valideringsfeil
+                                ?.ifEmpty { null }
+                                ?.let { ErrorResponse.Validering(kontekstId, it) }
                         },
                         successSerializer = JsonElement.serializer(),
                     ) {

--- a/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
+++ b/apps/api/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRouteKtTest.kt
@@ -12,6 +12,7 @@ import io.mockk.verify
 import io.mockk.verifySequence
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import no.nav.hag.simba.kontrakt.resultat.lagreim.LagreImError
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.toJson
@@ -130,7 +131,43 @@ class InnsendingRouteKtTest : ApiTest() {
         }
 
     @Test
-    fun `skal returnere feilmelding ved timeout fra Redis`() =
+    fun `svarer med valideringsfeil`() =
+        testApi {
+            val skjema = mockSkjemaInntektsmelding()
+            val valideringsfeil =
+                setOf(
+                    "Surely you can't be serious.",
+                    "I am serious. And don't call me Shirley.",
+                )
+            val failure = ResultJson(failure = LagreImError(valideringsfeil).toJson(LagreImError.serializer()))
+
+            coEvery { anyConstructed<RedisPoller>().hent(any()) } returns harTilgangResultat andThen failure
+
+            val response = post(path, skjema, SkjemaInntektsmelding.serializer())
+            val responseBody = response.bodyAsText().fromJson(ErrorResponse.serializer())
+
+            response.status shouldBe HttpStatusCode.BadRequest
+            responseBody.shouldBeTypeOf<ErrorResponse.Validering>()
+            responseBody.valideringsfeil shouldBe valideringsfeil
+        }
+
+    @Test
+    fun `svarer med ukjent feil`() =
+        testApi {
+            val skjema = mockSkjemaInntektsmelding()
+            val failure = ResultJson(failure = LagreImError(emptySet()).toJson(LagreImError.serializer()))
+
+            coEvery { anyConstructed<RedisPoller>().hent(any()) } returns harTilgangResultat andThen failure
+
+            val response = post(path, skjema, SkjemaInntektsmelding.serializer())
+            val responseBody = response.bodyAsText().fromJson(ErrorResponse.serializer())
+
+            response.status shouldBe HttpStatusCode.InternalServerError
+            responseBody.shouldBeTypeOf<ErrorResponse.Unknown>()
+        }
+
+    @Test
+    fun `svarer med Redis-timeout`() =
         testApi {
             val skjema = mockSkjemaInntektsmelding()
 

--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -134,14 +134,16 @@ class InnsendingService(
         val inntektsmeldingId = UUID.randomUUID()
         val avsenderNavn = steg2.personer[steg0.avsenderFnr]?.navn ?: Tekst.UKJENT_NAVN
 
-        val agp = steg0.skjema.agp
-        if (agp == null ||
-            agp.erGyldigHvisIkkeForespurt(
-                erAgpForespurt = steg1.forespoersel.forespurtData.arbeidsgiverperiode.paakrevd,
-                egenmeldingsperioder = steg1.forespoersel.egenmeldingsperioder,
-                sykmeldingsperioder = steg1.forespoersel.sykmeldingsperioder,
-            )
-        ) {
+        val agpValideringsfeil =
+            steg0.skjema
+                .agp
+                ?.validerMotSykmeldingsperioder(
+                    erAgpForespurt = steg1.forespoersel.forespurtData.arbeidsgiverperiode.paakrevd,
+                    egenmeldingerFraForespoersel = steg1.forespoersel.egenmeldingsperioder,
+                    sykmeldingsperioder = steg1.forespoersel.sykmeldingsperioder,
+                ).orEmpty()
+
+        if (agpValideringsfeil.isEmpty()) {
             publisher
                 .publish(
                     key = steg0.skjema.forespoerselId,
@@ -158,7 +160,7 @@ class InnsendingService(
                             ).toJson(),
                 ).also { loggBehovPublisert(BehovType.LAGRE_IM_SKJEMA, it) }
         } else {
-            "Avviser inntektsmelding som inneholder ikke-forespurt AGP som er ugyldig.".also {
+            "Avviser inntektsmelding som inneholder ugyldig AGP. Valideringsfeil: $agpValideringsfeil".also {
                 logger.warn(it)
                 sikkerLogger.warn(it)
             }
@@ -167,7 +169,7 @@ class InnsendingService(
                 ResultJson(
                     failure =
                         LagreImError(
-                            feiletValidering = "Arbeidsgiverperioden må indikere at sykmeldt arbeidet i starten av sykmeldingsperioden.",
+                            valideringsfeil = agpValideringsfeil,
                         ).toJson(LagreImError.serializer()),
                 )
 
@@ -227,7 +229,7 @@ class InnsendingService(
 
         val resultJson =
             ResultJson(
-                failure = LagreImError().toJson(LagreImError.serializer()),
+                failure = LagreImError(valideringsfeil = emptySet()).toJson(LagreImError.serializer()),
             )
 
         redisStore.skrivResultat(fail.kontekstId, resultJson)

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
@@ -36,10 +36,12 @@ import no.nav.hag.simba.utils.valkey.ResultJson
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Arbeidsgiverperiode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Periode
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.skjema.SkjemaInntektsmelding
+import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.til
 import no.nav.helsearbeidsgiver.utils.json.serializer.LocalDateTimeSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.test.date.august
+import no.nav.helsearbeidsgiver.utils.test.date.februar
 import no.nav.helsearbeidsgiver.utils.test.date.kl
 import no.nav.helsearbeidsgiver.utils.test.wrapper.genererGyldig
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
@@ -103,6 +105,104 @@ class InnsendingServiceTest :
                     kontekstId,
                     ResultJson(
                         success = skjema.forespoerselId.toJson(),
+                    ),
+                )
+            }
+        }
+
+        test("godtar inntektsmeldingskjema dersom egenmeldinger i AGP er gyldige") {
+            val kontekstId = UUID.randomUUID()
+            val forespoersel =
+                mockForespoersel().copy(
+                    sykmeldingsperioder =
+                        listOf(
+                            1.februar til 12.februar,
+                            19.februar til 28.februar,
+                        ),
+                    egenmeldingsperioder = emptyList(), // fjerner for å vektlegge at det ikke er disse egenmeldingene vi validerer
+                )
+            val skjemaMedGyldigeEgenmenldinger =
+                mockSkjemaInntektsmelding().copy(
+                    agp =
+                        Arbeidsgiverperiode(
+                            perioder =
+                                listOf(
+                                    1.februar til 12.februar,
+                                    14.februar til 15.februar, // egenmelding er gyldig pga. gjenopptatt arbeid 13.
+                                    19.februar til 20.februar,
+                                ),
+                            redusertLoennIAgp = null,
+                        ),
+                )
+
+            testRapid.sendJson(
+                Mock.steg2(kontekstId, skjemaMedGyldigeEgenmenldinger).plusData(
+                    Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
+                ),
+            )
+
+            testRapid.inspektør.size shouldBeExactly 1
+            testRapid.message(0).lesBehov() shouldBe BehovType.LAGRE_IM_SKJEMA
+
+            testRapid.sendJson(
+                Mock.steg3(kontekstId, skjemaMedGyldigeEgenmenldinger).plusData(
+                    Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
+                ),
+            )
+
+            testRapid.inspektør.size shouldBeExactly 2
+            testRapid.message(1).lesEventName() shouldBe EventName.INNTEKTSMELDING_SKJEMA_LAGRET
+
+            verifySequence {
+                mockRedisStore.skrivResultat(
+                    kontekstId,
+                    ResultJson(
+                        success = skjemaMedGyldigeEgenmenldinger.forespoerselId.toJson(),
+                    ),
+                )
+            }
+        }
+
+        test("avviser inntektsmeldingskjema dersom egenmeldinger i AGP er ugyldige") {
+            val kontekstId = UUID.randomUUID()
+            val forespoersel =
+                mockForespoersel().copy(
+                    sykmeldingsperioder =
+                        listOf(
+                            1.februar til 12.februar,
+                            19.februar til 28.februar,
+                        ),
+                    egenmeldingsperioder = emptyList(), // fjerner for å vektlegge at det ikke er disse egenmeldingene vi validerer
+                )
+            val skjemaMedUgyldigeEgenmenldinger =
+                mockSkjemaInntektsmelding().copy(
+                    agp =
+                        Arbeidsgiverperiode(
+                            perioder =
+                                listOf(
+                                    1.februar til 14.februar, // egenmelding 13.-14. er ikke gyldig ettersom arbeid ikke er gjenopptatt før 13.
+                                    19.februar til 20.februar,
+                                ),
+                            redusertLoennIAgp = null,
+                        ),
+                )
+
+            testRapid.sendJson(
+                Mock.steg2(kontekstId, skjemaMedUgyldigeEgenmenldinger).plusData(
+                    Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
+                ),
+            )
+
+            testRapid.inspektør.size shouldBeExactly 0
+
+            verifySequence {
+                mockRedisStore.skrivResultat(
+                    kontekstId,
+                    ResultJson(
+                        failure =
+                            LagreImError(
+                                valideringsfeil = setOf("Egenmelding kan ikke benyttes dagen etter en sykmeldingsperiode."),
+                            ).toJson(LagreImError.serializer()),
                     ),
                 )
             }
@@ -175,7 +275,7 @@ class InnsendingServiceTest :
                     ResultJson(
                         failure =
                             LagreImError(
-                                feiletValidering = "Arbeidsgiverperioden må indikere at sykmeldt arbeidet i starten av sykmeldingsperioden.",
+                                valideringsfeil = setOf("Arbeidsgiverperioden må indikere at sykmeldt arbeidet i starten av sykefraværet."),
                             ).toJson(LagreImError.serializer()),
                     ),
                 )
@@ -237,7 +337,7 @@ class InnsendingServiceTest :
                 mockRedisStore.skrivResultat(
                     fail.kontekstId,
                     ResultJson(
-                        failure = LagreImError().toJson(LagreImError.serializer()),
+                        failure = LagreImError(valideringsfeil = emptySet()).toJson(LagreImError.serializer()),
                     ),
                 )
             }

--- a/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
+++ b/apps/joark/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/joark/dokument/PdfDokument.kt
@@ -15,10 +15,8 @@ import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Permittering
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Sykefravaer
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.Tariffendring
 import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.VarigLoennsendring
-import no.nav.helsearbeidsgiver.domene.inntektsmelding.v1.utils.utledEgenmeldinger
 import no.nav.helsearbeidsgiver.inntektsmelding.joark.tittel
 import no.nav.helsearbeidsgiver.utils.date.tilNorskFormat
-import no.nav.helsearbeidsgiver.utils.pipe.orDefault
 
 private const val FORKLARING_ENDRING = "Endringsårsak"
 
@@ -189,10 +187,10 @@ class PdfDokument(
 
         // --- Kolonnen til høyre ---------------------------------------------------
         val egenmeldinger =
-            utledEgenmeldinger(
-                arbeidsgiverperioder = inntektsmelding.agp?.perioder.orEmpty(),
-                sykmeldingsperioder = inntektsmelding.sykmeldingsperioder,
-            )
+            inntektsmelding
+                .agp
+                ?.utledEgenmeldinger(inntektsmelding.sykmeldingsperioder)
+                .orEmpty()
         moveCursorTo(seksjonStartY) // Gjenopprett y-aksen fra tidligere
 
         val egenmeldingLabel = "Egenmelding"
@@ -233,7 +231,7 @@ class PdfDokument(
                 "${inntektsmelding.inntekt?.beloep?.tilNorskFormat()} kr/måned",
             )
         }
-        val endringAarsaker = inntektsmelding.inntekt?.endringAarsaker.orDefault(emptyList())
+        val endringAarsaker = inntektsmelding.inntekt?.endringAarsaker.orEmpty()
         val antall = endringAarsaker.size
         endringAarsaker.forEachIndexed { indeks, endringAarsak ->
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -5,7 +5,7 @@ kotlinVersion=2.4.0
 kotlinterVersion=5.5.0
 
 # Dependency versions
-hagDomeneInntektsmeldingVersion=0.10.2
+hagDomeneInntektsmeldingVersion=0.11.0
 junitJupiterVersion=6.1.0
 kotestVersion=6.2.1
 kotlinxCoroutinesVersion=1.11.0

--- a/kontrakt/resultat-lagre-im/src/main/kotlin/no/nav/hag/simba/kontrakt/resultat/lagreim/LagreImError.kt
+++ b/kontrakt/resultat-lagre-im/src/main/kotlin/no/nav/hag/simba/kontrakt/resultat/lagreim/LagreImError.kt
@@ -1,10 +1,8 @@
 package no.nav.hag.simba.kontrakt.resultat.lagreim
 
-import kotlinx.serialization.EncodeDefault
 import kotlinx.serialization.Serializable
 
 @Serializable
 data class LagreImError(
-    @EncodeDefault
-    val feiletValidering: String? = null,
+    val valideringsfeil: Set<String>,
 )


### PR DESCRIPTION
Tar i bruk versjon av domenepakke som inkluderer validering av egenmeldinger i AGP. Det er nå ikke lov til å melde om egenmeldinger rett etter en sykmeldingsperiode. Man må gjenoppta arbeid før man kan bruke egenmelding.