### PR TITLE
API: Logg endepunkt og kontekst-ID som MDC-felt for alle endepunkt

### DIFF
--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/aktiveorgnr/AktiveOrgnrRoute.kt
@@ -6,6 +6,7 @@ import no.nav.hag.simba.kontrakt.domene.arbeidsgiver.AktiveArbeidsgivere
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
 import no.nav.hag.simba.utils.valkey.RedisPrefix
@@ -19,6 +20,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.readRequestOrError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondOk
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.util.UUID
 
@@ -31,26 +33,31 @@ fun Route.aktiveOrgnrRoute(
     post(Routes.AKTIVEORGNR) {
         val kontekstId = UUID.randomUUID()
 
-        readRequestOrError(
-            kontekstId,
-            AktiveOrgnrRequest.serializer(),
-        ) { request ->
-            producer.sendRequestEvent(
-                kontekstId = kontekstId,
-                avsenderFnr = call.request.lesFnrFraAuthToken(),
-                sykmeldtFnr = request.sykmeldtFnr,
-            )
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.AKTIVEORGNR),
+            Log.kontekstId(kontekstId),
+        ) {
+            readRequestOrError(
+                kontekstId,
+                AktiveOrgnrRequest.serializer(),
+            ) { request ->
+                producer.sendRequestEvent(
+                    kontekstId = kontekstId,
+                    avsenderFnr = call.request.lesFnrFraAuthToken(),
+                    sykmeldtFnr = request.sykmeldtFnr,
+                )
 
-            hentResultatFraRedisOrError(
-                redisPoller = redisPoller,
-                kontekstId = kontekstId,
-                logOnFailure = "Klarte ikke hente aktive arbeidsforhold pga. feil.",
-                successSerializer = AktiveArbeidsgivere.serializer(),
-            ) {
-                if (it.arbeidsgivere.isEmpty()) {
-                    respondError(ErrorResponse.NotFound(kontekstId, "Fant ingen arbeidsforhold."))
-                } else {
-                    respondOk(it.toResponse(), AktiveOrgnrResponse.serializer())
+                hentResultatFraRedisOrError(
+                    redisPoller = redisPoller,
+                    kontekstId = kontekstId,
+                    logOnFailure = "Klarte ikke hente aktive arbeidsforhold pga. feil.",
+                    successSerializer = AktiveArbeidsgivere.serializer(),
+                ) {
+                    if (it.arbeidsgivere.isEmpty()) {
+                        respondError(ErrorResponse.NotFound(kontekstId, "Fant ingen arbeidsforhold."))
+                    } else {
+                        respondOk(it.toResponse(), AktiveOrgnrResponse.serializer())
+                    }
                 }
             }
         }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforhold/HentArbeidsforholdRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentarbeidsforhold/HentArbeidsforholdRoute.kt
@@ -37,35 +37,37 @@ fun Route.hentArbeidsforholdRoute(
     get(Routes.HENT_ARBEIDSFORHOLD) {
         val kontekstId = UUID.randomUUID()
 
-        readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.HENT_ARBEIDSFORHOLD),
+            Log.kontekstId(kontekstId),
+        ) {
+            readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
+                MdcUtils.withLogFields(
+                    Log.forespoerselId(forespoerselId),
+                ) {
+                    validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
+                        producer.sendRequestEvent(kontekstId, forespoerselId)
 
-            MdcUtils.withLogFields(
-                Log.apiRoute(Routes.HENT_ARBEIDSFORHOLD),
-                Log.kontekstId(kontekstId),
-                Log.forespoerselId(forespoerselId),
-            ) {
-                validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
-                    producer.sendRequestEvent(kontekstId, forespoerselId)
+                        hentResultatFraRedisOrError(
+                            redisPoller = redisPoller,
+                            kontekstId = kontekstId,
+                            inntektsmeldingTypeId = forespoerselId,
+                            logOnFailure = "Klarte ikke hente arbeidsforhold.",
+                            successSerializer = Ansettelsesforhold.serializer().list(),
+                        ) { ansettelsesforhold ->
+                            val response =
+                                HentArbeidsforholdResponse(
+                                    ansettelsesforhold = ansettelsesforhold.map(AnsettelsesforholdResponse::fra),
+                                )
+                            val responseJson = response.toJson(HentArbeidsforholdResponse.serializer())
 
-                    hentResultatFraRedisOrError(
-                        redisPoller = redisPoller,
-                        kontekstId = kontekstId,
-                        inntektsmeldingTypeId = forespoerselId,
-                        logOnFailure = "Klarte ikke hente arbeidsforhold.",
-                        successSerializer = Ansettelsesforhold.serializer().list(),
-                    ) { ansettelsesforhold ->
-                        val response =
-                            HentArbeidsforholdResponse(
-                                ansettelsesforhold = ansettelsesforhold.map(AnsettelsesforholdResponse::fra),
-                            )
-                        val responseJson = response.toJson(HentArbeidsforholdResponse.serializer())
+                            "Arbeidsforhold hentet OK.".also {
+                                logger.info(it)
+                                sikkerLogger.info("$it\n${responseJson.toPretty()}")
+                            }
 
-                        "Arbeidsforhold hentet OK.".also {
-                            logger.info(it)
-                            sikkerLogger.info("$it\n${responseJson.toPretty()}")
+                            respondOk(response, HentArbeidsforholdResponse.serializer())
                         }
-
-                        respondOk(response, HentArbeidsforholdResponse.serializer())
                     }
                 }
             }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoersel/HentForespoerselRoute.kt
@@ -38,38 +38,41 @@ fun Route.hentForespoersel(
     get(Routes.HENT_FORESPOERSEL) {
         val kontekstId = UUID.randomUUID()
 
-        readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
-            MdcUtils.withLogFields(
-                Log.apiRoute(Routes.HENT_FORESPOERSEL),
-                Log.kontekstId(kontekstId),
-                Log.forespoerselId(forespoerselId),
-            ) {
-                validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
-                    "Henter forespørsel.".also {
-                        logger.info(it)
-                        sikkerLogger.info(it)
-                    }
-
-                    producer.sendRequestEvent(
-                        kontekstId = kontekstId,
-                        forespoerselId = forespoerselId,
-                        arbeidsgiverFnr = call.request.lesFnrFraAuthToken(),
-                    )
-
-                    hentResultatFraRedisOrError(
-                        redisPoller = redisPoller,
-                        kontekstId = kontekstId,
-                        logOnFailure = "Klarte ikke hente forespørsel for '$forespoerselId'.",
-                        successSerializer = HentForespoerselResultat.serializer(),
-                    ) { success ->
-                        val response = success.toResponse()
-
-                        "Forespørsel hentet OK.".also {
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.HENT_FORESPOERSEL),
+            Log.kontekstId(kontekstId),
+        ) {
+            readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
+                MdcUtils.withLogFields(
+                    Log.forespoerselId(forespoerselId),
+                ) {
+                    validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
+                        "Henter forespørsel.".also {
                             logger.info(it)
-                            sikkerLogger.info("$it\n${response.toJson(HentForespoerselResponse.serializer()).toPretty()}")
+                            sikkerLogger.info(it)
                         }
 
-                        respondOk(response, HentForespoerselResponse.serializer())
+                        producer.sendRequestEvent(
+                            kontekstId = kontekstId,
+                            forespoerselId = forespoerselId,
+                            arbeidsgiverFnr = call.request.lesFnrFraAuthToken(),
+                        )
+
+                        hentResultatFraRedisOrError(
+                            redisPoller = redisPoller,
+                            kontekstId = kontekstId,
+                            logOnFailure = "Klarte ikke hente forespørsel for '$forespoerselId'.",
+                            successSerializer = HentForespoerselResultat.serializer(),
+                        ) { success ->
+                            val response = success.toResponse()
+
+                            "Forespørsel hentet OK.".also {
+                                logger.info(it)
+                                sikkerLogger.info("$it\n${response.toJson(HentForespoerselResponse.serializer()).toPretty()}")
+                            }
+
+                            respondOk(response, HentForespoerselResponse.serializer())
+                        }
                     }
                 }
             }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentforespoerselIdListe/HentForespoerselIdListeRoute.kt
@@ -8,6 +8,7 @@ import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
 import no.nav.hag.simba.utils.valkey.RedisPrefix
@@ -26,6 +27,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondOk
 import no.nav.helsearbeidsgiver.utils.json.serializer.UuidSerializer
 import no.nav.helsearbeidsgiver.utils.json.serializer.list
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 const val MAKS_ANTALL_VEDTAKSPERIODE_IDER = 100
@@ -40,27 +42,32 @@ fun Route.hentForespoerselIdListe(
     post(Routes.HENT_FORESPOERSEL_ID_LISTE) {
         val kontekstId = UUID.randomUUID()
 
-        readRequestOrError(
-            kontekstId,
-            HentForespoerslerRequest.serializer(),
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.HENT_FORESPOERSEL_ID_LISTE),
+            Log.kontekstId(kontekstId),
         ) {
-            val vedtaksperiodeIdListe = it.vedtaksperiodeIdListe
+            readRequestOrError(
+                kontekstId,
+                HentForespoerslerRequest.serializer(),
+            ) {
+                val vedtaksperiodeIdListe = it.vedtaksperiodeIdListe
 
-            when {
-                vedtaksperiodeIdListe.isEmpty() -> {
-                    loggErrorSikkerOgUsikker("Kan ikke hente forespørsler for tom vedtaksperiode-ID-liste.")
-                    respondError(ErrorResponse.Unknown(kontekstId))
-                }
+                when {
+                    vedtaksperiodeIdListe.isEmpty() -> {
+                        loggErrorSikkerOgUsikker("Kan ikke hente forespørsler for tom vedtaksperiode-ID-liste.")
+                        respondError(ErrorResponse.Unknown(kontekstId))
+                    }
 
-                vedtaksperiodeIdListe.size > MAKS_ANTALL_VEDTAKSPERIODE_IDER -> {
-                    loggErrorSikkerOgUsikker(
-                        "Stopper forsøk på å hente forespørsler for mer enn $MAKS_ANTALL_VEDTAKSPERIODE_IDER vedtaksperiode-ID-er på en gang.",
-                    )
-                    respondError(ErrorResponse.Unknown(kontekstId))
-                }
+                    vedtaksperiodeIdListe.size > MAKS_ANTALL_VEDTAKSPERIODE_IDER -> {
+                        loggErrorSikkerOgUsikker(
+                            "Stopper forsøk på å hente forespørsler for mer enn $MAKS_ANTALL_VEDTAKSPERIODE_IDER vedtaksperiode-ID-er på en gang.",
+                        )
+                        respondError(ErrorResponse.Unknown(kontekstId))
+                    }
 
-                else -> {
-                    hentForespoersler(producer, tilgangskontroll, redisPoller, kontekstId, vedtaksperiodeIdListe)
+                    else -> {
+                        hentForespoersler(producer, tilgangskontroll, redisPoller, kontekstId, vedtaksperiodeIdListe)
+                    }
                 }
             }
         }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/hentselvbestemtim/HentSelvbestemtImRoute.kt
@@ -37,33 +37,36 @@ fun Route.hentSelvbestemtImRoute(
     get(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID) {
         val kontekstId = UUID.randomUUID()
 
-        readPathParamOrError(kontekstId, Routes.Params.selvbestemtId) { selvbestemtId ->
-            MdcUtils.withLogFields(
-                Log.apiRoute(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID),
-                Log.kontekstId(kontekstId),
-                Log.selvbestemtId(selvbestemtId),
-            ) {
-                producer.sendRequestEvent(kontekstId, selvbestemtId)
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.SELVBESTEMT_INNTEKTSMELDING_MED_ID),
+            Log.kontekstId(kontekstId),
+        ) {
+            readPathParamOrError(kontekstId, Routes.Params.selvbestemtId) { selvbestemtId ->
+                MdcUtils.withLogFields(
+                    Log.selvbestemtId(selvbestemtId),
+                ) {
+                    producer.sendRequestEvent(kontekstId, selvbestemtId)
 
-                hentResultatFraRedisOrError(
-                    redisPoller = redisPoller,
-                    kontekstId = kontekstId,
-                    inntektsmeldingTypeId = selvbestemtId,
-                    logOnFailure = "Klarte ikke hente selvbestemt inntektsmelding pga. feil.",
-                    successSerializer = Inntektsmelding.serializer(),
-                ) { inntektsmelding ->
-                    validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, inntektsmelding.avsender.orgnr) {
-                        val response =
-                            HentSelvbestemtImResponseSuccess(inntektsmelding.fjernNavnHvisIngenArbeidsforhold())
-                                .toJson(HentSelvbestemtImResponseSuccess.serializer())
+                    hentResultatFraRedisOrError(
+                        redisPoller = redisPoller,
+                        kontekstId = kontekstId,
+                        inntektsmeldingTypeId = selvbestemtId,
+                        logOnFailure = "Klarte ikke hente selvbestemt inntektsmelding pga. feil.",
+                        successSerializer = Inntektsmelding.serializer(),
+                    ) { inntektsmelding ->
+                        validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, inntektsmelding.avsender.orgnr) {
+                            val response =
+                                HentSelvbestemtImResponseSuccess(inntektsmelding.fjernNavnHvisIngenArbeidsforhold())
+                                    .toJson(HentSelvbestemtImResponseSuccess.serializer())
 
-                        "Selvbestemt inntektsmelding hentet OK.".also {
-                            logger.info(it)
-                            sikkerLogger.info("$it\n${response.toPretty()}")
+                            "Selvbestemt inntektsmelding hentet OK.".also {
+                                logger.info(it)
+                                sikkerLogger.info("$it\n${response.toPretty()}")
+                            }
+
+                            // TODO trenger ikke å wrappe i ResultJson (må endres i frontend først)
+                            respondOk(ResultJson(success = response), ResultJson.serializer())
                         }
-
-                        // TODO trenger ikke å wrappe i ResultJson (må endres i frontend først)
-                        respondOk(ResultJson(success = response), ResultJson.serializer())
                     }
                 }
             }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/innsending/InnsendingRoute.kt
@@ -7,6 +7,7 @@ import no.nav.hag.simba.kontrakt.resultat.lagreim.LagreImError
 import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
 import no.nav.hag.simba.utils.valkey.RedisPrefix
@@ -26,6 +27,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondCreated
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondError
 import no.nav.helsearbeidsgiver.utils.json.fromJson
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import no.nav.helsearbeidsgiver.utils.wrapper.Fnr
 import java.time.LocalDateTime
 import java.util.UUID
@@ -41,41 +43,50 @@ fun Route.innsending(
         val kontekstId = UUID.randomUUID()
         val mottatt = LocalDateTime.now()
 
-        readRequestOrError(
-            kontekstId,
-            SkjemaInntektsmelding.serializer(),
-        ) { skjema ->
-            if (skjema.valider().isNotEmpty()) {
-                val valideringsfeil = skjema.valider()
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.INNSENDING),
+            Log.kontekstId(kontekstId),
+        ) {
+            readRequestOrError(
+                kontekstId,
+                SkjemaInntektsmelding.serializer(),
+            ) { skjema ->
+                MdcUtils.withLogFields(
+                    Log.forespoerselId(skjema.forespoerselId),
+                ) {
+                    if (skjema.valider().isNotEmpty()) {
+                        val valideringsfeil = skjema.valider()
 
-                "Fikk valideringsfeil: $valideringsfeil".also {
-                    logger.error(it)
-                    sikkerLogger.error(it)
-                }
+                        "Fikk valideringsfeil: $valideringsfeil".also {
+                            logger.error(it)
+                            sikkerLogger.error(it)
+                        }
 
-                respondError(ErrorResponse.Validering(kontekstId, valideringsfeil))
-            } else {
-                validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, skjema.forespoerselId) {
-                    val avsenderFnr = call.request.lesFnrFraAuthToken()
+                        respondError(ErrorResponse.Validering(kontekstId, valideringsfeil))
+                    } else {
+                        validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, skjema.forespoerselId) {
+                            val avsenderFnr = call.request.lesFnrFraAuthToken()
 
-                    producer.sendRequestEvent(kontekstId, skjema, avsenderFnr, mottatt)
+                            producer.sendRequestEvent(kontekstId, skjema, avsenderFnr, mottatt)
 
-                    hentResultatFraRedisOrError(
-                        redisPoller = redisPoller,
-                        kontekstId = kontekstId,
-                        inntektsmeldingTypeId = skjema.forespoerselId,
-                        logOnFailure = "Klarte ikke motta forespurt inntektsmelding pga. feil.",
-                        onFailureCustomError = { failure ->
-                            failure
-                                ?.fromJson(LagreImError.serializer())
-                                ?.valideringsfeil
-                                ?.ifEmpty { null }
-                                ?.let { ErrorResponse.Validering(kontekstId, it) }
-                        },
-                        successSerializer = JsonElement.serializer(),
-                    ) {
-                        sikkerLogger.info("Fikk resultat for innsending:\n$it")
-                        respondCreated(InnsendingResponse(skjema.forespoerselId), InnsendingResponse.serializer())
+                            hentResultatFraRedisOrError(
+                                redisPoller = redisPoller,
+                                kontekstId = kontekstId,
+                                inntektsmeldingTypeId = skjema.forespoerselId,
+                                logOnFailure = "Klarte ikke motta forespurt inntektsmelding pga. feil.",
+                                onFailureCustomError = { failure ->
+                                    failure
+                                        ?.fromJson(LagreImError.serializer())
+                                        ?.valideringsfeil
+                                        ?.ifEmpty { null }
+                                        ?.let { ErrorResponse.Validering(kontekstId, it) }
+                                },
+                                successSerializer = JsonElement.serializer(),
+                            ) {
+                                sikkerLogger.info("Fikk resultat for innsending:\n$it")
+                                respondCreated(InnsendingResponse(skjema.forespoerselId), InnsendingResponse.serializer())
+                            }
+                        }
                     }
                 }
             }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntekt/InntektRoute.kt
@@ -6,6 +6,7 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.felles.utils.gjennomsnitt
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
@@ -21,6 +22,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.hentResultatFraRedisOr
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.readRequestOrError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondOk
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 fun Route.inntektRoute(
@@ -33,34 +35,43 @@ fun Route.inntektRoute(
     post(Routes.INNTEKT) {
         val kontekstId = UUID.randomUUID()
 
-        readRequestOrError(
-            kontekstId,
-            InntektRequest.serializer(),
-        ) { request ->
-            validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, request.forespoerselId) {
-                "Henter oppdatert inntekt for forespoerselId: ${request.forespoerselId}".let {
-                    logger.info(it)
-                    sikkerLogger.info("$it og request:\n$request")
-                }
-
-                producer.sendRequestEvent(kontekstId, request)
-
-                hentResultatFraRedisOrError(
-                    redisPoller = redisPoller,
-                    kontekstId = kontekstId,
-                    inntektsmeldingTypeId = request.forespoerselId,
-                    logOnFailure = "Klarte ikke hente oppdatert inntekt pga. feil.",
-                    successSerializer = inntektMapSerializer,
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.INNTEKT),
+            Log.kontekstId(kontekstId),
+        ) {
+            readRequestOrError(
+                kontekstId,
+                InntektRequest.serializer(),
+            ) { request ->
+                MdcUtils.withLogFields(
+                    Log.forespoerselId(request.forespoerselId),
                 ) {
-                    sikkerLogger.info("Resultat for henting av inntekt:\n$it")
+                    validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, request.forespoerselId) {
+                        "Henter oppdatert inntekt for forespoerselId: ${request.forespoerselId}".let {
+                            logger.info(it)
+                            sikkerLogger.info("$it og request:\n$request")
+                        }
 
-                    val response =
-                        InntektResponse(
-                            gjennomsnitt = it.gjennomsnitt(),
-                            historikk = it,
-                        )
+                        producer.sendRequestEvent(kontekstId, request)
 
-                    respondOk(response, InntektResponse.serializer())
+                        hentResultatFraRedisOrError(
+                            redisPoller = redisPoller,
+                            kontekstId = kontekstId,
+                            inntektsmeldingTypeId = request.forespoerselId,
+                            logOnFailure = "Klarte ikke hente oppdatert inntekt pga. feil.",
+                            successSerializer = inntektMapSerializer,
+                        ) {
+                            sikkerLogger.info("Resultat for henting av inntekt:\n$it")
+
+                            val response =
+                                InntektResponse(
+                                    gjennomsnitt = it.gjennomsnitt(),
+                                    historikk = it,
+                                )
+
+                            respondOk(response, InntektResponse.serializer())
+                        }
+                    }
                 }
             }
         }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/inntektselvbestemt/InntektSelvbestemtRoute.kt
@@ -6,6 +6,7 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.json.inntektMapSerializer
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.felles.utils.gjennomsnitt
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
@@ -20,6 +21,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.hentResultatFraRedisOr
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.readRequestOrError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondOk
 import no.nav.helsearbeidsgiver.utils.json.toJson
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 fun Route.inntektSelvbestemtRoute(
@@ -32,28 +34,33 @@ fun Route.inntektSelvbestemtRoute(
     post(Routes.INNTEKT_SELVBESTEMT) {
         val kontekstId = UUID.randomUUID()
 
-        readRequestOrError(
-            kontekstId,
-            InntektSelvbestemtRequest.serializer(),
-        ) { request ->
-            validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, request.orgnr) {
-                producer.sendRequestEvent(kontekstId, request)
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.INNTEKT_SELVBESTEMT),
+            Log.kontekstId(kontekstId),
+        ) {
+            readRequestOrError(
+                kontekstId,
+                InntektSelvbestemtRequest.serializer(),
+            ) { request ->
+                validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, request.orgnr) {
+                    producer.sendRequestEvent(kontekstId, request)
 
-                hentResultatFraRedisOrError(
-                    redisPoller = redisPoller,
-                    kontekstId = kontekstId,
-                    logOnFailure = "Klarte ikke hente oppdatert inntekt for selvbestemt inntektsmelding pga. feil.",
-                    successSerializer = inntektMapSerializer,
-                ) {
-                    sikkerLogger.info("Resultat for henting av inntekt for selvbestemt inntektsmelding:\n$it")
+                    hentResultatFraRedisOrError(
+                        redisPoller = redisPoller,
+                        kontekstId = kontekstId,
+                        logOnFailure = "Klarte ikke hente oppdatert inntekt for selvbestemt inntektsmelding pga. feil.",
+                        successSerializer = inntektMapSerializer,
+                    ) {
+                        sikkerLogger.info("Resultat for henting av inntekt for selvbestemt inntektsmelding:\n$it")
 
-                    val response =
-                        InntektSelvbestemtResponse(
-                            gjennomsnitt = it.gjennomsnitt(),
-                            historikk = it,
-                        )
+                        val response =
+                            InntektSelvbestemtResponse(
+                                gjennomsnitt = it.gjennomsnitt(),
+                                historikk = it,
+                            )
 
-                    respondOk(response, InntektSelvbestemtResponse.serializer())
+                        respondOk(response, InntektSelvbestemtResponse.serializer())
+                    }
                 }
             }
         }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/kvittering/KvitteringRoute.kt
@@ -9,6 +9,7 @@ import no.nav.hag.simba.utils.felles.EventName
 import no.nav.hag.simba.utils.felles.Key
 import no.nav.hag.simba.utils.felles.Tekst
 import no.nav.hag.simba.utils.felles.json.toJson
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.hag.simba.utils.kafka.Producer
 import no.nav.hag.simba.utils.valkey.RedisConnection
 import no.nav.hag.simba.utils.valkey.RedisPrefix
@@ -29,6 +30,7 @@ import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.respondOk
 import no.nav.helsearbeidsgiver.utils.date.toOffsetDateTimeOslo
 import no.nav.helsearbeidsgiver.utils.json.toJson
 import no.nav.helsearbeidsgiver.utils.json.toPretty
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 fun Route.kvittering(
@@ -41,33 +43,46 @@ fun Route.kvittering(
     get(Routes.KVITTERING) {
         val kontekstId = UUID.randomUUID()
 
-        readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
-            validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
-                logger.info("Henter kvittering for forespørsel-ID '$forespoerselId'.")
-                producer.sendRequestEvent(kontekstId, forespoerselId)
-
-                hentResultatFraRedisOrError(
-                    redisPoller = redisPoller,
-                    kontekstId = kontekstId,
-                    inntektsmeldingTypeId = forespoerselId,
-                    logOnFailure = "Klarte ikke hente inntektsmelding pga. feil.",
-                    successSerializer = KvitteringResultat.serializer(),
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.KVITTERING),
+            Log.kontekstId(kontekstId),
+        ) {
+            readPathParamOrError(kontekstId, Routes.Params.forespoerselId) { forespoerselId ->
+                MdcUtils.withLogFields(
+                    Log.forespoerselId(forespoerselId),
                 ) {
-                    sikkerLogger.info("Hentet kvittering for forespørsel-ID '$forespoerselId'.\n${it.toJson(KvitteringResultat.serializer()).toPretty()}")
+                    validerTilgangForespoerselOrError(tilgangskontroll, kontekstId, forespoerselId) {
+                        logger.info("Henter kvittering for forespørsel-ID '$forespoerselId'.")
+                        producer.sendRequestEvent(kontekstId, forespoerselId)
 
-                    when (val lagret = it.lagret) {
-                        is LagretInntektsmelding.Skjema -> {
-                            val skjemaResponse = lagResponse(it.forespoersel, it.sykmeldtNavn, it.orgNavn, lagret)
-                            respondOk(skjemaResponse, KvitteringResponse.serializer())
-                        }
+                        hentResultatFraRedisOrError(
+                            redisPoller = redisPoller,
+                            kontekstId = kontekstId,
+                            inntektsmeldingTypeId = forespoerselId,
+                            logOnFailure = "Klarte ikke hente inntektsmelding pga. feil.",
+                            successSerializer = KvitteringResultat.serializer(),
+                        ) {
+                            sikkerLogger.info(
+                                "Hentet kvittering for forespørsel-ID '$forespoerselId'.\n${
+                                    it.toJson(KvitteringResultat.serializer()).toPretty()
+                                }",
+                            )
 
-                        is LagretInntektsmelding.Ekstern -> {
-                            val eksternResponse = lagResponse(lagret)
-                            respondOk(eksternResponse, KvitteringResponse.serializer())
-                        }
+                            when (val lagret = it.lagret) {
+                                is LagretInntektsmelding.Skjema -> {
+                                    val skjemaResponse = lagResponse(it.forespoersel, it.sykmeldtNavn, it.orgNavn, lagret)
+                                    respondOk(skjemaResponse, KvitteringResponse.serializer())
+                                }
 
-                        is LagretInntektsmelding.IkkeFunnet -> {
-                            respondError(ErrorResponse.NotFound(kontekstId, "Kvittering ikke funnet for forespørsel-ID '$forespoerselId'."))
+                                is LagretInntektsmelding.Ekstern -> {
+                                    val eksternResponse = lagResponse(lagret)
+                                    respondOk(eksternResponse, KvitteringResponse.serializer())
+                                }
+
+                                is LagretInntektsmelding.IkkeFunnet -> {
+                                    respondError(ErrorResponse.NotFound(kontekstId, "Kvittering ikke funnet for forespørsel-ID '$forespoerselId'."))
+                                }
+                            }
                         }
                     }
                 }

--- a/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
+++ b/apps/api/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/api/tilgangorgnr/TilgangOrgnrRoute.kt
@@ -4,19 +4,26 @@ import io.ktor.http.HttpStatusCode
 import io.ktor.server.response.respond
 import io.ktor.server.routing.Route
 import io.ktor.server.routing.get
+import no.nav.hag.simba.utils.felles.utils.Log
 import no.nav.helsearbeidsgiver.inntektsmelding.api.Routes
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.Tilgangskontroll
 import no.nav.helsearbeidsgiver.inntektsmelding.api.auth.validerTilgangOrgnrOrError
 import no.nav.helsearbeidsgiver.inntektsmelding.api.utils.readPathParamOrError
+import no.nav.helsearbeidsgiver.utils.log.MdcUtils
 import java.util.UUID
 
 fun Route.tilgangOrgnrRoute(tilgangskontroll: Tilgangskontroll) {
     get(Routes.TILGANG_ORGNR) {
         val kontekstId = UUID.randomUUID()
 
-        readPathParamOrError(kontekstId, Routes.Params.orgnr) { orgnr ->
-            validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, orgnr) {
-                call.respond(HttpStatusCode.OK)
+        MdcUtils.withLogFields(
+            Log.apiRoute(Routes.TILGANG_ORGNR),
+            Log.kontekstId(kontekstId),
+        ) {
+            readPathParamOrError(kontekstId, Routes.Params.orgnr) { orgnr ->
+                validerTilgangOrgnrOrError(tilgangskontroll, kontekstId, orgnr) {
+                    call.respond(HttpStatusCode.OK)
+                }
             }
         }
     }


### PR DESCRIPTION
Endringen gjør det lettere å bruke MDC-felt når man ser over loggene.