### PR TITLE
Midlertidig: Ignorer egenmeldingsvalidering

### DIFF
--- a/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
+++ b/apps/innsending/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingService.kt
@@ -142,6 +142,9 @@ class InnsendingService(
                     egenmeldingerFraForespoersel = steg1.forespoersel.egenmeldingsperioder,
                     sykmeldingsperioder = steg1.forespoersel.sykmeldingsperioder,
                 ).orEmpty()
+                // MIDLERTIDIG: Ignorerer denne feilmeldingen til egenmeldingsvalideringen blir mer presis
+                .filter { it != "Egenmelding kan ikke benyttes dagen etter en sykmeldingsperiode." }
+                .toSet()
 
         if (agpValideringsfeil.isEmpty()) {
             publisher

--- a/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
+++ b/apps/innsending/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/innsending/InnsendingServiceTest.kt
@@ -163,7 +163,7 @@ class InnsendingServiceTest :
             }
         }
 
-        test("avviser inntektsmeldingskjema dersom egenmeldinger i AGP er ugyldige") {
+        xtest("avviser inntektsmeldingskjema dersom egenmeldinger i AGP er ugyldige") {
             val kontekstId = UUID.randomUUID()
             val forespoersel =
                 mockForespoersel().copy(


### PR DESCRIPTION
Egenmeldingsvalideringen fungerer dårlig på tilfeller der sykefraværet strekker seg over flere sykmeldinger. Stort sett så ser vi kun på én sykmeldingsperiode når vi validerer egenmeldinger, som fører til at sykmeldingsdager fra andre sykmeldinger blir feilaktig tolket som egenmeldinger. Dersom den "ukjente" sykmeldingen er en forlengelse, så blir de respektive "egenmeldingene" ansett som ugyldige.