### PR TITLE
Videresend forespørsel sammen med beriket inntektsmelding

### DIFF
--- a/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
+++ b/apps/berik-inntektsmelding-service/src/main/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingService.kt
@@ -195,6 +195,7 @@ class BerikInntektsmeldingService(
                     Key.DATA to
                         mapOf(
                             Key.FORESPOERSEL_ID to steg0.skjema.forespoerselId.toJson(),
+                            Key.FORESPOERSEL to steg0.forespoersel.toJson(),
                             Key.INNTEKTSMELDING to steg3.inntektsmelding.toJson(Inntektsmelding.serializer()),
                         ).toJson(),
                 )

--- a/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
+++ b/apps/berik-inntektsmelding-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/berikinntektsmeldingservice/BerikInntektsmeldingServiceTest.kt
@@ -9,6 +9,7 @@ import io.kotest.matchers.shouldNotBe
 import io.mockk.clearAllMocks
 import kotlinx.serialization.builtins.serializer
 import kotlinx.serialization.json.JsonElement
+import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
@@ -106,6 +107,7 @@ class BerikInntektsmeldingServiceTest :
 
                 val data = it.lesData()
                 Key.FORESPOERSEL_ID.lesOrNull(UuidSerializer, data) shouldBe Mock.skjema.forespoerselId
+                Key.FORESPOERSEL.lesOrNull(Forespoersel.serializer(), data) shouldBe Mock.forespoersel
                 Key.INNTEKTSMELDING.lesOrNull(Inntektsmelding.serializer(), data) shouldNotBe null
             }
         }
@@ -177,8 +179,7 @@ class BerikInntektsmeldingServiceTest :
 private object Mock {
     val skjema = mockSkjemaInntektsmelding()
     val innsending = mockInnsending()
-
-    private val forespoersel = mockForespoersel()
+    val forespoersel = mockForespoersel()
 
     private val sykmeldt =
         Person(

--- a/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdServiceTest.kt
+++ b/apps/faisu-service/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/faisuservice/HentArbeidsforholdServiceTest.kt
@@ -10,7 +10,6 @@ import io.mockk.verify
 import kotlinx.serialization.json.JsonElement
 import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.Ansettelsesforhold
 import no.nav.hag.simba.kontrakt.domene.ansettelsesforhold.ansettelsesforholdSerializer
-import no.nav.hag.simba.kontrakt.domene.forespoersel.Forespoersel
 import no.nav.hag.simba.kontrakt.domene.forespoersel.test.mockForespoersel
 import no.nav.hag.simba.utils.felles.BehovType
 import no.nav.hag.simba.utils.felles.EventName
@@ -180,7 +179,7 @@ private object Mock {
         steg0(kontekstId)
             .plus(Key.EVENT_NAME to EventName.SERVICE_HENT_ARBEIDSFORHOLD.toJson())
             .plusData(
-                Key.FORESPOERSEL_SVAR to forespoersel.toJson(Forespoersel.serializer()),
+                Key.FORESPOERSEL_SVAR to forespoersel.toJson(),
             )
 
     fun steg2(

--- a/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
+++ b/apps/integrasjonstest/src/test/kotlin/no/nav/helsearbeidsgiver/inntektsmelding/integrasjonstest/BerikInntektsmeldingServiceIT.kt
@@ -138,6 +138,10 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
 
+                    data[Key.FORESPOERSEL]
+                        .shouldNotBeNull()
+                        .fromJson(Forespoersel.serializer())
+
                     data[Key.INNTEKTSMELDING]
                         .shouldNotBeNull()
                         .fromJson(Inntektsmelding.serializer())
@@ -261,6 +265,10 @@ class BerikInntektsmeldingServiceIT : EndToEndTest() {
                     data[Key.FORESPOERSEL_ID]
                         .shouldNotBeNull()
                         .fromJson(UuidSerializer)
+
+                    data[Key.FORESPOERSEL]
+                        .shouldNotBeNull()
+                        .fromJson(Forespoersel.serializer())
 
                     data[Key.INNTEKTSMELDING]
                         .shouldNotBeNull()


### PR DESCRIPTION
Dette er et steg på veien for å kunne bruke bestemmende fraværsdag i tittelen på journalførte dokumenter.