### PR TITLE
Oppdater ag-notifikasjon til 4.2.0

### DIFF
--- a/apps/notifikasjon/gradle.properties
+++ b/apps/notifikasjon/gradle.properties
@@ -1,1 +1,1 @@
-arbeidsgiverNotifikasjonKlientVersion=4.0.0
+arbeidsgiverNotifikasjonKlientVersion=4.2.0

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/App.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/App.kt
@@ -6,7 +6,6 @@ import no.nav.hag.simba.utils.rr.Publisher
 import no.nav.hag.simba.utils.rr.river.ObjectRiver
 import no.nav.hag.simba.utils.rr.service.ServiceRiverStateless
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.AltinnMottaker
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.Sendevindu
 import no.nav.helsearbeidsgiver.inntektsmelding.notifikasjon.river.FerdigstillSakOgOppgaveRiver
@@ -51,7 +50,6 @@ fun createNotifikasjonRivers(
 
 private fun agNotifikasjonKlient(): ArbeidsgiverNotifikasjonKlient {
     val tokenGetter = AuthClient().tokenGetter(IdentityProvider.AZURE_AD, Env.agNotifikasjonScope)
-    val altinnMottaker = AltinnMottaker.Altinn3(Altinn3Ressurs.INNTEKTSMELDING)
-    sikkerLogger().info("Oppretter ArbeidsgiverNotifikasjonKlient med mottaker ${altinnMottaker.tilTekst()}")
-    return ArbeidsgiverNotifikasjonKlient(Env.agNotifikasjonUrl, altinnMottaker, tokenGetter, Sendevindu.NKS_AAPNINGSTID)
+    sikkerLogger().info("Oppretter ArbeidsgiverNotifikasjonKlient med ressurs ${Altinn3Ressurs.INNTEKTSMELDING}}")
+    return ArbeidsgiverNotifikasjonKlient(Env.agNotifikasjonUrl, Altinn3Ressurs.INNTEKTSMELDING, tokenGetter, Sendevindu.NKS_AAPNINGSTID)
 }

--- a/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
+++ b/apps/notifikasjon/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/ArbeidsgiverNotifikasjonKlientUtils.kt
@@ -4,7 +4,7 @@ import kotlinx.coroutines.runBlocking
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.domene.Person
 import no.nav.hag.simba.utils.felles.utils.tilKortFormat
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.AltinnMottaker
+import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Paaminnelse
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
@@ -99,12 +99,6 @@ object NotifikasjonTekst {
         ).joinToString(separator = " ")
 }
 
-fun AltinnMottaker.tilTekst(): String =
-    when (this) {
-        is AltinnMottaker.Altinn3 -> "Altinn 3 ressurs ${this.ressurs.value}"
-        is AltinnMottaker.Altinn2 -> "Altinn 2 tjeneste ${this.serviceCode} versjon ${this.serviceEdition}"
-    }
-
 fun ArbeidsgiverNotifikasjonKlient.opprettSak(
     lenke: String,
     inntektsmeldingType: Inntektsmelding.Type,
@@ -120,7 +114,7 @@ fun ArbeidsgiverNotifikasjonKlient.opprettSak(
         }
 
     logger.info(
-        "Oppretter sak med ${mottaker.tilTekst()} for inntektsmelding med typeId ${inntektsmeldingType.id}",
+        "Oppretter sak med ressurs ${Altinn3Ressurs.INNTEKTSMELDING} for inntektsmelding med typeId ${inntektsmeldingType.id}",
     )
 
     return try {

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettForespoerselSakOgOppgaveRiverTest.kt
@@ -23,8 +23,6 @@ import no.nav.hag.simba.utils.felles.json.toMap
 import no.nav.hag.simba.utils.rr.test.firstMessage
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.AltinnMottaker
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Paaminnelse
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
@@ -54,7 +52,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
         beforeTest {
             testRapid.reset()
             clearAllMocks()
-            coEvery { mockAgNotifikasjonKlient.mottaker } returns AltinnMottaker.Altinn3(Altinn3Ressurs.INNTEKTSMELDING)
         }
 
         test("oppretter sak og oppgave") {
@@ -73,7 +70,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, sakId, oppgaveId)
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(
                     virksomhetsnummer = innkommendeMelding.forespoersel.orgnr.verdi,
                     grupperingsid = innkommendeMelding.forespoerselId.toString(),
@@ -134,7 +130,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, sakId, duplikatOppgaveId)
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
                 mockAgNotifikasjonKlient.opprettNyOppgave(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
@@ -159,7 +154,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, oppgaveId)
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
                 mockAgNotifikasjonKlient.opprettNyOppgave(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
@@ -186,7 +180,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetUtgaaendeMelding(innkommendeMelding, duplikatSakId, duplikatOppgaveId)
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
                 mockAgNotifikasjonKlient.opprettNyOppgave(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
@@ -206,7 +199,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
         }
@@ -229,7 +221,6 @@ class OpprettForespoerselSakOgOppgaveRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail(innkommendeMelding).tilMelding()
 
             coVerifySequence {
-                mockAgNotifikasjonKlient.mottaker
                 mockAgNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
                 mockAgNotifikasjonKlient.opprettNyOppgave(any(), any(), any(), any(), any(), any(), any(), any(), any(), any())
             }

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
@@ -23,7 +23,6 @@ import no.nav.hag.simba.utils.rr.test.firstMessage
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.AltinnMottaker
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus
@@ -47,7 +46,6 @@ class OpprettSelvbestemtSakRiverTest :
         beforeTest {
             testRapid.reset()
             clearAllMocks()
-            coEvery { mockagNotifikasjonKlient.mottaker } returns AltinnMottaker.Altinn3(Altinn3Ressurs.INNTEKTSMELDING)
         }
 
         test("opprett sak") {
@@ -72,7 +70,6 @@ class OpprettSelvbestemtSakRiverTest :
                 )
 
             coVerifySequence {
-                mockagNotifikasjonKlient.mottaker
                 mockagNotifikasjonKlient.opprettNySak(
                     virksomhetsnummer = innkommendeMelding.inntektsmelding.avsender.orgnr.verdi,
                     merkelapp = "Inntektsmelding sykepenger",
@@ -115,7 +112,6 @@ class OpprettSelvbestemtSakRiverTest :
                 )
 
             coVerifySequence {
-                mockagNotifikasjonKlient.mottaker
                 mockagNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
         }
@@ -135,7 +131,6 @@ class OpprettSelvbestemtSakRiverTest :
             testRapid.firstMessage().toMap() shouldContainExactly forventetFail.tilMelding()
 
             coVerifySequence {
-                mockagNotifikasjonKlient.mottaker
                 mockagNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
             }
         }
@@ -157,7 +152,6 @@ class OpprettSelvbestemtSakRiverTest :
                 testRapid.inspektør.size shouldBeExactly 0
 
                 coVerify(exactly = 0) {
-                    mockagNotifikasjonKlient.mottaker
                     mockagNotifikasjonKlient.opprettNySak(any(), any(), any(), any(), any(), any(), any(), any(), any())
                 }
             }

--- a/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
+++ b/apps/notifikasjon/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/notifikasjon/river/OpprettSelvbestemtSakRiverTest.kt
@@ -22,7 +22,6 @@ import no.nav.hag.simba.utils.felles.test.mock.mockInntektsmeldingV1
 import no.nav.hag.simba.utils.rr.test.firstMessage
 import no.nav.hag.simba.utils.rr.test.mockConnectToRapid
 import no.nav.hag.simba.utils.rr.test.sendJson
-import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.Altinn3Ressurs
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.ArbeidsgiverNotifikasjonKlient
 import no.nav.helsearbeidsgiver.arbeidsgivernotifikasjon.SakEllerOppgaveDuplikatException
 import no.nav.helsearbeidsgiver.arbeidsgivernotifkasjon.graphql.generated.enums.SaksStatus

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,8 +13,3 @@ kotlinxSerializationVersion=1.11.0
 ktorVersion=3.5.1
 mockkVersion=1.14.11
 utilsVersion=0.10.2
-
-org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
-org.gradle.workers.max=2
-org.gradle.parallel=false
-kotlin.daemon.jvmargs=-Xmx2g

--- a/gradle.properties
+++ b/gradle.properties
@@ -13,3 +13,8 @@ kotlinxSerializationVersion=1.11.0
 ktorVersion=3.5.1
 mockkVersion=1.14.11
 utilsVersion=0.10.2
+
+org.gradle.jvmargs=-Xmx4g -Xms1g -XX:MaxMetaspaceSize=1g -Dfile.encoding=UTF-8
+org.gradle.workers.max=2
+org.gradle.parallel=false
+kotlin.daemon.jvmargs=-Xmx2g


### PR DESCRIPTION
Oppdaterer ag-notifikasjonsklient til 4.2.0 som fjerner altinn 2 tjenestekode og unødvendig abstraksjon for mottaker.